### PR TITLE
Support qwen3_moe architecture (Qwen3-30B-A3B / Coder)

### DIFF
--- a/app/Sources/MLXServe/Models/HFModels.swift
+++ b/app/Sources/MLXServe/Models/HFModels.swift
@@ -26,6 +26,7 @@ let supportedModelTypes: Set<String> = [
     "gemma3", "gemma4", "gemma4_text",
     "gemma4_unified", "gemma4_unified_text",
     "qwen3", "qwen3_5", "qwen3_5_moe", "qwen3_5_moe_text", "qwen3_next",
+    "qwen3_moe", "qwen3_moe_text",
     "qwen2",
     "llama", "mistral",
     "lfm2", "lfm2-vl",

--- a/app/Tests/MLXCoreTests/DownloadManagerLayoutTests.swift
+++ b/app/Tests/MLXCoreTests/DownloadManagerLayoutTests.swift
@@ -177,6 +177,19 @@ final class DownloadManagerLayoutTests: XCTestCase {
         }
     }
 
+    func testQwen3MoeIsSupportedArchitecture() {
+        // Qwen3-30B-A3B / Qwen3-Coder-30B-A3B ship model_type "qwen3_moe".
+        // A locally-discovered checkpoint must NOT be flagged "Unsupported
+        // architecture" in the model manager (issue #19).
+        for mt in ["qwen3_moe", "qwen3_moe_text"] {
+            let m = LocalModel(
+                id: "test:\(mt)", name: mt, path: "/tmp/Qwen3-Coder-30B-A3B-8bit",
+                sizeFormatted: "32 GB", modelType: mt, source: .custom, kind: .base
+            )
+            XCTAssertTrue(m.isSupportedArchitecture, "\"\(mt)\" must be in supportedModelTypes")
+        }
+    }
+
     // MARK: - mmproj sidecar filtering
 
     /// `mmproj-*.gguf` files are CLIP / audio encoders, not language models —

--- a/src/model.zig
+++ b/src/model.zig
@@ -612,6 +612,35 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
         if (cfg_obj.get("query_pre_attn_scalar") == null) {
             config.query_pre_attn_scalar = config.head_dim;
         }
+    } else if (std.mem.eql(u8, model_type, "qwen3_moe") or
+        std.mem.eql(u8, model_type, "qwen3_moe_text"))
+    {
+        // Qwen3-30B-A3B / Qwen3-Coder-30B-A3B. Shares qwen3_5_moe's weight
+        // layout (`mlp.gate` router + stacked `mlp.switch_mlp.*` experts) and
+        // its MoE forward, but differs in three ways that make it its OWN
+        // model_type rather than a remap onto qwen3_5_moe:
+        //   1. No GatedDeltaNet — every layer is full attention
+        //      (full_attention_interval stays 0 ⇒ isLinearLayer == false).
+        //   2. No attention output gate (attn_output_gate stays false; the
+        //      qwen3_5 split-Q path would mis-shape the projection here).
+        //   3. No shared expert (shared_expert_intermediate_size: 0, no
+        //      mlp.shared_expert.* weights). The MoE binding in
+        //      transformer.zig loads those optionally and the forward skips
+        //      the shared branch when shared_expert_gate_w is null.
+        // weight_prefix is plain "model" (no language_model nesting).
+        config.model_type = "qwen3_moe";
+        config.weight_prefix = "model";
+        config.norm_has_offset = false;
+        config.scale_embeddings = false;
+        config.has_pre_ff_norm = false;
+        config.has_qk_norm = true;
+        config.hidden_act = .silu;
+        config.has_sliding_window = false;
+        config.rope_scaling_factor = 1.0;
+        config.rope_local_base_freq = config.rope_theta;
+        if (cfg_obj.get("query_pre_attn_scalar") == null) {
+            config.query_pre_attn_scalar = config.head_dim;
+        }
     } else if (std.mem.eql(u8, model_type, "qwen3_next")) {
         config.model_type = "qwen3_next";
         config.weight_prefix = "model";
@@ -1367,4 +1396,47 @@ test "parseConfigFromJson quantized qwen3_5_moe → quant_bits from key" {
     const config = try parseConfigFromJson(testing.allocator, json);
     try testing.expectEqual(@as(u32, 4), config.quant_bits);
     try testing.expectEqual(@as(u32, 64), config.quant_group_size);
+}
+
+test "parseConfigFromJson qwen3_moe (Qwen3-30B-A3B) → MoE, no shared expert, no output gate" {
+    // Qwen3-Coder-30B-A3B / Qwen3-30B-A3B ship model_type "qwen3_moe": a pure
+    // full-attention MoE (no GatedDeltaNet) that DROPPED the shared expert that
+    // Qwen2-MoE / Qwen3.5-MoE carry (shared_expert_intermediate_size: 0, no
+    // mlp.shared_expert.* weights). It must NOT be remapped onto qwen3_5_moe
+    // (which assumes a shared expert and an attention output gate) — doing so
+    // crashed at load with "MISSING WEIGHT: ...mlp.shared_expert.gate_proj.weight".
+    const json =
+        \\{
+        \\  "model_type": "qwen3_moe",
+        \\  "hidden_size": 2048,
+        \\  "head_dim": 128,
+        \\  "num_hidden_layers": 48,
+        \\  "num_attention_heads": 32,
+        \\  "num_key_value_heads": 4,
+        \\  "num_experts": 128,
+        \\  "num_experts_per_tok": 8,
+        \\  "moe_intermediate_size": 768,
+        \\  "shared_expert_intermediate_size": 0,
+        \\  "use_qk_norm": true,
+        \\  "use_sliding_window": false,
+        \\  "rope_theta": 10000000,
+        \\  "tie_word_embeddings": false,
+        \\  "quantization": {"bits": 8, "group_size": 64}
+        \\}
+    ;
+    const config = try parseConfigFromJson(testing.allocator, json);
+    try testing.expectEqualStrings("qwen3_moe", config.model_type);
+    try testing.expectEqualStrings("model", config.weight_prefix);
+    try testing.expect(config.isMoe());
+    try testing.expectEqual(@as(u32, 128), config.num_experts);
+    try testing.expectEqual(@as(u32, 8), config.num_experts_per_tok);
+    // qwen3 attention: QK-norm on, NO output gate (that's a qwen3_5 thing).
+    try testing.expect(config.has_qk_norm);
+    try testing.expect(!config.attn_output_gate);
+    // Full attention everywhere — no GatedDeltaNet/linear layers.
+    try testing.expect(!config.isLinearLayer(0));
+    try testing.expect(!config.isLinearLayer(3));
+    try testing.expect(!config.has_hybrid_layers);
+    try testing.expect(!config.has_sliding_window);
+    try testing.expectEqual(@as(u32, 8), config.quant_bits);
 }

--- a/src/model_discovery.zig
+++ b/src/model_discovery.zig
@@ -33,6 +33,7 @@ const supported_model_types = [_][]const u8{
     "gemma4_unified", "gemma4_unified_text",
     "qwen3",        "qwen3_5",        "qwen3_5_text",
     "qwen3_5_moe",  "qwen3_5_moe_text",
+    "qwen3_moe",    "qwen3_moe_text",
     "qwen3_next",
     "llama",        "mistral",
     "lfm2",         // also matches any "lfm2*" prefix (lfm2_vl etc. when added)
@@ -311,4 +312,17 @@ test "isMmprojGgufBasename catches the multimodal-projection sidecars" {
     try testing.expect(!isMmprojGgufBasename("mmproj"));
     // Suffix-only — model-mmproj.gguf is NOT the convention.
     try testing.expect(!isMmprojGgufBasename("model-mmproj.gguf"));
+}
+
+test "isSupportedModelType accepts qwen3_moe (Qwen3-30B-A3B)" {
+    // Regression for the "[discovery] skip ...: unsupported model_type
+    // 'qwen3_moe'" warning: Qwen3-30B-A3B / Qwen3-Coder-30B-A3B must be
+    // discoverable by the model manager, not silently skipped.
+    try testing.expect(isSupportedModelType("qwen3_moe"));
+    try testing.expect(isSupportedModelType("qwen3_moe_text"));
+    // Sibling arches still recognized.
+    try testing.expect(isSupportedModelType("qwen3_5_moe"));
+    try testing.expect(isSupportedModelType("qwen3"));
+    // A genuinely unknown arch is still rejected.
+    try testing.expect(!isSupportedModelType("totally_made_up_arch"));
 }

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -6090,12 +6090,20 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
                 lw.mlp.moe.router_scale = folded;
             }
         } else if (config.isMoe()) {
-            // Qwen3.5 MoE. Each `*_s`/`*_b` is loaded optionally — Unsloth Dynamic
-            // checkpoints (e.g. Qwen3.6-A3B UD) leave the router (`mlp.gate`) and the
-            // shared-expert gate (`mlp.shared_expert_gate`) as plain bf16, with no
-            // scales/biases. The `maybeTransposeForBf16` calls below pre-transpose
-            // bf16 weights from `[out, in]` → `[in, out]` so `qmatmulBits` can
-            // dispatch to plain `mlx_matmul`. They no-op on already-quantized weights.
+            // Qwen3.5 MoE — also serves Qwen3-30B-A3B (`qwen3_moe`), which shares
+            // this exact router/switch_mlp layout. Each `*_s`/`*_b` is loaded
+            // optionally — Unsloth Dynamic checkpoints (e.g. Qwen3.6-A3B UD) leave
+            // the router (`mlp.gate`) and the shared-expert gate
+            // (`mlp.shared_expert_gate`) as plain bf16, with no scales/biases.
+            // The shared-expert WEIGHTS themselves are also optional: qwen3_moe
+            // (Qwen3-30B-A3B / Coder) dropped the shared expert entirely
+            // (shared_expert_intermediate_size: 0, no mlp.shared_expert.*). When
+            // absent they bind to empty handles and `shared_expert_gate_w` stays
+            // null, which makes moeMLP early-return the routed-expert sum without
+            // ever reading them — so no MISSING WEIGHT crash. The
+            // `maybeTransposeForBf16` calls below pre-transpose bf16 weights from
+            // `[out, in]` → `[in, out]` so `qmatmulBits` can dispatch to plain
+            // `mlx_matmul`; they no-op on already-quantized AND on empty handles.
             lw.mlp = .{ .moe = .{
                 .router_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.gate.weight"),
                 .router_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.gate.scales") orelse mlx.mlx_array_new(),
@@ -6109,16 +6117,16 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
                 .switch_down_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.switch_mlp.down_proj.weight"),
                 .switch_down_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.switch_mlp.down_proj.scales") orelse mlx.mlx_array_new(),
                 .switch_down_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.switch_mlp.down_proj.biases") orelse mlx.mlx_array_new(),
-                .shared_gate_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.shared_expert.gate_proj.weight"),
+                .shared_gate_w = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.gate_proj.weight") orelse mlx.mlx_array_new(),
                 .shared_gate_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.gate_proj.scales") orelse mlx.mlx_array_new(),
                 .shared_gate_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.gate_proj.biases") orelse mlx.mlx_array_new(),
-                .shared_up_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.shared_expert.up_proj.weight"),
+                .shared_up_w = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.up_proj.weight") orelse mlx.mlx_array_new(),
                 .shared_up_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.up_proj.scales") orelse mlx.mlx_array_new(),
                 .shared_up_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.up_proj.biases") orelse mlx.mlx_array_new(),
-                .shared_down_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.shared_expert.down_proj.weight"),
+                .shared_down_w = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.down_proj.weight") orelse mlx.mlx_array_new(),
                 .shared_down_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.down_proj.scales") orelse mlx.mlx_array_new(),
                 .shared_down_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert.down_proj.biases") orelse mlx.mlx_array_new(),
-                .shared_expert_gate_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.shared_expert_gate.weight"),
+                .shared_expert_gate_w = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert_gate.weight"),
                 .shared_expert_gate_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert_gate.scales") orelse mlx.mlx_array_new(),
                 .shared_expert_gate_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_expert_gate.biases") orelse mlx.mlx_array_new(),
             } };


### PR DESCRIPTION
## Problem

Qwen3-30B-A3B and Qwen3-Coder-30B-A3B ship `model_type: "qwen3_moe"` — a pure full-attention MoE that **dropped the shared expert** present in Qwen2-MoE / Qwen3.5-MoE (`shared_expert_intermediate_size: 0`, no `mlp.shared_expert.*` weights).

These models had no config branch, so they fell through to `model_type "unknown"`, hit the qwen3_5_moe weight binding (which **requires** a shared expert), and aborted at load:

```
Model: unknown (48 layers, 2048-dim, head_dim=128, 32h/4kv, 8-bit quant)
Precomputing MoE layer weights...
MISSING WEIGHT: model.layers.0.mlp.shared_expert.gate_proj.weight
```

They were also skipped by model discovery (`[discovery] skip …: unsupported model_type 'qwen3_moe'`).

## Fix

- **`model.zig`** — add a `qwen3_moe`/`qwen3_moe_text` branch: full attention (no GatedDeltaNet), no attention output gate, no shared expert. Reuses the existing qwen3_5_moe MoE forward (same `mlp.gate` router + stacked `mlp.switch_mlp.*` experts).
- **`transformer.zig`** — bind the shared-expert weights *optionally* so absent `mlp.shared_expert.*` no longer aborts. The MoE forward already early-returns the routed-expert sum when `shared_expert_gate_w == null`, so no forward changes were needed. qwen3_5_moe behavior is unchanged.
- **`model_discovery.zig`** — add `qwen3_moe`/`qwen3_moe_text` to the discovery allowlist.
- **`HFModels.swift`** — add to `supportedModelTypes` so locally-discovered checkpoints aren't flagged "unsupported architecture".

## Tests

- `model.zig`: config-parse asserts `model_type=qwen3_moe`, `isMoe()`, 128 experts, QK-norm on, output gate off, no linear layers.
- `model_discovery.zig`: `isSupportedModelType("qwen3_moe")`.
- `DownloadManagerLayoutTests.swift`: `LocalModel(qwen3_moe).isSupportedArchitecture`.

`zig build test` → 402 pass / 3 skip / 0 fail. Swift tests pass.

## End-to-end verification

Loaded `mlx-community/Qwen3-Coder-30B-A3B-Instruct-8bit`:
- Reports `Model: qwen3_moe` (was `unknown`)
- **0** `MISSING WEIGHT`
- Generates correctly (e.g. `square = lambda n: n ** 2`, `finish_reason: stop`)

Fixes #19
