### PR TITLE
Fix macOS dependency syntax for MLX Core

### DIFF
--- a/Casks/mlx-core.rb
+++ b/Casks/mlx-core.rb
@@ -7,7 +7,7 @@ cask "mlx-core" do
   desc "Native LLM server for Apple Silicon with OpenAI & Anthropic compatible APIs"
   homepage "https://github.com/ddalcu/mlx-serve"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: :sonoma
   depends_on arch: :arm64
 
   app "MLX Core.app"

--- a/Casks/mlx-core.rb
+++ b/Casks/mlx-core.rb
@@ -7,7 +7,7 @@ cask "mlx-core" do
   desc "Native LLM server for Apple Silicon with OpenAI & Anthropic compatible APIs"
   homepage "https://github.com/ddalcu/mlx-serve"
 
-  depends_on macos: :sonoma
+  depends_on macos: :tahoe
   depends_on arch: :arm64
 
   app "MLX Core.app"


### PR DESCRIPTION
Fixes the syntax issue 

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sonoma` instead.
Please report this issue to the Homebrew/homebrew-mlx-serve tap, or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/homebrew/homebrew-mlx-serve/Casks/mlx-core.rb:10
```