### PR TITLE
Fix download cancel/delete in Model Browser; enrich Downloaded tab

### DIFF
--- a/app/Sources/MLXServe/Models/ChatModels.swift
+++ b/app/Sources/MLXServe/Models/ChatModels.swift
@@ -353,6 +353,17 @@ enum ModelEngine: String, Hashable {
         }
     }
 
+    /// Weight-format tag for metadata captions — the useful MLX-vs-GGUF
+    /// distinction, without the "MLX-Serve" app-name noise (`shortLabel` keeps
+    /// that for picker disambiguation).
+    var formatLabel: String {
+        switch self {
+        case .mlx: "MLX"
+        case .llamaCpp: "GGUF"
+        case .ds4: "GGUF·DS4"
+        }
+    }
+
     /// Human-readable engine name for the status menu.
     var displayName: String {
         switch self {
@@ -371,9 +382,78 @@ struct LocalModel: Identifiable, Hashable {
     let modelType: String
     let source: LocalModelSource
     let kind: ModelKind
+    // The fields below are read from `config.json` at discovery (the
+    // authoritative source); they default to nil/false for GGUF and any model
+    // whose config we didn't parse, in which case the accessors fall back to
+    // name-derived hints where possible.
+    /// `vision_config` present on a non-`_text` architecture.
+    var hasVision: Bool = false
+    /// Quantization bit-width from `config.json`'s `quantization.bits`.
+    var quantBits: Int? = nil
+    /// `max_position_embeddings`.
+    var contextLength: Int? = nil
+    /// Total MoE experts (`num_experts` / `num_local_experts` / `n_routed_experts`).
+    var numExperts: Int? = nil
+    /// Active MoE experts per token (`num_experts_per_tok`).
+    var activeExperts: Int? = nil
 
     var isSupportedArchitecture: Bool {
         supportedModelTypes.contains(modelType)
+    }
+
+    /// Likely tool/function-calling support (name heuristic, shared with the
+    /// search rows via `HFModel.likelyToolCalling`).
+    var hasToolCalling: Bool {
+        HFModel.likelyToolCalling(forName: name)
+    }
+
+    /// Quantization label. Prefers `config.json`'s `bits` (authoritative);
+    /// falls back to the name parser for GGUF / configs without a quant block.
+    var quantization: String? {
+        if let b = quantBits { return "\(b)-bit" }
+        return HFModel.quantizationLabel(forId: name)
+    }
+
+    /// Headline parameter count parsed from the name (e.g. "32B", "30B"). This
+    /// is the one figure NOT in config.json — it's marketing-rounded in the name
+    /// and only exactly recoverable by summing tensor shapes. nil when absent.
+    var paramSize: String? {
+        HFModel.paramSizeLabel(forName: name)
+    }
+
+    /// "8/128 experts" (active/total) when this is an MoE config, else nil.
+    var expertSummary: String? {
+        guard let total = numExperts, let active = activeExperts else { return nil }
+        return "\(active)/\(total) experts"
+    }
+
+    /// Context window as a compact label, e.g. 262144 → "256K ctx", 1048576 →
+    /// "1M ctx". nil when unknown.
+    var contextSummary: String? {
+        guard let n = contextLength else { return nil }
+        return Self.formatContext(n)
+    }
+
+    static func formatContext(_ n: Int) -> String {
+        if n >= 1024 * 1024, n % (1024 * 1024) == 0 { return "\(n / (1024 * 1024))M ctx" }
+        if n >= 1024 { return "\(n / 1024)K ctx" }
+        return "\(n) ctx"
+    }
+
+    /// One-line metadata caption for the Downloaded tab, e.g.
+    /// "30B · 8-bit · 8/128 experts · 256K ctx · qwen3_moe · MLX". Everything
+    /// except the headline param count is config-sourced; tokens the model
+    /// doesn't have are omitted. Capabilities (vision / tools) render as icons
+    /// in the row, not here.
+    var metadataSummary: String {
+        var tokens: [String] = []
+        if let p = paramSize { tokens.append(p) }
+        if let q = quantization { tokens.append(q) }
+        if let e = expertSummary { tokens.append(e) }
+        if let c = contextSummary { tokens.append(c) }
+        tokens.append(modelType)
+        tokens.append(engine.formatLabel)
+        return tokens.joined(separator: " · ")
     }
 
     /// Defaults to `.mlx` (MLX-Serve) whenever the engine can't be

--- a/app/Sources/MLXServe/Models/HFModels.swift
+++ b/app/Sources/MLXServe/Models/HFModels.swift
@@ -152,8 +152,13 @@ struct HFModel: Identifiable, Codable {
 
     /// Whether this model likely supports tool/function calling.
     /// Heuristic: instruction-tuned models from known families that implement tool call formats.
-    var hasToolCalling: Bool {
-        let lower = id.lowercased()
+    var hasToolCalling: Bool { Self.likelyToolCalling(forName: id) }
+
+    /// Name-based tool-calling heuristic, shared with `LocalModel` so the
+    /// Downloaded tab and search rows agree. Instruction-tuned (`-it`/`-instruct`
+    /// /`-chat`) checkpoints from families that implement a tool-call format.
+    static func likelyToolCalling(forName name: String) -> Bool {
+        let lower = name.lowercased()
         let isInstructTuned = lower.contains("-it") || lower.contains("-instruct") || lower.contains("-chat")
         guard isInstructTuned else { return false }
         let toolFamilies = ["gemma-4", "gemma-3", "qwen3", "qwen2.5", "llama-3", "mistral"]
@@ -248,14 +253,20 @@ struct HFModel: Identifiable, Codable {
     /// More reliable than safetensors.total for quantized models, where total
     /// counts packed tensor values rather than actual parameters.
     var modelSize: String {
-        let name = modelName
+        Self.paramSizeLabel(forName: modelName) ?? "\u{2014}"
+    }
+
+    /// Parameter-count token parsed from a model name (e.g. "31B", "82M",
+    /// "0.6B"), or nil when the name encodes none. Shared by `HFModel.modelSize`
+    /// and `LocalModel` so the Downloaded tab labels match the search rows.
+    static func paramSizeLabel(forName name: String) -> String? {
         // Match patterns like "31b", "E2B", "82M", "1.2B", "0.6b" preceded by - or _
         // Negative lookahead excludes "bit" (4bit, 8bit)
         let pattern = #"(?:^|[-_])[Ee]?(\d+(?:\.\d+)?[BbMm])(?![Ii])"#
         guard let regex = try? NSRegularExpression(pattern: pattern),
               let match = regex.firstMatch(in: name, range: NSRange(name.startIndex..., in: name)),
               let range = Range(match.range(at: 1), in: name) else {
-            return "\u{2014}"
+            return nil
         }
         return String(name[range]).uppercased()
     }

--- a/app/Sources/MLXServe/Services/DownloadManager.swift
+++ b/app/Sources/MLXServe/Services/DownloadManager.swift
@@ -368,10 +368,12 @@ class DownloadManager: ObservableObject {
                         try? fm.removeItem(atPath: destPath)
                         try fm.moveItem(atPath: partialPath, toPath: destPath)
                         break
-                    } catch is CancellationError {
-                        // Keep partial file for future resume
-                        throw CancellationError()
                     } catch {
+                        // User-cancelled? Stop immediately. URLSession surfaces
+                        // cancellation as NSURLErrorCancelled, not CancellationError,
+                        // so route both here instead of into the retry path. Partial
+                        // file stays on disk for a future resume.
+                        if Self.isCancellation(error) { throw CancellationError() }
                         // Partial file stays on disk — next attempt resumes from it
                         if attempt < maxRetries - 1 {
                             let isStall = error is DownloadStallError
@@ -445,44 +447,78 @@ class DownloadManager: ObservableObject {
     }
 
     /// Cancel an in-flight download. The state row disappears from the UI and
-    /// any `.partial` files are removed so no Resume path remains. No-op if
-    /// nothing is in flight for `repoId`.
+    /// the entire download directory is removed — completed shards, config, and
+    /// `.partial` files alike — so a cancel leaves ZERO footprint (no remnant
+    /// that masquerades as a complete model, no undeletable config-only orphan).
+    /// No-op if nothing is in flight for `repoId`. The actual wipe for a live
+    /// task happens in `finalizeIfCancelled` once the task has stopped writing;
+    /// the branch here covers the no-live-task case (already finished, or cancel
+    /// fired before start).
     func cancel(_ repoId: String) {
         activeTasks[repoId]?.cancel()
-        // Defensive: if there's no live task (already finished, or cancel
-        // fired before start), still clear the row and partials so the UI
-        // returns to a clean "Download" state.
         if activeTasks[repoId] == nil {
             downloads.removeValue(forKey: repoId)
-            Self.cleanupPartials(rootDir: modelsDir, repoId: repoId)
+            wipeDownloadDir(repoId)
         }
     }
 
-    /// Post-await cleanup for the start() wrappers. When the task was
-    /// cancelled mid-flight, drop the (possibly `.failed`) row and wipe
-    /// `.partial` files. On normal completion this is a no-op.
+    /// Post-await cleanup for the start() wrappers. When the task was cancelled
+    /// mid-flight, drop the (possibly `.failed`) row and wipe the whole download
+    /// dir. Runs after `download()` has fully returned, so the file handle is
+    /// closed and it's safe to delete. On normal completion this is a no-op.
     private func finalizeIfCancelled(repoId: String) {
         guard Task.isCancelled else { return }
         downloads.removeValue(forKey: repoId)
-        Self.cleanupPartials(rootDir: modelsDir, repoId: repoId)
+        wipeDownloadDir(repoId)
     }
 
-    /// Recursively remove every `.partial` file under the model's dest dir.
-    /// If the dir is empty afterward, remove it too — so the next click
-    /// starts from a truly clean slate (no orphan empty `<author>/<name>/`).
-    /// Nonisolated + static so tests can hit it without a `DownloadManager`
-    /// instance (which is tied to the real `~/.mlx-serve/models`).
-    nonisolated static func cleanupPartials(rootDir: String, repoId: String) {
-        let dir = newLayoutDir(rootDir: rootDir, repoId: repoId)
+    /// Remove the entire download directory for `repoId`. Used only on
+    /// user-cancel — distinct from the network-error resume path, which keeps
+    /// `.partial` files on disk so the "Resume" button can pick up where it
+    /// left off.
+    private func wipeDownloadDir(_ repoId: String) {
+        Self.removeModelFiles(at: newLayoutDir(for: repoId), roots: [modelsDir])
+    }
+
+    /// True if `error` represents a user/task cancellation rather than a
+    /// transient failure. URLSession surfaces `session.invalidateAndCancel()`
+    /// as `NSURLErrorCancelled` (NOT Swift's `CancellationError`), so the
+    /// download retry loop must recognize both — otherwise a cancelled
+    /// transfer falls into the generic `catch`, flashes "Connection lost,
+    /// retrying…", and only unwinds when the next `Task.sleep` throws.
+    nonisolated static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+        let ns = error as NSError
+        return ns.domain == NSURLErrorDomain && ns.code == NSURLErrorCancelled
+    }
+
+    /// Delete a model's on-disk files given its resolved `path` (a model
+    /// directory, or a single `.gguf` file living inside one). Removes the
+    /// containing model directory and, when it sits in the 2-level
+    /// `<author>/<name>` layout, prunes the now-empty author dir. Never deletes
+    /// or climbs past a directory in `roots` (the scan roots), so emptying the
+    /// last model under `~/.mlx-serve/models` can't wipe the root itself.
+    /// Returns true if the model dir was removed. `nonisolated`/static so it's
+    /// unit-testable without the real models root.
+    @discardableResult
+    nonisolated static func removeModelFiles(at path: String, roots: [String]) -> Bool {
         let fm = FileManager.default
-        guard let enumerator = fm.enumerator(atPath: dir) else { return }
-        while let rel = enumerator.nextObject() as? String {
-            guard rel.hasSuffix(".partial") else { continue }
-            try? fm.removeItem(atPath: (dir as NSString).appendingPathComponent(rel))
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: path, isDirectory: &isDir) else { return false }
+        let modelDir = isDir.boolValue ? path : (path as NSString).deletingLastPathComponent
+        let normRoots = Set(roots.map { URL(fileURLWithPath: $0).standardizedFileURL.path })
+        // Never remove a root directory itself.
+        if normRoots.contains(URL(fileURLWithPath: modelDir).standardizedFileURL.path) { return false }
+        try? fm.removeItem(atPath: modelDir)
+        // Prune the parent (author) dir if it's now empty — unless it's a root.
+        let authorDir = (modelDir as NSString).deletingLastPathComponent
+        let authorNorm = URL(fileURLWithPath: authorDir).standardizedFileURL.path
+        if !normRoots.contains(authorNorm),
+           let kids = try? fm.contentsOfDirectory(atPath: authorDir),
+           kids.filter({ !$0.hasPrefix(".") }).isEmpty {
+            try? fm.removeItem(atPath: authorDir)
         }
-        if let entries = try? fm.contentsOfDirectory(atPath: dir), entries.isEmpty {
-            try? fm.removeItem(atPath: dir)
-        }
+        return !fm.fileExists(atPath: modelDir)
     }
 
     /// Download a single GGUF artifact from a HuggingFace repo. Used by the
@@ -574,9 +610,8 @@ class DownloadManager: ObservableObject {
                     try? fm.removeItem(atPath: destPath)
                     try fm.moveItem(atPath: partialPath, toPath: destPath)
                     break
-                } catch is CancellationError {
-                    throw CancellationError()
                 } catch {
+                    if Self.isCancellation(error) { throw CancellationError() }
                     if attempt < maxRetries - 1 {
                         let isStall = error is DownloadStallError
                         let delay = isStall ? 2.0 : Double(attempt + 1) * 2.0
@@ -919,6 +954,23 @@ class DownloadManager: ObservableObject {
 
     func deleteModel(repoId: String) {
         removeFromDisk(repoId: repoId)
+    }
+
+    /// Delete a discovered local model by its real on-disk `path`. Preferred
+    /// over `deleteModel(repoId:)` for `LocalModelRow`, whose `model.id` is
+    /// source-prefixed (`"mlxServe:author/name"`) and therefore can't be fed to
+    /// the repoId-based path resolver — and for LM Studio / custom-root models,
+    /// which live outside `modelsDir` entirely. Scopes pruning to the known
+    /// scan roots so it never climbs out of a model tree.
+    func deleteModel(_ model: LocalModel) {
+        var roots = [modelsDir]
+        if let lms = lmStudioRoot { roots.append(lms) }
+        if let custom = resolvedCustomRoot() { roots.append(custom) }
+        Self.removeModelFiles(at: model.path, roots: roots)
+        // Clear any lingering download-state row, keyed by the clean repoId
+        // (drop the `source:` prefix the LocalModel id carries).
+        let cleanId = model.id.split(separator: ":", maxSplits: 1).last.map(String.init) ?? model.id
+        downloads.removeValue(forKey: cleanId)
     }
 
     private func removeFromDisk(repoId: String) {

--- a/app/Sources/MLXServe/Services/DownloadManager.swift
+++ b/app/Sources/MLXServe/Services/DownloadManager.swift
@@ -738,12 +738,8 @@ class DownloadManager: ObservableObject {
 
         guard entries.contains(where: { $0.hasSuffix(".safetensors") && !$0.hasSuffix(".index.json") }) else { return nil }
 
-        var modelType = "unknown"
-        if let data = FileManager.default.contents(atPath: configPath),
-           let cfg = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let mt = cfg["model_type"] as? String {
-            modelType = mt
-        }
+        let meta = Self.parseConfigMetadata(atPath: configPath)
+        let modelType = meta.modelType
 
         let size = directorySize(resolved)
         // Drafter config dirs aren't loadable as a target — they pair with a
@@ -760,8 +756,48 @@ class DownloadManager: ObservableObject {
             sizeFormatted: MemoryInfo.format(Int64(size)),
             modelType: modelType,
             source: source,
-            kind: kind
+            kind: kind,
+            hasVision: meta.hasVision,
+            quantBits: meta.quantBits,
+            contextLength: meta.contextLength,
+            numExperts: meta.numExperts,
+            activeExperts: meta.activeExperts
         )
+    }
+
+    /// Metadata read from a model's `config.json` — the authoritative source for
+    /// quant, context window, MoE expert routing, and vision (the model name only
+    /// reliably carries the headline param count, which isn't a config field).
+    struct ConfigMetadata: Equatable {
+        var modelType = "unknown"
+        var hasVision = false
+        var quantBits: Int? = nil
+        var contextLength: Int? = nil
+        var numExperts: Int? = nil
+        var activeExperts: Int? = nil
+    }
+
+    /// Parse the subset of `config.json` the Downloaded tab surfaces. `nonisolated`
+    /// + static so it's unit-testable against a temp config without a real model.
+    /// Tolerant of missing keys — every field is optional and defaults sensibly.
+    nonisolated static func parseConfigMetadata(atPath configPath: String) -> ConfigMetadata {
+        var meta = ConfigMetadata()
+        guard let data = FileManager.default.contents(atPath: configPath),
+              let cfg = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return meta }
+        if let mt = cfg["model_type"] as? String { meta.modelType = mt }
+        // Vision: a `vision_config` block on a non-`_text` arch (the `_text`
+        // guard skips text-only quantized checkpoints with a vestigial block).
+        meta.hasVision = cfg["vision_config"] != nil && !meta.modelType.hasSuffix("_text")
+        // Quant: MLX writes `quantization`/`quantization_config` with `bits`.
+        if let q = (cfg["quantization"] ?? cfg["quantization_config"]) as? [String: Any] {
+            meta.quantBits = q["bits"] as? Int
+        }
+        meta.contextLength = cfg["max_position_embeddings"] as? Int
+        // MoE: total experts under one of several arch-specific keys; active
+        // experts per token under `num_experts_per_tok`.
+        meta.numExperts = (cfg["num_experts"] ?? cfg["num_local_experts"] ?? cfg["n_routed_experts"]) as? Int
+        meta.activeExperts = cfg["num_experts_per_tok"] as? Int
+        return meta
     }
 
     func discoverLocalModels() -> [LocalModel] {

--- a/app/Sources/MLXServe/Views/ModelBrowserView.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserView.swift
@@ -458,12 +458,23 @@ private struct ModelBrowserRow: View {
                 Text("Delete \(model.modelName)? This will remove all downloaded files.")
             }
         } else if let state, state.status == .downloading {
-            VStack(spacing: 1) {
-                ProgressView(value: state.fileProgress)
-                    .frame(width: 50)
-                Text(state.percentFormatted)
-                    .font(.system(size: 9).monospacedDigit())
-                    .foregroundStyle(.secondary)
+            HStack(spacing: 4) {
+                VStack(spacing: 1) {
+                    ProgressView(value: state.fileProgress)
+                        .frame(width: 50)
+                    Text(state.percentFormatted)
+                        .font(.system(size: 9).monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+                Button {
+                    downloads.cancel(model.id)
+                    appState.refreshModels()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Cancel download")
             }
         } else if let state, state.status == .completed {
             Button {
@@ -489,10 +500,7 @@ private struct ModelBrowserRow: View {
                 GgufDownloadMenu(repoId: model.id, label: "Retry")
             } else {
                 Button(downloads.hasPartialDownload(model.id) ? "Resume" : "Retry") {
-                    Task {
-                        await downloads.download(repoId: model.id)
-                        appState.refreshModels()
-                    }
+                    downloads.start(repoId: model.id) { appState.refreshModels() }
                 }
                 .font(.callout)
                 .controlSize(.small)
@@ -503,10 +511,7 @@ private struct ModelBrowserRow: View {
                 GgufDownloadMenu(repoId: model.id, label: "Download")
             } else {
                 Button(downloads.hasPartialDownload(model.id) ? "Resume" : "Download") {
-                    Task {
-                        await downloads.download(repoId: model.id)
-                        appState.refreshModels()
-                    }
+                    downloads.start(repoId: model.id) { appState.refreshModels() }
                 }
                 .font(.callout)
                 .controlSize(.small)
@@ -534,8 +539,7 @@ private struct GgufDownloadMenu: View {
             } else {
                 ForEach(quants, id: \.self) { file in
                     Button(DownloadManager.quantLabel(forFilename: file)) {
-                        Task {
-                            await downloads.downloadGguf(repoId: repoId, ggufFilename: file)
+                        downloads.startGguf(repoId: repoId, ggufFilename: file) {
                             appState.refreshModels()
                         }
                     }
@@ -614,7 +618,7 @@ private struct LocalModelRow: View {
             .alert("Delete Model", isPresented: $confirmDelete) {
                 Button("Cancel", role: .cancel) {}
                 Button("Delete", role: .destructive) {
-                    downloads.deleteModel(repoId: model.id)
+                    downloads.deleteModel(model)
                     appState.refreshModels()
                 }
             } message: {
@@ -661,20 +665,28 @@ private struct ActiveDownloadRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             if state.status == .downloading {
-                VStack(alignment: .trailing, spacing: 1) {
-                    ProgressView(value: state.fileProgress)
-                        .frame(width: 80)
-                    Text("\(state.percentFormatted) \(state.speedFormatted)")
-                        .font(.system(size: 9).monospacedDigit())
-                        .foregroundStyle(.secondary)
+                HStack(spacing: 4) {
+                    VStack(alignment: .trailing, spacing: 1) {
+                        ProgressView(value: state.fileProgress)
+                            .frame(width: 80)
+                        Text("\(state.percentFormatted) \(state.speedFormatted)")
+                            .font(.system(size: 9).monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    Button {
+                        downloads.cancel(repoId)
+                        appState.refreshModels()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Cancel download")
                 }
-                .frame(width: 90, alignment: .trailing)
+                .frame(width: 116, alignment: .trailing)
             } else if state.status == .failed {
                 Button(downloads.hasPartialDownload(repoId) ? "Resume" : "Retry") {
-                    Task {
-                        await downloads.download(repoId: repoId)
-                        appState.refreshModels()
-                    }
+                    downloads.start(repoId: repoId) { appState.refreshModels() }
                 }
                 .font(.callout)
                 .controlSize(.small)

--- a/app/Sources/MLXServe/Views/ModelBrowserView.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserView.swift
@@ -206,6 +206,27 @@ struct ModelBrowserView: View {
         .onChange(of: showDownloadedOnly) { _, isLocal in
             if isLocal { appState.refreshModels() }
         }
+        // Live-refresh on-disk sizes while the Downloaded tab is open and a
+        // download is in flight, so completion + growing size show up without
+        // the user toggling the button. The task id flips when the tab closes
+        // or the active-download set changes, which cancels + re-evaluates the
+        // guard — so it self-terminates once everything finishes.
+        .task(id: "\(showDownloadedOnly)-\(activeDownloads.count)") {
+            guard Self.shouldLivePoll(downloadedTab: showDownloadedOnly,
+                                      hasActiveDownloads: !activeDownloads.isEmpty) else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                if Task.isCancelled { break }
+                appState.refreshModels()
+            }
+        }
+    }
+
+    /// Whether the Downloaded tab should live-refresh on-disk sizes: only when
+    /// the tab is showing AND a download is in flight. Pulled out so the polling
+    /// trigger is unit-testable without driving SwiftUI.
+    static func shouldLivePoll(downloadedTab: Bool, hasActiveDownloads: Bool) -> Bool {
+        downloadedTab && hasActiveDownloads
     }
 }
 

--- a/app/Sources/MLXServe/Views/ModelBrowserView.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserView.swift
@@ -608,15 +608,38 @@ private struct LocalModelRow: View {
                             .help("Speculative-decoding drafter — pairs with a Gemma 4 base model in Settings, not loadable on its own.")
                     }
                 }
-                // Only flag genuinely unsupported architectures. Drafters
-                // declare `gemma4_assistant` (not in supportedModelTypes) but
-                // are intentionally so — the badge above already tells the
-                // user what they're for.
-                if model.kind != .drafter, !model.isSupportedArchitecture {
-                    Text("Unsupported architecture (\(model.modelType))")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.red.opacity(0.8))
+                // Metadata caption: params · quant · architecture · engine, so
+                // the row actually tells the user what the model is — previously
+                // it was just a name and a delete button.
+                HStack(spacing: 6) {
+                    Text(model.metadataSummary)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .truncationMode(.middle)
+                    // Capability icons mirror the search rows.
+                    if model.hasVision {
+                        Image(systemName: "eye")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .help("Vision (image input)")
+                    }
+                    if model.hasToolCalling {
+                        Image(systemName: "wrench")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .help("Tool calling")
+                    }
+                    // Only flag genuinely unsupported architectures. Drafters
+                    // declare `gemma4_assistant` (not in supportedModelTypes)
+                    // intentionally — the badge above already explains them.
+                    if model.kind != .drafter, !model.isSupportedArchitecture {
+                        Text("Unsupported")
+                            .font(.system(size: 10).weight(.medium))
+                            .foregroundStyle(.red.opacity(0.8))
+                            .padding(.horizontal, 5).padding(.vertical, 1)
+                            .background(Color.red.opacity(0.12), in: Capsule())
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/app/Tests/MLXCoreTests/DownloadManagerLayoutTests.swift
+++ b/app/Tests/MLXCoreTests/DownloadManagerLayoutTests.swift
@@ -390,6 +390,127 @@ final class DownloadManagerLayoutTests: XCTestCase {
         XCTAssertFalse(ModelBrowserView.shouldLivePoll(downloadedTab: false, hasActiveDownloads: false))
     }
 
+    // MARK: - LocalModel metadata caption
+    //
+    // The Downloaded tab used to render only a name + delete button. These pin
+    // the parsed metadata (params / quant / architecture / engine) that now
+    // makes each row actually informative.
+
+    private func localModel(
+        name: String, type: String, path: String,
+        vision: Bool = false, quantBits: Int? = nil, ctx: Int? = nil,
+        numExperts: Int? = nil, activeExperts: Int? = nil
+    ) -> LocalModel {
+        LocalModel(id: "mlxServe:\(name)", name: name, path: path,
+                   sizeFormatted: "10 GB", modelType: type, source: .mlxServe, kind: .base,
+                   hasVision: vision, quantBits: quantBits, contextLength: ctx,
+                   numExperts: numExperts, activeExperts: activeExperts)
+    }
+
+    // Captions below use the real config values dumped from the user's models:
+    // Qwen2.5-Coder-32B (qwen2, bits 8, ctx 32768, dense),
+    // Qwen3-Coder-30B-A3B (qwen3_moe, bits 8, ctx 262144, 128/8 experts),
+    // Qwen3-Coder-Next (qwen3_next, bits 4, ctx 262144, 512/10 experts).
+
+    func testMetadataSummaryDenseFromConfig() {
+        let m = localModel(name: "Qwen2.5-Coder-32B-Instruct-8bit", type: "qwen2",
+                           path: "/m/Qwen2.5-Coder-32B-Instruct-8bit",
+                           quantBits: 8, ctx: 32768)
+        XCTAssertEqual(m.paramSize, "32B")
+        XCTAssertNil(m.expertSummary, "dense model → no expert token")
+        // Format reads "MLX" (the weight format), not the "MLX-Serve" app name.
+        XCTAssertEqual(m.metadataSummary, "32B · 8-bit · 32K ctx · qwen2 · MLX")
+        XCTAssertTrue(m.hasToolCalling)
+        XCTAssertFalse(m.hasVision)
+    }
+
+    func testMetadataSummaryMoEShowsConfigExperts() {
+        let m = localModel(name: "Qwen3-Coder-30B-A3B-Instruct-8bit", type: "qwen3_moe",
+                           path: "/m/Qwen3-Coder-30B-A3B-Instruct-8bit",
+                           quantBits: 8, ctx: 262144, numExperts: 128, activeExperts: 8)
+        XCTAssertEqual(m.expertSummary, "8/128 experts")
+        XCTAssertEqual(m.metadataSummary, "30B · 8-bit · 8/128 experts · 256K ctx · qwen3_moe · MLX")
+    }
+
+    func testMetadataSummaryConfigQuantOverridesNameAndNoParamToken() {
+        // Name says nothing about params; config says bits 4. Caption must use
+        // the config bits and skip the missing param token.
+        let n = localModel(name: "Qwen3-Coder-Next-4bit", type: "qwen3_next",
+                           path: "/m/Qwen3-Coder-Next-4bit",
+                           quantBits: 4, ctx: 262144, numExperts: 512, activeExperts: 10)
+        XCTAssertNil(n.paramSize)
+        XCTAssertEqual(n.quantization, "4-bit")
+        XCTAssertEqual(n.metadataSummary, "4-bit · 10/512 experts · 256K ctx · qwen3_next · MLX")
+    }
+
+    func testMetadataSummaryGgufFallsBackToNameQuant() {
+        // GGUF has no config.json here → quant comes from the name, format = GGUF.
+        let g = LocalModel(id: "mlxServe:team/m", name: "Meta-Llama-3.1-8B-Instruct-Q4_K_M",
+                           path: "/m/team/m/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf",
+                           sizeFormatted: "5 GB", modelType: "gguf", source: .mlxServe, kind: .base)
+        XCTAssertEqual(g.paramSize, "8B")
+        XCTAssertEqual(g.quantization, "4-bit")   // Q4_K_M → 4-bit, via name fallback
+        XCTAssertEqual(g.metadataSummary, "8B · 4-bit · gguf · GGUF")
+        XCTAssertTrue(g.hasToolCalling)
+    }
+
+    func testContextFormatting() {
+        XCTAssertEqual(LocalModel.formatContext(262144), "256K ctx")
+        XCTAssertEqual(LocalModel.formatContext(32768), "32K ctx")
+        XCTAssertEqual(LocalModel.formatContext(1048576), "1M ctx")
+        XCTAssertEqual(LocalModel.formatContext(512), "512 ctx")
+    }
+
+    // MARK: - config.json parsing (the authoritative metadata source)
+
+    func testParseConfigMetadataReadsQuantCtxExpertsVision() throws {
+        let dir = (tempRoot as NSString).appendingPathComponent("cfg-moe")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let cfg = (dir as NSString).appendingPathComponent("config.json")
+        try """
+        {"model_type":"qwen3_moe","quantization":{"group_size":64,"bits":8},
+         "max_position_embeddings":262144,"num_experts":128,"num_experts_per_tok":8}
+        """.write(toFile: cfg, atomically: true, encoding: .utf8)
+
+        let meta = DownloadManager.parseConfigMetadata(atPath: cfg)
+        XCTAssertEqual(meta.modelType, "qwen3_moe")
+        XCTAssertEqual(meta.quantBits, 8)
+        XCTAssertEqual(meta.contextLength, 262144)
+        XCTAssertEqual(meta.numExperts, 128)
+        XCTAssertEqual(meta.activeExperts, 8)
+        XCTAssertFalse(meta.hasVision)
+    }
+
+    func testParseConfigMetadataQuantizationConfigAndVision() throws {
+        // Some checkpoints use `quantization_config`; vision via `vision_config`.
+        let dir = (tempRoot as NSString).appendingPathComponent("cfg-vision")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let cfg = (dir as NSString).appendingPathComponent("config.json")
+        try """
+        {"model_type":"gemma4","quantization_config":{"bits":4},"vision_config":{"hidden_size":1152}}
+        """.write(toFile: cfg, atomically: true, encoding: .utf8)
+
+        let meta = DownloadManager.parseConfigMetadata(atPath: cfg)
+        XCTAssertEqual(meta.quantBits, 4)
+        XCTAssertTrue(meta.hasVision)
+    }
+
+    func testParseConfigMetadataTextOnlyArchSuppressesVision() throws {
+        // A `_text` arch with a vestigial vision_config must NOT report vision.
+        let dir = (tempRoot as NSString).appendingPathComponent("cfg-text")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let cfg = (dir as NSString).appendingPathComponent("config.json")
+        try #"{"model_type":"qwen3_5_moe_text","vision_config":{"x":1}}"#
+            .write(toFile: cfg, atomically: true, encoding: .utf8)
+
+        XCTAssertFalse(DownloadManager.parseConfigMetadata(atPath: cfg).hasVision)
+    }
+
+    func testParseConfigMetadataMissingFileDefaults() {
+        let meta = DownloadManager.parseConfigMetadata(atPath: "/nope/config.json")
+        XCTAssertEqual(meta, DownloadManager.ConfigMetadata())
+    }
+
     // MARK: - Helpers
 
     /// Minimal model dir layout: just `config.json`. The path-resolution and

--- a/app/Tests/MLXCoreTests/DownloadManagerLayoutTests.swift
+++ b/app/Tests/MLXCoreTests/DownloadManagerLayoutTests.swift
@@ -226,50 +226,152 @@ final class DownloadManagerLayoutTests: XCTestCase {
         XCTAssertFalse(DownloadManager.isSupportedGguf("config.json"))
     }
 
-    // MARK: - Cancellation cleanup
+    // MARK: - Cancellation cleanup (full wipe)
+    //
+    // User-cancel removes the ENTIRE download dir — completed shards, config,
+    // and `.partial` files alike — so a cancel leaves zero footprint: no remnant
+    // that masquerades as a complete model, no undeletable config-only orphan.
+    // (Network-error resume is a separate path that keeps `.partial`s; it does
+    // NOT go through this wipe.)
 
-    /// User-cancel must leave `.partial` files gone (no Resume path) and final
-    /// files untouched. Pinned because the cancel button promises this exact
-    /// behavior; a regression would silently leave half-files on disk and the
-    /// "Resume" button would reappear on the next launch.
-    func testCleanupPartialsRemovesPartialsKeepsFinalFiles() throws {
+    func testCancelWipeRemovesCompletedShardsNotJustPartials() throws {
+        // The late-cancel case: some shards finished before the user hit cancel.
         let repoId = "acme/demo"
+        let author = (tempRoot as NSString).appendingPathComponent("acme")
         let dir = DownloadManager.newLayoutDir(rootDir: tempRoot, repoId: repoId)
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         let finalCfg = (dir as NSString).appendingPathComponent("config.json")
-        let topPartial = (dir as NSString).appendingPathComponent("model.safetensors.partial")
-        let subdir = (dir as NSString).appendingPathComponent("nested")
-        try FileManager.default.createDirectory(atPath: subdir, withIntermediateDirectories: true)
-        let nestedPartial = (subdir as NSString).appendingPathComponent("shard-1.safetensors.partial")
+        let doneShard = (dir as NSString).appendingPathComponent("model-00001.safetensors")
+        let inFlight = (dir as NSString).appendingPathComponent("model-00002.safetensors.partial")
         try "{}".write(toFile: finalCfg, atomically: true, encoding: .utf8)
-        FileManager.default.createFile(atPath: topPartial, contents: Data())
-        FileManager.default.createFile(atPath: nestedPartial, contents: Data())
+        FileManager.default.createFile(atPath: doneShard, contents: Data("w".utf8))
+        FileManager.default.createFile(atPath: inFlight, contents: Data())
 
-        DownloadManager.cleanupPartials(rootDir: tempRoot, repoId: repoId)
+        DownloadManager.removeModelFiles(at: dir, roots: [tempRoot])
 
         let fm = FileManager.default
-        XCTAssertTrue(fm.fileExists(atPath: finalCfg), "completed files must stay on disk")
-        XCTAssertFalse(fm.fileExists(atPath: topPartial), "top-level .partial must be removed")
-        XCTAssertFalse(fm.fileExists(atPath: nestedPartial), "nested .partial must be removed")
-        XCTAssertTrue(fm.fileExists(atPath: dir), "dest dir must remain when other files survive")
+        XCTAssertFalse(fm.fileExists(atPath: dir), "whole download dir must be gone, completed shards included")
+        XCTAssertFalse(fm.fileExists(atPath: author), "now-empty author dir must be pruned")
+        XCTAssertTrue(fm.fileExists(atPath: tempRoot), "scan root must survive")
     }
 
-    func testCleanupPartialsRemovesEmptyDestDir() throws {
-        let repoId = "acme/empty"
+    func testCancelWipeRemovesConfigOnlyOrphan() throws {
+        // The previously-invisible case: config downloaded, no shard yet. Must
+        // not be left behind (it wouldn't surface as a deletable LocalModel).
+        let repoId = "acme/justconfig"
         let dir = DownloadManager.newLayoutDir(rootDir: tempRoot, repoId: repoId)
-        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-        let onlyPartial = (dir as NSString).appendingPathComponent("only.partial")
-        FileManager.default.createFile(atPath: onlyPartial, contents: Data())
+        try makeFakeModel(at: dir)   // config.json only
 
-        DownloadManager.cleanupPartials(rootDir: tempRoot, repoId: repoId)
+        DownloadManager.removeModelFiles(at: dir, roots: [tempRoot])
 
-        XCTAssertFalse(FileManager.default.fileExists(atPath: dir),
-                       "dest dir should be removed when it's empty after partials are deleted")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: dir))
     }
 
-    func testCleanupPartialsNoOpWhenDirMissing() {
+    func testCancelWipeNoOpWhenDirMissing() {
         // Cancelling a fresh download that bailed before mkdir must not crash.
-        DownloadManager.cleanupPartials(rootDir: tempRoot, repoId: "ghost/never-created")
+        let dir = DownloadManager.newLayoutDir(rootDir: tempRoot, repoId: "ghost/never-created")
+        XCTAssertFalse(DownloadManager.removeModelFiles(at: dir, roots: [tempRoot]))
+    }
+
+    // MARK: - Delete by on-disk path
+    //
+    // `LocalModelRow` used to delete via `deleteModel(repoId: model.id)`, but a
+    // LocalModel's `id` is source-prefixed (`"mlxServe:author/name"`), so the
+    // repoId-based path resolver looked under `<root>/mlxServe:author/name` and
+    // deleted nothing — the trash button silently no-op'd and the user had to
+    // `rm -rf` from a terminal. Deletion now keys off the model's real resolved
+    // `path` instead. These pin that behavior.
+
+    func testRemoveModelFilesDeletesNestedDirAndPrunesAuthor() throws {
+        let author = (tempRoot as NSString).appendingPathComponent("acme")
+        let modelDir = (author as NSString).appendingPathComponent("demo")
+        try makeFakeModel(at: modelDir)
+        let partial = (modelDir as NSString).appendingPathComponent("model.safetensors.partial")
+        FileManager.default.createFile(atPath: partial, contents: Data())
+
+        let removed = DownloadManager.removeModelFiles(at: modelDir, roots: [tempRoot])
+
+        let fm = FileManager.default
+        XCTAssertTrue(removed)
+        XCTAssertFalse(fm.fileExists(atPath: modelDir), "model dir (incl. .partial) must be gone")
+        XCTAssertFalse(fm.fileExists(atPath: author), "now-empty author dir must be pruned")
+        XCTAssertTrue(fm.fileExists(atPath: tempRoot), "the scan root itself must never be removed")
+    }
+
+    func testRemoveModelFilesFromGgufFilePath() throws {
+        // A GGUF model's `path` is the .gguf file, not its containing dir.
+        let modelDir = ((tempRoot as NSString).appendingPathComponent("team") as NSString)
+            .appendingPathComponent("mygguf")
+        try FileManager.default.createDirectory(atPath: modelDir, withIntermediateDirectories: true)
+        let gguf = (modelDir as NSString).appendingPathComponent("model-Q4_K_M.gguf")
+        FileManager.default.createFile(atPath: gguf, contents: Data("x".utf8))
+
+        let removed = DownloadManager.removeModelFiles(at: gguf, roots: [tempRoot])
+
+        XCTAssertTrue(removed)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelDir),
+                       "deleting by a file path must remove its containing model dir")
+    }
+
+    func testRemoveModelFilesKeepsAuthorWithSurvivingSiblings() throws {
+        let author = (tempRoot as NSString).appendingPathComponent("acme")
+        let a = (author as NSString).appendingPathComponent("model-a")
+        let b = (author as NSString).appendingPathComponent("model-b")
+        try makeFakeModel(at: a)
+        try makeFakeModel(at: b)
+
+        DownloadManager.removeModelFiles(at: a, roots: [tempRoot])
+
+        let fm = FileManager.default
+        XCTAssertFalse(fm.fileExists(atPath: a))
+        XCTAssertTrue(fm.fileExists(atPath: author), "author dir must survive while a sibling model remains")
+        XCTAssertTrue(fm.fileExists(atPath: b))
+    }
+
+    func testRemoveModelFilesLegacyFlatDoesNotPruneRoot() throws {
+        // Legacy flat layout: the model dir sits directly under a root, so its
+        // "author" IS the root — pruning must stop there.
+        let modelDir = (tempRoot as NSString).appendingPathComponent("flatmodel")
+        try makeFakeModel(at: modelDir)
+
+        DownloadManager.removeModelFiles(at: modelDir, roots: [tempRoot])
+
+        let fm = FileManager.default
+        XCTAssertFalse(fm.fileExists(atPath: modelDir))
+        XCTAssertTrue(fm.fileExists(atPath: tempRoot), "a root must never be pruned even when emptied")
+    }
+
+    func testRemoveModelFilesRefusesToDeleteARoot() throws {
+        // Defensive: never remove a root directory itself.
+        let removed = DownloadManager.removeModelFiles(at: tempRoot, roots: [tempRoot])
+        XCTAssertFalse(removed)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempRoot))
+    }
+
+    func testRemoveModelFilesMissingPathIsNoOp() {
+        let ghost = (tempRoot as NSString).appendingPathComponent("nope/missing")
+        XCTAssertFalse(DownloadManager.removeModelFiles(at: ghost, roots: [tempRoot]))
+    }
+
+    // MARK: - Cancellation detection
+    //
+    // Cancelling an in-flight download surfaces as URLSession's
+    // NSURLErrorCancelled, NOT Swift's CancellationError — so the retry loop
+    // must recognize both, or a cancelled transfer flashes "retrying…" before
+    // it finally unwinds.
+
+    func testIsCancellationMatchesCancellationErrorAndURLCancel() {
+        XCTAssertTrue(DownloadManager.isCancellation(CancellationError()))
+        XCTAssertTrue(DownloadManager.isCancellation(URLError(.cancelled)))
+        XCTAssertTrue(DownloadManager.isCancellation(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)))
+    }
+
+    func testIsCancellationRejectsTransientFailures() {
+        // These are genuine transient errors the retry loop must keep retrying.
+        XCTAssertFalse(DownloadManager.isCancellation(URLError(.timedOut)))
+        XCTAssertFalse(DownloadManager.isCancellation(URLError(.networkConnectionLost)))
+        XCTAssertFalse(DownloadManager.isCancellation(URLError(.notConnectedToInternet)))
     }
 
     // MARK: - Helpers

--- a/app/Tests/MLXCoreTests/DownloadManagerLayoutTests.swift
+++ b/app/Tests/MLXCoreTests/DownloadManagerLayoutTests.swift
@@ -374,6 +374,22 @@ final class DownloadManagerLayoutTests: XCTestCase {
         XCTAssertFalse(DownloadManager.isCancellation(URLError(.notConnectedToInternet)))
     }
 
+    // MARK: - Downloaded tab live-refresh trigger
+    //
+    // The Downloaded tab's "Size on Disk" comes from a disk re-scan
+    // (`refreshModels`), which previously only fired on tab entry — so sizes
+    // froze mid-download until the user toggled the button. The tab now
+    // live-polls, but only while it's showing AND a download is in flight.
+
+    func testShouldLivePollOnlyWhenTabOpenAndDownloading() {
+        XCTAssertTrue(ModelBrowserView.shouldLivePoll(downloadedTab: true, hasActiveDownloads: true))
+        // No active downloads → nothing to refresh, don't spin.
+        XCTAssertFalse(ModelBrowserView.shouldLivePoll(downloadedTab: true, hasActiveDownloads: false))
+        // Not in the Downloaded tab → the sizes aren't even visible.
+        XCTAssertFalse(ModelBrowserView.shouldLivePoll(downloadedTab: false, hasActiveDownloads: true))
+        XCTAssertFalse(ModelBrowserView.shouldLivePoll(downloadedTab: false, hasActiveDownloads: false))
+    }
+
     // MARK: - Helpers
 
     /// Minimal model dir layout: just `config.json`. The path-resolution and


### PR DESCRIPTION
Fixes #33.

Fixes two download-lifecycle defects in the macOS app's Model Browser and closes a few UX gaps in the Downloaded tab. macOS-app / `DownloadManager` only — no Zig server changes.

## Commits

### 1. Fix model download cancel and delete in the browser
- **Cancel**: browser downloads ran via an untracked `Task`, so they were never registered for cancellation, and the downloading row had no cancel button. Route them through the tracked `start()`/`startGguf()` and add ✕ cancel buttons to `ModelBrowserRow` + `ActiveDownloadRow`.
- **Delete**: `LocalModelRow` deleted via `deleteModel(repoId: model.id)`, but a local model's id is source-prefixed (`mlxServe:author/name`), so the repoId→path resolver pointed at a nonexistent dir and deleted nothing. Delete by the model's real on-disk `path` (`deleteModel(_:)` + `removeModelFiles`), which also covers LM Studio / custom-root models outside `~/.mlx-serve/models`.
- **Full-wipe on cancel**: a cancel now removes the whole download dir (completed shards, config, partials) so it leaves zero footprint — no complete-looking-but-incomplete remnant, no undeletable config-only orphan. Network-error resume still keeps `.partial` files for "Resume".
- Treat URLSession's `NSURLErrorCancelled` as cancellation so a cancelled transfer stops immediately instead of flashing "retrying…".

### 2. Live-refresh the Downloaded tab while downloads are in flight
On-disk sizes only refreshed on tab entry, freezing mid-download until the user toggled the tab. Poll `refreshModels()` ~1/s while the tab is open and a download is active; self-cancels once the tab closes or downloads finish. Trigger factored into a testable `shouldLivePoll`.

### 3. Show config-sourced model metadata in the Downloaded tab
Rows showed only name + delete. Each row now has a metadata caption + capability icons, sourced from `config.json` at discovery (authoritative) rather than guessed from the name:
- Quant from `quantization.bits`, context from `max_position_embeddings`, MoE routing from `num_experts`/`num_experts_per_tok` ("8/128 experts"), vision from `vision_config` (gated against `_text` archs).
- Weight format shown as MLX vs GGUF (not the "MLX-Serve" app name).
- Headline param count still name-derived — the one figure not in `config.json`.
- Tool-calling via the shared name heuristic.

Config parsing is factored into a testable `DownloadManager.parseConfigMetadata`; quant/param parsers shared with the search rows via `HFModel`.

## Testing
- Each commit carries its own unit tests in `DownloadManagerLayoutTests` (delete-by-path, cancellation detection, full-wipe, live-poll trigger, metadata/config parsing).
- Full Swift suite: 595 tests, 0 failures (6 pre-existing skips).
- App bundle builds via `app/build.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)