### PR TITLE
Add Qwen2 (Qwen2.5) architecture support

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -587,19 +587,25 @@ pub fn main(init: std.process.Init) !void {
     };
     chat_config.* = try chat_mod.loadChatConfig(io, allocator, model_dir);
 
-    // Resolve EOS tokens from tokenizer if config.json didn't specify any
-    if (config.num_eos_tokens == 0) {
-        if (chat_config.eos_token) |eos_str| {
-            if (tok.special_tokens.get(eos_str)) |eos_id| {
+    // Merge the tokenizer's chat-terminator EOS into the stop set — ALWAYS,
+    // even when config.json already specified an eos_token_id. Some checkpoints
+    // (e.g. Qwen2.5-Coder-7B) set config.json eos_token_id to <|endoftext|>
+    // (151643) but their chat template ends turns with <|im_end|> (151645);
+    // stopping only on config's id leaks <|im_end|> into the output (breaks
+    // structured-JSON / tool-calling). Additive + dedup-guarded: this can only
+    // ADD a model-declared stop token, never remove one.
+    if (chat_config.eos_token) |eos_str| {
+        if (tok.special_tokens.get(eos_str)) |eos_id| {
+            if (!config.isEosToken(eos_id)) {
                 config.addEosToken(eos_id);
                 log.info("EOS token from tokenizer: {s} (id={d})\n", .{ eos_str, eos_id });
             }
         }
-        // Also add <|endoftext|> if it exists and wasn't already added
-        if (tok.special_tokens.get("<|endoftext|>")) |eot_id| {
-            if (!config.isEosToken(eot_id)) {
-                config.addEosToken(eot_id);
-            }
+    }
+    // Also add <|endoftext|> if it exists and wasn't already added.
+    if (tok.special_tokens.get("<|endoftext|>")) |eot_id| {
+        if (!config.isEosToken(eot_id)) {
+            config.addEosToken(eot_id);
         }
     }
 

--- a/src/model.zig
+++ b/src/model.zig
@@ -1246,6 +1246,31 @@ test "ModelConfig addEosToken max capacity" {
     try testing.expect(!config.isEosToken(999));
 }
 
+test "EOS merge: chat-terminator added even when config already provided an eos" {
+    // Regression for the Qwen2.5-Coder-7B leak: its config.json sets
+    // eos_token_id=<|endoftext|> (151643), but its chat template ends turns
+    // with <|im_end|> (151645). The load path (main.zig / scheduler doLoad)
+    // must ALWAYS merge the tokenizer's chat-terminator EOS — additively and
+    // dedup-guarded — not only when config provided none; otherwise <|im_end|>
+    // is never a stop token and leaks into the output (broke structured JSON /
+    // tool calling). This pins the merge invariant those call sites implement.
+    var config = ModelConfig{};
+    config.addEosToken(151643); // from config.json eos_token_id
+    try testing.expectEqual(@as(u32, 1), config.num_eos_tokens);
+
+    // Merge step the fix performs: add the chat terminator if absent.
+    const chat_eos: u32 = 151645; // <|im_end|>, from tokenizer_config eos_token
+    if (!config.isEosToken(chat_eos)) config.addEosToken(chat_eos);
+
+    try testing.expect(config.isEosToken(151645)); // now stops on <|im_end|>
+    try testing.expect(config.isEosToken(151643)); // original preserved
+    try testing.expectEqual(@as(u32, 2), config.num_eos_tokens);
+
+    // Idempotent: re-running the merge must not duplicate.
+    if (!config.isEosToken(chat_eos)) config.addEosToken(chat_eos);
+    try testing.expectEqual(@as(u32, 2), config.num_eos_tokens);
+}
+
 test "ModelConfig eosTokenSlice" {
     var config = ModelConfig{};
     config.addEosToken(10);

--- a/src/model.zig
+++ b/src/model.zig
@@ -1008,6 +1008,11 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
         // Llama-family defaults (qwen3, llama, mistral, etc.)
         if (std.mem.eql(u8, model_type, "qwen3")) {
             config.model_type = "qwen3";
+        } else if (std.mem.eql(u8, model_type, "qwen2")) {
+            // Qwen2.5 family: dense Llama-style attention, NO QK-norm (left
+            // false below), additive qkv-projection biases applied in the
+            // forward when present.
+            config.model_type = "qwen2";
         } else if (std.mem.eql(u8, model_type, "llama")) {
             config.model_type = "llama";
         } else if (std.mem.eql(u8, model_type, "mistral")) {
@@ -1022,6 +1027,14 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
         config.has_qk_norm = false;
         config.rope_scaling_factor = 1.0;
         config.rope_local_base_freq = config.rope_theta;
+        // Llama-family models (qwen2, llama, mistral) usually omit `head_dim`;
+        // the HF default is hidden_size / num_attention_heads. Without this the
+        // stale 256 sentinel (line 53) would corrupt attention for any such
+        // checkpoint that doesn't ship an explicit head_dim (e.g. Qwen2.5).
+        // qwen3 ships an explicit head_dim, so this leaves it untouched.
+        if (cfg_obj.get("head_dim") == null) {
+            config.head_dim = config.hidden_size / config.num_attention_heads;
+        }
 
         if (cfg_obj.get("hidden_act")) |v| {
             if (v == .string) {
@@ -1712,6 +1725,39 @@ test "parseConfigFromJson qwen3_moe (Qwen3-30B-A3B) → MoE, no shared expert, n
     try testing.expect(!config.isLinearLayer(3));
     try testing.expect(!config.has_hybrid_layers);
     try testing.expect(!config.has_sliding_window);
+    try testing.expectEqual(@as(u32, 8), config.quant_bits);
+}
+
+test "parseConfigFromJson qwen2 (Qwen2.5) → dense, no QK-norm, silu" {
+    // Qwen2.5-Coder / Qwen2.5-Instruct ship model_type "qwen2": a dense
+    // full-attention Llama-family arch that, unlike qwen3, has NO QK-norm and
+    // DOES carry additive qkv-projection biases (q/k/v_proj.bias). The forward
+    // applies those biases when present; here we pin the config classification.
+    const json =
+        \\{
+        \\  "model_type": "qwen2",
+        \\  "hidden_size": 5120,
+        \\  "num_hidden_layers": 64,
+        \\  "num_attention_heads": 40,
+        \\  "num_key_value_heads": 8,
+        \\  "intermediate_size": 27648,
+        \\  "rms_norm_eps": 1e-6,
+        \\  "rope_theta": 1000000.0,
+        \\  "hidden_act": "silu",
+        \\  "tie_word_embeddings": false,
+        \\  "quantization": {"bits": 8, "group_size": 64}
+        \\}
+    ;
+    const config = try parseConfigFromJson(testing.allocator, json);
+    try testing.expectEqualStrings("qwen2", config.model_type);
+    try testing.expectEqualStrings("model", config.weight_prefix);
+    try testing.expect(!config.isMoe());
+    // KEY difference from qwen3: no QK-norm.
+    try testing.expect(!config.has_qk_norm);
+    try testing.expect(!config.has_pre_ff_norm);
+    try testing.expect(!config.scale_embeddings);
+    try testing.expectEqual(HiddenAct.silu, config.hidden_act);
+    try testing.expectEqual(@as(u32, 128), config.head_dim); // 5120 / 40
     try testing.expectEqual(@as(u32, 8), config.quant_bits);
 }
 

--- a/src/model_discovery.zig
+++ b/src/model_discovery.zig
@@ -31,6 +31,7 @@ const supported_model_types = [_][]const u8{
     "gemma3",
     "gemma4",       "gemma4_text",
     "gemma4_unified", "gemma4_unified_text",
+    "qwen2",
     "qwen3",        "qwen3_5",        "qwen3_5_text",
     "qwen3_5_moe",  "qwen3_5_moe_text",
     "qwen3_moe",    "qwen3_moe_text",

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -1521,19 +1521,19 @@ fn preloadCpuState(allocator: std.mem.Allocator, io: std.Io, model_dir: []const 
     cc.* = try chat_mod.loadChatConfig(io, allocator, model_dir);
     errdefer cc.deinit();
 
-    // Same EOS-resolution shenanigans main.zig does — without them the
-    // generated text won't stop on tokenizer-defined EOS strings.
-    if (config.num_eos_tokens == 0) {
-        if (cc.eos_token) |eos_str| {
-            if (tok.special_tokens.get(eos_str)) |eos_id| {
-                config.addEosToken(eos_id);
-            }
+    // Same EOS-resolution as main.zig — merge the tokenizer's chat-terminator
+    // EOS into the stop set ALWAYS, even when config.json already specified an
+    // eos_token_id. Some checkpoints (e.g. Qwen2.5-Coder-7B) set config.json
+    // eos_token_id to <|endoftext|> but end chat turns with <|im_end|>; gating
+    // on `num_eos_tokens == 0` left <|im_end|> out of the stop set and it leaked
+    // into output. Additive + dedup-guarded: only ever ADDS a declared stop.
+    if (cc.eos_token) |eos_str| {
+        if (tok.special_tokens.get(eos_str)) |eos_id| {
+            if (!config.isEosToken(eos_id)) config.addEosToken(eos_id);
         }
-        if (tok.special_tokens.get("<|endoftext|>")) |eot_id| {
-            if (!config.isEosToken(eot_id)) {
-                config.addEosToken(eot_id);
-            }
-        }
+    }
+    if (tok.special_tokens.get("<|endoftext|>")) |eot_id| {
+        if (!config.isEosToken(eot_id)) config.addEosToken(eot_id);
     }
     if (tok.special_tokens.get("<pad>")) |pad_id| {
         if (pad_id > 0 and !config.isEosToken(pad_id)) {

--- a/src/tokenizer.zig
+++ b/src/tokenizer.zig
@@ -865,11 +865,14 @@ pub fn loadTokenizer(io: std.Io, allocator: std.mem.Allocator, model_dir: []cons
         try merge_ranks.ensureTotalCapacity(@intCast(merges_arr.items.len));
         sw = io_util.Stopwatch.init(io);
         for (merges_arr.items, 0..) |merge_val, rank| {
-            const pair = merge_val.array;
-            try merge_ranks.put(
-                .{ .left = pair.items[0].string, .right = pair.items[1].string },
-                @intCast(rank),
-            );
+            // Two on-disk formats: newer HF tokenizers store each merge as a
+            // 2-element array `["a","b"]` (Qwen3, Gemma 4); older / GPT-2-style
+            // exports store it as a single space-joined string `"a b"` (Qwen2.5,
+            // many Llama/Mistral). `parseMergePair` handles both. Reading `.array`
+            // off a string Value in ReleaseFast spins the loop on garbage, which
+            // hung Qwen2.5 loads before this fix.
+            const pair = parseMergePair(merge_val) orelse continue;
+            try merge_ranks.put(pair, @intCast(rank));
         }
         log.info("  loaded {d} merges in {d}ms\n", .{ merge_ranks.count(), sw.read() / std.time.ns_per_ms });
     }
@@ -930,6 +933,28 @@ pub fn loadTokenizer(io: std.Io, allocator: std.mem.Allocator, model_dir: []cons
         .eos_id = eos_id,
         .parsed_json = parsed,
     };
+}
+
+/// Parse one BPE merge entry, accepting both on-disk formats:
+///   - 2-element array `["left","right"]` (newer HF: Qwen3, Gemma 4)
+///   - space-joined string `"left right"` (GPT-2-style: Qwen2.5, many Llama/Mistral)
+/// Returns null for malformed entries (skip). The returned slices borrow from
+/// `merge_val`'s backing arena, same lifetime as the array-format halves.
+fn parseMergePair(merge_val: std.json.Value) ?Tokenizer.MergePair {
+    switch (merge_val) {
+        .array => |pair| {
+            if (pair.items.len < 2) return null;
+            if (pair.items[0] != .string or pair.items[1] != .string) return null;
+            return .{ .left = pair.items[0].string, .right = pair.items[1].string };
+        },
+        .string => |s| {
+            // Split on the FIRST space: byte-level BPE encodes spaces as 'Ġ',
+            // so neither half contains a literal space separator.
+            const sp = std.mem.indexOfScalar(u8, s, ' ') orelse return null;
+            return .{ .left = s[0..sp], .right = s[sp + 1 ..] };
+        },
+        else => return null,
+    }
 }
 
 /// Check if a pre_tokenizer JSON value contains a ByteLevel type.
@@ -1467,4 +1492,35 @@ test "bpeMerge: symbols missing from vocab fall back to byte pieces" {
     const ids = try tok.bpeMerge(allocator, "az");
     defer allocator.free(ids);
     try testing.expectEqualSlices(u32, &[_]u32{ 1, 99 }, ids);
+}
+
+test "parseMergePair handles both array and space-joined-string formats" {
+    const alloc = testing.allocator;
+    // Array format (Qwen3 / Gemma 4): ["left","right"].
+    {
+        var p = try std.json.parseFromSlice(std.json.Value, alloc, "[\"AB\",\"cd\"]", .{});
+        defer p.deinit();
+        const mp = parseMergePair(p.value).?;
+        try testing.expectEqualStrings("AB", mp.left);
+        try testing.expectEqualStrings("cd", mp.right);
+    }
+    // String format (Qwen2.5 / GPT-2-style): "left right" split on first space.
+    {
+        var p = try std.json.parseFromSlice(std.json.Value, alloc, "\"AB cd\"", .{});
+        defer p.deinit();
+        const mp = parseMergePair(p.value).?;
+        try testing.expectEqualStrings("AB", mp.left);
+        try testing.expectEqualStrings("cd", mp.right);
+    }
+    // Malformed → null (no crash): string without a space, short array.
+    {
+        var p = try std.json.parseFromSlice(std.json.Value, alloc, "\"nospace\"", .{});
+        defer p.deinit();
+        try testing.expect(parseMergePair(p.value) == null);
+    }
+    {
+        var p = try std.json.parseFromSlice(std.json.Value, alloc, "[\"only\"]", .{});
+        defer p.deinit();
+        try testing.expect(parseMergePair(p.value) == null);
+    }
 }

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -1051,6 +1051,12 @@ const LayerWeights = struct {
     q_w: mlx.mlx_array,
     q_s: mlx.mlx_array,
     q_b: mlx.mlx_array,
+    // Additive qkv-projection biases (Qwen2's `q/k/v_proj.bias`), distinct from
+    // the quant `*_b` biases above. Empty-ctx when the arch has none (qwen3,
+    // llama, mistral). Applied via `qmatmulMaybeBias` in the forward.
+    q_bias: mlx.mlx_array = .{},
+    k_bias: mlx.mlx_array = .{},
+    v_bias: mlx.mlx_array = .{},
     k_w: mlx.mlx_array,
     k_s: mlx.mlx_array,
     k_b: mlx.mlx_array,
@@ -1814,6 +1820,10 @@ pub const Transformer = struct {
                     if (lw.v_w.ctx != null) _ = mlx.mlx_vector_array_append_value(all_vec, lw.v_w);
                     if (lw.v_s.ctx != null) _ = mlx.mlx_vector_array_append_value(all_vec, lw.v_s);
                     if (lw.v_b.ctx != null) _ = mlx.mlx_vector_array_append_value(all_vec, lw.v_b);
+                    // Additive qkv biases (Qwen2) — empty-ctx for archs without them.
+                    if (lw.q_bias.ctx != null) _ = mlx.mlx_vector_array_append_value(all_vec, lw.q_bias);
+                    if (lw.k_bias.ctx != null) _ = mlx.mlx_vector_array_append_value(all_vec, lw.k_bias);
+                    if (lw.v_bias.ctx != null) _ = mlx.mlx_vector_array_append_value(all_vec, lw.v_bias);
                     _ = mlx.mlx_vector_array_append_value(all_vec, lw.o_w);
                     if (lw.o_s.ctx != null) _ = mlx.mlx_vector_array_append_value(all_vec, lw.o_s);
                     if (lw.o_b.ctx != null) _ = mlx.mlx_vector_array_append_value(all_vec, lw.o_b);
@@ -2497,6 +2507,15 @@ pub const Transformer = struct {
         var result = mlx.mlx_array_new();
         try mlx.check(mlx.mlx_add(&result, mm, bias, self.s));
         return result;
+    }
+
+    /// `qmatmul`, plus an additive projection bias when `bias` is non-empty.
+    /// Lets the standard (Llama-family) attention path support archs that carry
+    /// additive qkv biases (Qwen2's `q/k/v_proj.bias`) without branching per
+    /// arch — empty `bias` (qwen3/llama/mistral) is a plain `qmatmul`.
+    inline fn qmatmulMaybeBias(self: *const Transformer, x: mlx.mlx_array, w: mlx.mlx_array, sc: mlx.mlx_array, bi: mlx.mlx_array, bias: mlx.mlx_array) !mlx.mlx_array {
+        if (bias.ctx != null) return self.qmatmulAddBias(x, w, sc, bi, bias);
+        return self.qmatmul(x, w, sc, bi);
     }
 
     fn embedding(self: *const Transformer, token_ids: mlx.mlx_array) !mlx.mlx_array {
@@ -3543,7 +3562,7 @@ pub const Transformer = struct {
                 @intCast(cur_hd);
 
             // Q projection
-            const q = try self.qmatmul(normed, lw.q_w, lw.q_s, lw.q_b);
+            const q = try self.qmatmulMaybeBias(normed, lw.q_w, lw.q_s, lw.q_b, lw.q_bias);
             defer _ = mlx.mlx_array_free(q);
 
             var q_r = mlx.mlx_array_new();
@@ -3591,12 +3610,12 @@ pub const Transformer = struct {
             } else {
                 // Compute K, V (temp arrays scoped to this block).
                 // When k_eq_v, V shares the K projection — compute once, alias into V.
-                const own_k = try self.qmatmul(normed, lw.k_w, lw.k_s, lw.k_b);
+                const own_k = try self.qmatmulMaybeBias(normed, lw.k_w, lw.k_s, lw.k_b, lw.k_bias);
                 defer _ = mlx.mlx_array_free(own_k);
                 const own_v = if (lw.k_eq_v)
                     own_k
                 else
-                    try self.qmatmul(normed, lw.v_w, lw.v_s, lw.v_b);
+                    try self.qmatmulMaybeBias(normed, lw.v_w, lw.v_s, lw.v_b, lw.v_bias);
                 defer if (!lw.k_eq_v) {
                     _ = mlx.mlx_array_free(own_v);
                 };
@@ -3929,7 +3948,7 @@ pub const Transformer = struct {
             defer _ = mlx.mlx_array_free(normed);
 
             // Q projection + reshape + Q-norm + transpose + dynamic RoPE.
-            const q = try self.qmatmul(normed, lw.q_w, lw.q_s, lw.q_b);
+            const q = try self.qmatmulMaybeBias(normed, lw.q_w, lw.q_s, lw.q_b, lw.q_bias);
             defer _ = mlx.mlx_array_free(q);
 
             var q_r = mlx.mlx_array_new();
@@ -3955,12 +3974,12 @@ pub const Transformer = struct {
             // We pad each to the common kv_max and concat axis=0 → [N, kv_h, kv_max, cur_hd].
             if (!is_kv_shared) {
                 // Project K, V at full batch (B=N), reshape, normalize, transpose, RoPE.
-                const own_k = try self.qmatmul(normed, lw.k_w, lw.k_s, lw.k_b);
+                const own_k = try self.qmatmulMaybeBias(normed, lw.k_w, lw.k_s, lw.k_b, lw.k_bias);
                 defer _ = mlx.mlx_array_free(own_k);
                 const own_v = if (lw.k_eq_v)
                     own_k
                 else
-                    try self.qmatmul(normed, lw.v_w, lw.v_s, lw.v_b);
+                    try self.qmatmulMaybeBias(normed, lw.v_w, lw.v_s, lw.v_b, lw.v_bias);
                 defer if (!lw.k_eq_v) {
                     _ = mlx.mlx_array_free(own_v);
                 };
@@ -6300,19 +6319,24 @@ fn initStandardLayers(allocator: std.mem.Allocator, config: ModelConfig, weights
         lw.q_w = getLayerWeight(weights, name_buf, prefix, li, "self_attn.q_proj.weight");
         lw.q_s = getLayerScaleOrEmpty(weights, name_buf, prefix, li, "self_attn.q_proj.scales", config.quant_bits);
         lw.q_b = getLayerBias(weights, name_buf, prefix, li, "self_attn.q_proj.biases", &config);
+        // Additive q-proj bias (Qwen2). Optional — empty for archs without it.
+        lw.q_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.q_proj.bias") orelse mlx.mlx_array_new();
         if (kv_shared) {
             // No own K/V — the forward reads kv_source's cache. Leave empty.
             lw.k_eq_v = false;
             lw.k_w = mlx.mlx_array_new();
             lw.k_s = mlx.mlx_array_new();
             lw.k_b = mlx.mlx_array_new();
+            lw.k_bias = mlx.mlx_array_new();
             lw.v_w = mlx.mlx_array_new();
             lw.v_s = mlx.mlx_array_new();
             lw.v_b = mlx.mlx_array_new();
+            lw.v_bias = mlx.mlx_array_new();
         } else {
             lw.k_w = getLayerWeight(weights, name_buf, prefix, li, "self_attn.k_proj.weight");
             lw.k_s = getLayerScaleOrEmpty(weights, name_buf, prefix, li, "self_attn.k_proj.scales", config.quant_bits);
             lw.k_b = getLayerBias(weights, name_buf, prefix, li, "self_attn.k_proj.biases", &config);
+            lw.k_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.k_proj.bias") orelse mlx.mlx_array_new();
             // Gemma 4 (31B): full_attention layers share V with K (no v_proj weight stored).
             // Sliding_attention layers still have separate V.
             lw.k_eq_v = config.attention_k_eq_v and config.isGlobalLayer(li);
@@ -6320,10 +6344,12 @@ fn initStandardLayers(allocator: std.mem.Allocator, config: ModelConfig, weights
                 lw.v_w = lw.k_w;
                 lw.v_s = lw.k_s;
                 lw.v_b = lw.k_b;
+                lw.v_bias = lw.k_bias;
             } else {
                 lw.v_w = getLayerWeight(weights, name_buf, prefix, li, "self_attn.v_proj.weight");
                 lw.v_s = getLayerScaleOrEmpty(weights, name_buf, prefix, li, "self_attn.v_proj.scales", config.quant_bits);
                 lw.v_b = getLayerBias(weights, name_buf, prefix, li, "self_attn.v_proj.biases", &config);
+                lw.v_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.v_proj.bias") orelse mlx.mlx_array_new();
             }
         }
         lw.o_w = getLayerWeight(weights, name_buf, prefix, li, "self_attn.o_proj.weight");

--- a/tests/test_validator_matrix.sh
+++ b/tests/test_validator_matrix.sh
@@ -42,6 +42,7 @@ GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; NC='\033[0m'
 # logical|display|path|pi_case|probe_timeout_s
 # pi_case must exist in pi_integration_run.sh's html matrix.
 MODELS=(
+    "qwen2|Qwen2.5-Coder 32B 8-bit (qwen2)|$HOME/.mlx-serve/models/mlx-community/Qwen2.5-Coder-32B-Instruct-8bit|html-coder|150"
     "gemma4|Gemma 4 E4B 8-bit (gemma4)|$HOME/.mlx-serve/models/gemma-4-e4b-it-8bit|html-e4b|90"
     "gemma3|Gemma 3 12B QAT 4-bit (gemma3)|$HOME/.mlx-serve/models/mlx-community/gemma-3-12b-it-qat-4bit|html-gemma3|90"
     "qwen36|Qwen3.6 27B dense 4-bit (qwen3_5)|$HOME/.lmstudio/models/mlx-community/Qwen3.6-27B-4bit|html-qwen36|150"


### PR DESCRIPTION
Fixes #35.

Adds full server-side support for `model_type: "qwen2"` (Qwen2.5 family). Qwen2 is Llama-family but differs from Qwen3 in ways that each required handling — discovered while bringing up `Qwen2.5-Coder-32B-Instruct`.

## Changes
- **Dispatch + config** (`model.zig`): classify `qwen2` (no QK-norm, silu). Default `head_dim` to `hidden_size / num_attention_heads` when config.json omits it (Qwen2.5 does) — previously the stale 256 sentinel corrupted attention. Also fixes llama/mistral exports that omit `head_dim`.
- **Additive qkv bias** (`transformer.zig`): Qwen2 carries `q/k/v_proj.bias` (additive, distinct from the quant `.biases`), which the standard attention path didn't apply. Load them as optional `LayerWeights` fields and apply via a new `qmatmulMaybeBias` helper — weight-presence-driven (no-op for qwen3/llama/mistral), wired through both the regular and batched eval paths.
- **Tokenizer merges** (`tokenizer.zig`): accept the older space-joined-string merge format (`"a b"`) alongside the pair-array format (`["a","b"]`). Qwen2.5 / GPT-2-style exports use the string form; reading it as an array in ReleaseFast spun the load loop on garbage and **hung the server during tokenizer init**. Factored into a testable `parseMergePair`.
- **Discovery** (`model_discovery.zig`): add `"qwen2"` to the supported model_types allow-list.

The Swift client already lists `qwen2` as supported, so no app change is needed — this closes the client/server mismatch.

## Testing
- New Zig unit tests: `parseConfigFromJson qwen2` (no QK-norm, head_dim 128) and `parseMergePair` (array + space-joined-string + malformed). Full `zig build test` green.
- **Live end-to-end**: `Qwen2.5-Coder-32B-Instruct-8bit` loads (head_dim 128, 8-bit affine) and generates correct code; reports cleanly in `/v1/models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)