### PR TITLE
Report full metadata for unloaded models in /v1/models

### DIFF
--- a/src/model_discovery.zig
+++ b/src/model_discovery.zig
@@ -326,6 +326,105 @@ pub fn probeModelDir(io: std.Io, allocator: std.mem.Allocator, abs_path: []const
     return .{ .model_type = model_type, .bytes_on_disk = if (bytes_ok) bytes else null };
 }
 
+/// Metadata an `unloaded` stub can advertise via `/v1/models` without faulting
+/// in weights — all sourced from `config.json` (+ chat-template presence). Lets
+/// clients see context window, dims, MoE-ness, and capabilities (tools/vision)
+/// before a cold load. `found=false` means config.json couldn't be read/parsed.
+pub const StubMeta = struct {
+    found: bool = false,
+    vocab_size: u32 = 0,
+    hidden_size: u32 = 0,
+    num_hidden_layers: u32 = 0,
+    max_position_embeddings: u32 = 0,
+    quant_bits: u32 = 0,
+    is_moe: bool = false,
+    has_vision: bool = false,
+    has_chat: bool = false,
+};
+
+fn jsonU32(obj: std.json.ObjectMap, key: []const u8) u32 {
+    if (obj.get(key)) |v| {
+        if (v == .integer and v.integer > 0) return @intCast(v.integer);
+    }
+    return 0;
+}
+
+/// Pure: extract `StubMeta` from raw config.json bytes. `has_chat_template` is
+/// supplied by the caller (the template lives outside config.json), and
+/// determines chat/tool capabilities — gated off for encoder-only (`bert`)
+/// archs. Mirrors the loaded-path capability rules in `server.renderModelEntry`
+/// (chat-template presence ⇒ chat/tool_use/streaming/json_schema). Returns
+/// `.found=false` on any parse failure.
+pub fn parseStubMeta(allocator: std.mem.Allocator, config_json: []const u8, has_chat_template: bool) StubMeta {
+    var meta: StubMeta = .{};
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, config_json, .{}) catch return meta;
+    defer parsed.deinit();
+    if (parsed.value != .object) return meta;
+    const root = parsed.value.object;
+    meta.found = true;
+    meta.vocab_size = jsonU32(root, "vocab_size");
+    meta.hidden_size = jsonU32(root, "hidden_size");
+    meta.num_hidden_layers = jsonU32(root, "num_hidden_layers");
+    meta.max_position_embeddings = jsonU32(root, "max_position_embeddings");
+    if (root.get("quantization")) |q| {
+        if (q == .object) meta.quant_bits = jsonU32(q.object, "bits");
+    }
+    meta.is_moe = jsonU32(root, "num_experts") > 0 or
+        jsonU32(root, "num_local_experts") > 0 or
+        jsonU32(root, "n_routed_experts") > 0;
+    const mt: []const u8 = if (root.get("model_type")) |v|
+        (if (v == .string) v.string else "")
+    else
+        "";
+    // Vision: a `vision_config` block on a non-`_text` arch (the `_text` guard
+    // skips text-only quantized checkpoints with a vestigial block).
+    meta.has_vision = root.get("vision_config") != null and !std.mem.endsWith(u8, mt, "_text");
+    const is_encoder = std.mem.eql(u8, mt, "bert");
+    meta.has_chat = has_chat_template and !is_encoder;
+    return meta;
+}
+
+/// Read `StubMeta` for the model directory at `abs_path` (config.json + a
+/// chat-template-presence check). Best-effort: any I/O / parse failure yields
+/// `.found=false`. Called per unloaded entry from `/v1/models` — cheap (small
+/// JSON files) and that endpoint isn't hot.
+pub fn readStubMeta(io: std.Io, allocator: std.mem.Allocator, abs_path: []const u8) StubMeta {
+    const trimmed = trimTrailingSlash(abs_path);
+    const base = std.fs.path.basename(trimmed);
+    const parent = std.fs.path.dirname(trimmed) orelse return .{};
+    if (base.len == 0 or parent.len == 0) return .{};
+    var parent_dir = std.Io.Dir.openDirAbsolute(io, parent, .{}) catch return .{};
+    defer parent_dir.close(io);
+    var dir = parent_dir.openDir(io, base, .{}) catch return .{};
+    defer dir.close(io);
+
+    var file = dir.openFile(io, "config.json", .{}) catch return .{};
+    defer file.close(io);
+    var rbuf: [4096]u8 = undefined;
+    var rs = file.reader(io, &rbuf);
+    const bytes = rs.interface.allocRemaining(allocator, .limited(4 * 1024 * 1024)) catch return .{};
+    defer allocator.free(bytes);
+
+    return parseStubMeta(allocator, bytes, hasChatTemplate(io, allocator, dir));
+}
+
+/// True if the model dir ships a chat template — a `chat_template.jinja` file,
+/// or a `tokenizer_config.json` that carries a `chat_template` key. Cheap proxy
+/// for "this is an instruct/chat model" used to gate chat/tool capabilities on
+/// unloaded stubs.
+fn hasChatTemplate(io: std.Io, allocator: std.mem.Allocator, dir: std.Io.Dir) bool {
+    if (dir.statFile(io, "chat_template.jinja", .{})) |st| {
+        if (st.kind == .file) return true;
+    } else |_| {}
+    var f = dir.openFile(io, "tokenizer_config.json", .{}) catch return false;
+    defer f.close(io);
+    var rbuf: [4096]u8 = undefined;
+    var rs = f.reader(io, &rbuf);
+    const bytes = rs.interface.allocRemaining(allocator, .limited(8 * 1024 * 1024)) catch return false;
+    defer allocator.free(bytes);
+    return std.mem.indexOf(u8, bytes, "\"chat_template\"") != null;
+}
+
 fn lessThanById(_: void, a: DiscoveredModel, b: DiscoveredModel) bool {
     return std.mem.lessThan(u8, a.id, b.id);
 }
@@ -407,4 +506,59 @@ test "isSupportedQuantMode accepts nvfp4 (issue #24), rejects unknown" {
     try testing.expect(isSupportedQuantMode("mxfp4"));
     try testing.expect(isSupportedQuantMode("mxfp8"));
     try testing.expect(!isSupportedQuantMode("fp99"));
+}
+
+test "parseStubMeta extracts dims/ctx/quant/MoE + chat/vision capabilities" {
+    const a = testing.allocator;
+    // MoE chat model (Qwen3-Coder-30B-A3B shape), chat template present.
+    {
+        const json =
+            \\{"model_type":"qwen3_moe","vocab_size":151936,"hidden_size":2048,
+            \\"num_hidden_layers":48,"max_position_embeddings":262144,
+            \\"num_experts":128,"num_experts_per_tok":8,"quantization":{"bits":8,"group_size":64}}
+        ;
+        const m = parseStubMeta(a, json, true);
+        try testing.expect(m.found);
+        try testing.expectEqual(@as(u32, 151936), m.vocab_size);
+        try testing.expectEqual(@as(u32, 2048), m.hidden_size);
+        try testing.expectEqual(@as(u32, 48), m.num_hidden_layers);
+        try testing.expectEqual(@as(u32, 262144), m.max_position_embeddings);
+        try testing.expectEqual(@as(u32, 8), m.quant_bits);
+        try testing.expect(m.is_moe);
+        try testing.expect(m.has_chat); // template present, not encoder
+        try testing.expect(!m.has_vision);
+    }
+    // Dense model, no template → no chat caps; no quant block → 0 bits.
+    {
+        const json =
+            \\{"model_type":"qwen2","hidden_size":5120,"num_attention_heads":40,
+            \\"max_position_embeddings":32768}
+        ;
+        const m = parseStubMeta(a, json, false);
+        try testing.expect(m.found);
+        try testing.expect(!m.is_moe);
+        try testing.expect(!m.has_chat);
+        try testing.expectEqual(@as(u32, 0), m.quant_bits);
+        try testing.expectEqual(@as(u32, 32768), m.max_position_embeddings);
+    }
+    // Vision: vision_config on a non-_text arch → has_vision.
+    {
+        const m = parseStubMeta(a, "{\"model_type\":\"gemma4\",\"vision_config\":{\"hidden_size\":1152}}", true);
+        try testing.expect(m.has_vision);
+    }
+    // …but a `_text` arch with a vestigial vision_config must NOT report vision.
+    {
+        const m = parseStubMeta(a, "{\"model_type\":\"qwen3_5_moe_text\",\"vision_config\":{}}", true);
+        try testing.expect(!m.has_vision);
+    }
+    // Encoder (bert): chat/tool caps suppressed even with a template present.
+    {
+        const m = parseStubMeta(a, "{\"model_type\":\"bert\",\"hidden_size\":384}", true);
+        try testing.expect(!m.has_chat);
+    }
+    // Malformed → found=false.
+    {
+        const m = parseStubMeta(a, "not json", true);
+        try testing.expect(!m.found);
+    }
 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -16,6 +16,7 @@ const tokenize_cache_mod = @import("tokenize_cache.zig");
 const scheduler_mod = @import("scheduler.zig");
 const ds4_ffi = @import("ds4_ffi.zig");
 const model_registry_mod = @import("model_registry.zig");
+const model_discovery = @import("model_discovery.zig");
 const arch_llama = @import("arch/llama.zig");
 const stb = @cImport({ @cInclude("stb_image.h"); });
 const webp = @cImport({ @cInclude("webp/decode.h"); });
@@ -1343,21 +1344,76 @@ fn renderModelEntry(
         );
     } else &[_]u8{};
     defer if (err_part.len > 0) allocator.free(err_part);
-    // Arch-derived capabilities for stubs: encoder-only models advertise
-    // "embeddings" pre-load so clients (e.g. the app's document indexer)
-    // can pick a GPU embedder without forcing a cold load. Chat-derived
-    // caps stay load-gated (they need the chat template).
+    // Stub metadata sourced from config.json (+ chat-template presence) WITHOUT
+    // faulting in weights: dims, context window, MoE-ness, and capabilities.
+    // `/v1/models` isn't hot, so reading a small JSON per unloaded entry is fine.
+    const sm = model_discovery.readStubMeta(io, allocator, entry.path);
+
+    // Capabilities. Encoder-only models advertise "embeddings"; chat models get
+    // chat/tool_use/streaming/json_schema (gated on chat-template presence, the
+    // same rule the loaded path uses) plus "vision" when a vision config is
+    // present. Reasoning/audio stay load-gated (they need the live template /
+    // encoder), so an unloaded stub may under-report those two.
     const is_encoder_stub = std.mem.eql(u8, entry.arch_hint, "bert");
-    const caps_part: []const u8 = if (is_encoder_stub) ",\"capabilities\":[\"embeddings\"]" else "";
+    const caps_part: []const u8 = blk: {
+        if (is_encoder_stub) break :blk try allocator.dupe(u8, ",\"capabilities\":[\"embeddings\"]");
+        if (!sm.found or !(sm.has_chat or sm.has_vision)) break :blk try allocator.dupe(u8, "");
+        var b = std.ArrayList(u8).empty;
+        errdefer b.deinit(allocator);
+        try b.appendSlice(allocator, ",\"capabilities\":[");
+        var n: usize = 0;
+        const add = struct {
+            fn call(a: std.mem.Allocator, list: *std.ArrayList(u8), cnt: *usize, name: []const u8) !void {
+                if (cnt.* > 0) try list.append(a, ',');
+                try list.append(a, '"');
+                try list.appendSlice(a, name);
+                try list.append(a, '"');
+                cnt.* += 1;
+            }
+        }.call;
+        if (sm.has_chat) {
+            try add(allocator, &b, &n, "chat");
+            try add(allocator, &b, &n, "tool_use");
+            try add(allocator, &b, &n, "streaming");
+            try add(allocator, &b, &n, "json_schema");
+        }
+        if (sm.has_vision) try add(allocator, &b, &n, "vision");
+        try b.append(allocator, ']');
+        break :blk try b.toOwnedSlice(allocator);
+    };
+    defer allocator.free(caps_part);
+
+    const mods_part: []const u8 = if (sm.found and sm.has_vision)
+        ",\"input_modalities\":[\"text\",\"image\"]"
+    else if (sm.found and sm.has_chat)
+        ",\"input_modalities\":[\"text\"]"
+    else
+        "";
+
     const arch_part: []const u8 = if (entry.arch_hint.len > 0) blk: {
         // arch_hint comes from config.json's model_type via discovery — the
         // supported-type allowlist guarantees no JSON metacharacters.
         break :blk try std.fmt.allocPrint(allocator, "\"architecture\":\"{s}\",", .{entry.arch_hint});
     } else &[_]u8{};
     defer if (arch_part.len > 0) allocator.free(arch_part);
+
+    // Dimensions/context/quant/MoE — emitted only when config.json was readable.
+    const dims_part: []const u8 = if (sm.found) blk: {
+        break :blk try std.fmt.allocPrint(allocator, "\"vocab_size\":{d},\"hidden_size\":{d},\"num_layers\":{d},\"quantization\":\"{d}-bit\",\"context_length\":{d},\"model_max_tokens\":{d},\"is_moe\":{s},", .{
+            sm.vocab_size,
+            sm.hidden_size,
+            sm.num_hidden_layers,
+            sm.quant_bits,
+            sm.max_position_embeddings,
+            sm.max_position_embeddings,
+            if (sm.is_moe) "true" else "false",
+        });
+    } else &[_]u8{};
+    defer if (dims_part.len > 0) allocator.free(dims_part);
+
     return std.fmt.allocPrint(allocator,
-        \\{{"id":"{s}","object":"model","created":0,"owned_by":"mlx-serve","loaded":false,"state":"{s}","bytes_resident":0,"bytes_on_disk":{s}{s}{s},"meta":{{{s}"bytes_on_disk":{s}}}}}
-    , .{ entry.id, state_str, bytes_on_disk_str, err_part, caps_part, arch_part, bytes_on_disk_str });
+        \\{{"id":"{s}","object":"model","created":0,"owned_by":"mlx-serve","loaded":false,"state":"{s}","bytes_resident":0,"bytes_on_disk":{s}{s}{s}{s},"meta":{{{s}{s}"bytes_on_disk":{s}}}}}
+    , .{ entry.id, state_str, bytes_on_disk_str, err_part, caps_part, mods_part, arch_part, dims_part, bytes_on_disk_str });
 }
 
 fn handleModels(


### PR DESCRIPTION
Fixes #37.

`/v1/models` returned only `id`/`state`/`bytes_on_disk`/`architecture` for unloaded (stub) entries — context window, dimensions, MoE flag, and capabilities only appeared once a model was loaded (the renderer read them off the resident config). Clients (and the Zed model-sync helper) therefore couldn't see a model's real context window or tool support until it was faulted into memory.

All of that lives in `config.json` (+ chat-template presence) and is cheap to read without loading weights — discovery already opens `config.json` for `model_type`.

## Changes
- `model_discovery.parseStubMeta` (pure, unit-tested) + `readStubMeta` (thin I/O wrapper): extract vocab/hidden/layers, `max_position_embeddings`, quant bits, MoE-ness (`num_experts`/`num_local_experts`/`n_routed_experts`), vision (`vision_config` on a non-`_text` arch), and chat-template presence (`chat_template.jinja` or a `chat_template` key in `tokenizer_config.json`).
- `server.renderModelEntry` stub branch now emits dims, `context_length` + `model_max_tokens`, `is_moe`, `quantization`, and capabilities — `chat`/`tool_use`/`streaming`/`json_schema` (gated on a chat template, the same rule the loaded path uses) plus `vision` + image modality.

`/v1/models` isn't a hot path, so reading a small JSON per unloaded entry is negligible. Reasoning/audio remain load-gated (they need the live template/encoder), so a stub may under-report those two; everything else now matches the loaded entry. Unloaded `context_length` reports the model's max (`max_position_embeddings`) since the memory-bounded effective window isn't known until load.

## Testing
- New `parseStubMeta` unit tests (dims/ctx/quant/MoE extraction; chat gated on template + suppressed for `bert`; vision gated on non-`_text`; malformed → `found=false`). Full `zig build test` green.
- **Live**: `--model-dir` with one model loaded — the unloaded sibling now reports `caps=[chat,tool_use,streaming,json_schema]`, `ctx`, `is_moe`, `quant`, and dims (previously all null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)