### PR TITLE
Fix GPU-memory oversubscription crash on concurrent model switch

### DIFF
--- a/src/model_registry.zig
+++ b/src/model_registry.zig
@@ -205,6 +205,11 @@ pub const LoadedModel = struct {
     /// Resident GPU bytes for this entry (weights + vision + drafter),
     /// summed at load time. Zero for non-`.ready` entries.
     bytes_resident: u64,
+    /// Estimated bytes reserved against `ModelRegistry.reserved_bytes` while
+    /// this entry is mid-load (`.loading`). Lets concurrent loaders see this
+    /// pending allocation in the budget gate so two loads can't both pass and
+    /// oversubscribe GPU memory. Released (zeroed) at markReady/Error/Unloaded.
+    load_estimate: u64 = 0,
     state: LoadState,
     /// Allocator-owned error name when state == .error_state. Echoed in
     /// the `/v1/models` snapshot so clients can see why a load failed
@@ -421,6 +426,12 @@ pub const ModelRegistry = struct {
     /// Running sum of `bytes_resident` across `.ready` entries. Updated
     /// under `mutex` on every state transition.
     current_resident_bytes: u64,
+    /// Sum of `load_estimate` across entries that are mid-load (`.loading`).
+    /// Counted alongside `current_resident_bytes` in the eviction gate so an
+    /// in-flight load is visible to a concurrent loader — without this, two
+    /// loads can both read a stale (pre-commit) resident total, both skip
+    /// eviction, and oversubscribe GPU memory (→ Metal OOM crash).
+    reserved_bytes: u64,
     /// Monotonic counter feeding `LoadedModel.last_used_ns`. We avoid
     /// reading the wall clock under the mutex; ordering is all the LRU
     /// pick needs.
@@ -456,6 +467,7 @@ pub const ModelRegistry = struct {
             .mutex = .init,
             .state_cond = .init,
             .current_resident_bytes = 0,
+            .reserved_bytes = 0,
             .lru_clock = 0,
         };
 
@@ -676,6 +688,7 @@ pub const ModelRegistry = struct {
     /// fields should already be cleaned up (or never installed) before
     /// calling.
     pub fn markUnloadedLocked(self: *ModelRegistry, entry: *LoadedModel) void {
+        self.releaseReservationLocked(entry);
         entry.state = .unloaded;
         entry.bytes_resident = 0;
         if (entry.error_name) |old| self.allocator.free(old);
@@ -780,6 +793,7 @@ pub const ModelRegistry = struct {
     /// populated weights/transformer/etc on `entry`; this just updates
     /// the bookkeeping + state field.
     pub fn markReadyLocked(self: *ModelRegistry, entry: *LoadedModel, bytes_resident: u64) void {
+        self.releaseReservationLocked(entry); // pending estimate → actual residency
         entry.bytes_resident = bytes_resident;
         entry.state = .ready;
         entry.error_name = null;
@@ -789,10 +803,80 @@ pub const ModelRegistry = struct {
         self.state_cond.broadcast(self.io);
     }
 
+    /// Reserve `estimated` bytes against `reserved_bytes` for an entry that has
+    /// just claimed `.loading`. Counted in the eviction gate so concurrent
+    /// loads see this pending allocation. Released by markReady/Error/Unloaded.
+    /// Caller holds `mutex`.
+    pub fn reserveLoadLocked(self: *ModelRegistry, entry: *LoadedModel, estimated: u64) void {
+        // Release any stale prior reservation first (defensive; should be 0).
+        self.releaseReservationLocked(entry);
+        entry.load_estimate = estimated;
+        self.reserved_bytes += estimated;
+    }
+
+    /// Drop an entry's in-flight load reservation (no-op if it never reserved).
+    /// Caller holds `mutex`.
+    fn releaseReservationLocked(self: *ModelRegistry, entry: *LoadedModel) void {
+        if (entry.load_estimate == 0) return;
+        if (self.reserved_bytes >= entry.load_estimate) {
+            self.reserved_bytes -= entry.load_estimate;
+        } else {
+            self.reserved_bytes = 0;
+        }
+        entry.load_estimate = 0;
+    }
+
+    /// Undo a `markEvictingLocked` — return a victim that was selected for
+    /// eviction back to `.ready` (used when an eviction PLAN can't be fully
+    /// satisfied and must roll back). Caller holds `mutex`.
+    pub fn unmarkEvictingLocked(self: *ModelRegistry, entry: *LoadedModel) void {
+        std.debug.assert(entry.state == .evicting);
+        entry.state = .ready;
+        self.state_cond.broadcast(self.io);
+    }
+
+    /// Select LRU victims to evict so that, once `entry` (already `.loading`,
+    /// with its estimate reserved) becomes resident, both caps hold. Marks each
+    /// chosen victim `.evicting` and writes it into `out`; returns the count,
+    /// or null if the caps can't be met (no more evictable victims, or `out`
+    /// too small) — in which case any victims marked here are rolled back so
+    /// the registry is left untouched. Caller holds `mutex` and must drain each
+    /// returned victim's refcount, then hand them to the load request to free.
+    pub fn planEvictionsLocked(self: *ModelRegistry, exclude_id: []const u8, out: []*LoadedModel) ?usize {
+        var n: usize = 0;
+        var freed: u64 = 0;
+        while (true) {
+            // Resident-after-plan = current minus what these victims free, plus
+            // every in-flight reservation (including this load's own estimate).
+            const projected_mem = (self.current_resident_bytes -| freed) + self.reserved_bytes;
+            // Count: .ready+.evicting now, minus the victims we'll drop, plus
+            // this load (currently `.loading`, becomes resident).
+            const projected_count = self.countLoadedLocked() - @as(u32, @intCast(n)) + 1;
+            const mem_ok = self.max_resident_mem == 0 or projected_mem <= self.max_resident_mem;
+            const count_ok = projected_count <= self.max_resident_models;
+            if (mem_ok and count_ok) return n;
+
+            const victim = self.pickLruEvictable(exclude_id) orelse {
+                // Can't satisfy the caps — roll back every marking we made.
+                for (out[0..n]) |v| self.unmarkEvictingLocked(v);
+                return null;
+            };
+            if (n >= out.len) {
+                for (out[0..n]) |v| self.unmarkEvictingLocked(v);
+                return null;
+            }
+            self.markEvictingLocked(victim); // now `.evicting` → pickLru won't repick
+            freed += victim.bytes_resident;
+            out[n] = victim;
+            n += 1;
+        }
+    }
+
     /// Mark an entry as `.error_state` and store `error_name` (duped).
     /// Future `ensureLoaded` calls fail with `error.LoadFailed` until the
     /// entry is reset to `.unloaded` (Phase D may add a retry path).
     pub fn markErrorLocked(self: *ModelRegistry, entry: *LoadedModel, error_name: []const u8) void {
+        self.releaseReservationLocked(entry);
         if (entry.error_name) |old| self.allocator.free(old);
         entry.error_name = self.allocator.dupe(u8, error_name) catch null;
         entry.state = .error_state;
@@ -1079,4 +1163,111 @@ test "ModelRegistry: peek does not refcount" {
     try testing.expectEqual(lm, peeked);
     try testing.expectEqual(@as(u32, 0), lm.refcount.load(.acquire));
     try testing.expectEqual(@as(?*LoadedModel, null), reg.peek("nope"));
+}
+
+// ── Eviction planner + reservation accounting (oversubscription fix) ──
+//
+// These pin the invariant that prevented the Metal-OOM crash: a cold load
+// reserves its estimate so a concurrent load sees the pending allocation, and
+// the planner evicts enough LRU victims to fit (multi-victim) or fails cleanly
+// (→ 503) rather than loading anyway and oversubscribing GPU memory.
+
+/// Claim `.loading` + reserve `estimate` for a fresh stub, the way the
+/// scheduler's ensureLoaded slow path does. Returns the loading entry.
+fn beginLoad(reg: *ModelRegistry, id: []const u8, estimate: u64) !*LoadedModel {
+    const stub = try reg.registerStub(id, id, estimate);
+    reg.mutex.lockUncancelable(reg.io);
+    defer reg.mutex.unlock(reg.io);
+    try testing.expect(reg.tryBeginLoadLocked(stub));
+    reg.reserveLoadLocked(stub, estimate);
+    return stub;
+}
+
+test "planEvictions: evicts one LRU victim to fit the memory budget" {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var reg = try ModelRegistry.init(testing.allocator, io, null, 10, 100, null);
+    defer reg.deinit();
+    _ = try makeReadyStub(reg, "a", 40); // oldest
+    _ = try makeReadyStub(reg, "b", 40);
+    try testing.expectEqual(@as(u64, 80), reg.current_resident_bytes);
+
+    const c = try beginLoad(reg, "c", 40); // 80 + 40 = 120 > 100 → must evict
+    try testing.expectEqual(@as(u64, 40), reg.reserved_bytes);
+
+    reg.mutex.lockUncancelable(io);
+    defer reg.mutex.unlock(io);
+    var buf: [16]*LoadedModel = undefined;
+    const n = reg.planEvictionsLocked(c.id, &buf).?;
+    try testing.expectEqual(@as(usize, 1), n);
+    try testing.expectEqualStrings("a", buf[0].id); // LRU victim
+    try testing.expectEqual(LoadState.evicting, buf[0].state);
+}
+
+test "planEvictions: multi-victim — evicts as many as needed to fit" {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var reg = try ModelRegistry.init(testing.allocator, io, null, 10, 100, null);
+    defer reg.deinit();
+    _ = try makeReadyStub(reg, "a", 40);
+    _ = try makeReadyStub(reg, "b", 40);
+    _ = try makeReadyStub(reg, "c", 40); // current = 120 (budget shrank under us)
+
+    const d = try beginLoad(reg, "d", 40); // need to free 2×40 to fit 40 in 100
+    reg.mutex.lockUncancelable(io);
+    defer reg.mutex.unlock(io);
+    var buf: [16]*LoadedModel = undefined;
+    const n = reg.planEvictionsLocked(d.id, &buf).?;
+    try testing.expectEqual(@as(usize, 2), n); // a and b (the two oldest)
+}
+
+test "planEvictions: returns null and rolls back when every victim is pinned" {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var reg = try ModelRegistry.init(testing.allocator, io, null, 10, 100, null);
+    defer reg.deinit();
+    const a = try makeReadyStub(reg, "a", 80);
+    _ = a.refcount.fetchAdd(1, .acq_rel); // pinned by an in-flight request
+
+    const b = try beginLoad(reg, "b", 80); // 80 + 80 = 160 > 100 → must evict a
+    reg.mutex.lockUncancelable(io);
+    var buf: [16]*LoadedModel = undefined;
+    const plan = reg.planEvictionsLocked(b.id, &buf);
+    try testing.expectEqual(@as(?usize, null), plan); // can't evict the pinned victim
+    try testing.expectEqual(LoadState.ready, a.state); // rolled back, not left .evicting
+    // Scheduler then rolls back the load → releases the reservation.
+    reg.markUnloadedLocked(b);
+    reg.mutex.unlock(io);
+    try testing.expectEqual(@as(u64, 0), reg.reserved_bytes);
+    a.refcount.store(0, .release);
+}
+
+test "reservation: concurrent in-flight load is visible in the budget gate" {
+    // The crash's core: load #2's gate must SEE load #1's pending bytes, even
+    // though #1 hasn't reached markReady. With both reserved, the gate trips.
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var reg = try ModelRegistry.init(testing.allocator, io, null, 10, 100, null);
+    defer reg.deinit();
+    _ = try beginLoad(reg, "a", 60); // in-flight, not yet ready: reserved=60
+    _ = try beginLoad(reg, "b", 60); // in-flight too: reserved=120
+    try testing.expectEqual(@as(u64, 120), reg.reserved_bytes);
+    try testing.expectEqual(@as(u64, 0), reg.current_resident_bytes);
+    // A third load sees reserved=120 (+its own) → over the 100 budget, and with
+    // no `.ready` victim to evict, the plan fails (→ 503) instead of loading.
+    const c = try beginLoad(reg, "c", 60);
+    reg.mutex.lockUncancelable(io);
+    defer reg.mutex.unlock(io);
+    var buf: [16]*LoadedModel = undefined;
+    try testing.expectEqual(@as(?usize, null), reg.planEvictionsLocked(c.id, &buf));
+}
+
+test "reservation: released back to zero on markReady / markUnloaded" {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    var reg = try ModelRegistry.init(testing.allocator, io, null, 10, 0, null);
+    defer reg.deinit();
+    const a = try beginLoad(reg, "a", 500);
+    try testing.expectEqual(@as(u64, 500), reg.reserved_bytes);
+    reg.mutex.lockUncancelable(io);
+    reg.markReadyLocked(a, 480); // actual differs from estimate
+    reg.mutex.unlock(io);
+    try testing.expectEqual(@as(u64, 0), reg.reserved_bytes); // reservation cleared
+    try testing.expectEqual(@as(u64, 480), reg.current_resident_bytes); // actual counted
+    try testing.expectEqual(@as(u64, 0), a.load_estimate);
 }

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -772,15 +772,13 @@ pub const LoadRequest = struct {
     llama_kv_type_k: i32 = 0,
     llama_kv_type_v: i32 = 0,
 
-    /// Optional victim to evict before the load. Already marked `.evicting`
-    /// with refcount == 0 by the conn thread under registry.mutex. The
-    /// inference thread calls `entry.unloadResident()` to free GPU memory
-    /// AND drops the resident-bytes accounting via `registry.accountEvictedLocked`,
-    /// then `registry.finalizeEvictionLocked`.
-    evict_entry: ?*LoadedModel = null,
-    /// Bytes accounted to the victim before eviction (so the inference
-    /// thread can subtract from `current_resident_bytes`).
-    evict_bytes: u64 = 0,
+    /// Victims to evict before the load (LRU-selected by the planner). Each is
+    /// already marked `.evicting` with refcount == 0 by the conn thread under
+    /// registry.mutex. The inference thread calls `unloadResident()` on each to
+    /// free GPU memory, drops its resident-bytes accounting via
+    /// `registry.accountEvictedLocked`, then `registry.finalizeEvictionLocked`.
+    /// Borrows the conn thread's stack buffer; valid until `done`.
+    evict_entries: []*LoadedModel = &.{},
 
     /// Output: error name on failure (owned by `allocator`; conn thread
     /// frees). Null on success.
@@ -1238,8 +1236,11 @@ pub const Scheduler = struct {
         var owned_active: bool = true;
         defer if (owned_active) freeCpuState(self.allocator, &owned);
 
-        var evict_entry: ?*LoadedModel = null;
-        var evict_bytes: u64 = 0;
+        // Victims selected by the eviction planner (multi-victim: one load may
+        // need to free several models to fit). Lives on this stack frame; the
+        // slice handed to the LoadRequest stays valid while we block on `done`.
+        var victims_buf: [16]*LoadedModel = undefined;
+        var n_victims: usize = 0;
 
         // ── Stage 1 (registry mutex): claim .loading, plan eviction.
         {
@@ -1281,26 +1282,25 @@ pub const Scheduler = struct {
                 break :blk base + base / 10;
             };
 
-            // Eviction loop: drop LRU victims until under both caps.
-            // Plan 05 limits to ONE victim per load for now (matches the
-            // "block-until-loaded" UX); multi-victim is a future enhancement.
-            const loaded_count = self.registry.countLoadedLocked();
-            const need_count_evict = loaded_count + 1 > self.registry.max_resident_models;
-            const need_mem_evict =
-                self.registry.max_resident_mem > 0 and
-                self.registry.current_resident_bytes + estimated > self.registry.max_resident_mem;
-            if (need_count_evict or need_mem_evict) {
-                evict_entry = self.registry.pickLruEvictable(entry.id);
-                if (evict_entry == null) {
-                    // Roll back .loading and return — caller surfaces 503.
-                    self.registry.markUnloadedLocked(entry);
-                    self.registry.mutex.unlock(self.io);
-                    return error.NotEnoughMemory;
-                }
-                evict_bytes = evict_entry.?.bytes_resident;
-                self.registry.markEvictingLocked(evict_entry.?);
-                self.registry.waitForRefcountZeroLocked(evict_entry.?);
-            }
+            // Reserve this load's estimate BEFORE planning eviction, so a
+            // concurrent loader sees the pending allocation in its own gate.
+            // Without this, two loads can both read a stale resident total
+            // (one's bytes not yet committed at markReady), both skip eviction,
+            // and oversubscribe GPU memory → Metal OOM → process crash.
+            self.registry.reserveLoadLocked(entry, estimated);
+
+            // Evict LRU victims until both caps hold for this reservation
+            // (multi-victim). On failure — every other resident model is pinned
+            // by an in-flight request — roll back and surface a 503 instead of
+            // loading anyway and crashing.
+            const n = self.registry.planEvictionsLocked(entry.id, &victims_buf) orelse {
+                self.registry.markUnloadedLocked(entry); // releases the reservation
+                self.registry.mutex.unlock(self.io);
+                return error.NotEnoughMemory;
+            };
+            n_victims = n;
+            // Drain readers on each victim before the inference thread frees it.
+            for (victims_buf[0..n_victims]) |v| self.registry.waitForRefcountZeroLocked(v);
             self.registry.mutex.unlock(self.io);
         }
 
@@ -1319,8 +1319,7 @@ pub const Scheduler = struct {
             .kv_quant_config = self.kv_quant_config,
             .prefix_cache_capacity = 1,
             .prefix_cache_mem_bytes = 0,
-            .evict_entry = evict_entry,
-            .evict_bytes = evict_bytes,
+            .evict_entries = victims_buf[0..n_victims],
             .allocator = self.allocator,
         };
 
@@ -2360,16 +2359,18 @@ fn finishEmbedRequest(sch: *Scheduler, req: *EmbedRequest, err_name: []const u8)
 /// thread wakes. On failure, mark `.error_state` so future ensureLoaded
 /// calls fail fast; the conn thread surfaces a 500.
 fn runLoadRequest(sch: *Scheduler, req: *LoadRequest) void {
-    // Step 1: evict victim if requested. unloadResident() drops
+    // Step 1: evict victims (if any) BEFORE the load, so peak GPU residency
+    // never holds the old + new model at once. unloadResident() drops
     // mlx_arrays — same thread-stream invariant as cleanup_queue drain.
-    if (req.evict_entry) |victim| {
+    for (req.evict_entries) |victim| {
+        const victim_bytes = victim.bytes_resident; // unloadResident zeroes it
         log.info("[registry] evicting model id={s} ({d:.2} GB resident)\n", .{
             victim.id,
-            @as(f64, @floatFromInt(victim.bytes_resident)) / 1_073_741_824.0,
+            @as(f64, @floatFromInt(victim_bytes)) / 1_073_741_824.0,
         });
         victim.unloadResident();
         sch.registry.mutex.lockUncancelable(sch.io);
-        sch.registry.accountEvictedLocked(req.evict_bytes);
+        sch.registry.accountEvictedLocked(victim_bytes);
         sch.registry.finalizeEvictionLocked(victim);
         sch.registry.mutex.unlock(sch.io);
     }


### PR DESCRIPTION
Fixes #40.

A model switch under concurrency could crash the whole server with an uncaught Metal OOM (`kIOGPUCommandBufferCallbackErrorOutOfMemory` → `std::terminate`).

## Root cause
The resident-memory budget gate in `scheduler.ensureLoaded` counted only `registry.current_resident_bytes`, updated at `markReadyLocked` — an **in-flight load reserved nothing**. Two loads for two models could each read a stale (pre-commit) resident total, both skip eviction, and load both models at once (e.g. 74 GB against a 62 GB budget) → GPU OOM. The exception crosses the C ABI from MLX, so it can't be caught — prevention is the only fix. (Compounded by a weights-only estimate and single-victim eviction.)

## Fix
- **Reserve in-flight bytes.** A load reserves its estimate (`reserved_bytes` / per-entry `load_estimate`) when it claims `.loading`; released at markReady/markError/markUnloaded. The gate now counts `current_resident_bytes + reserved_bytes`, so a concurrent loader sees the pending allocation and evicts (or 503s) instead of oversubscribing.
- **Evict-to-fit (multi-victim).** Replaced the single-victim eviction with `registry.planEvictionsLocked`, which drops as many LRU victims as needed to satisfy both caps, marks them `.evicting`, and rolls back cleanly (→ `error.NotEnoughMemory` → 503) when every other resident model is pinned. `LoadRequest` carries the victim list; the inference thread evicts all before loading (peak never holds old + new).

## Testing
- New registry unit tests: single-victim fit, multi-victim fit, null+rollback when all victims pinned, **concurrent in-flight reservation visible in the gate** (the crash's core invariant), and reservation release on markReady/markUnloaded. Full `zig build test` green.
- **Live**: `--model-dir` with two large models, one-model budget — concurrent requests for both yield one 200 + one graceful 503 with the **server staying up** (no Metal OOM); sequential switches all 200 with evictions logged. Before the fix this exact contention crashed.

Note: the per-request auto-ctx already bounds KV-cache growth at generation time; this PR fixes the weight-load oversubscription that caused the crash. Folding KV headroom into the load estimate is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)