### PR TITLE
Handle GPU OOM at model load gracefully (pre-flight + legible error)

### DIFF
--- a/app/Sources/MLXServe/Services/ServerManager.swift
+++ b/app/Sources/MLXServe/Services/ServerManager.swift
@@ -172,6 +172,43 @@ class ServerManager: ObservableObject {
         }
     }
 
+    /// Distill a crashed server's stderr tail into one human-meaningful line for
+    /// the menu-bar error. A blind `suffix(N)` lands mid-native-backtrace (e.g.
+    /// "…wqthread + 8") and buries the real cause; this surfaces the actual fatal
+    /// line — GPU OOM, our own pre-flight refusal, or a recognized error
+    /// signature — falling back to the last non-empty line. Pure + testable.
+    nonisolated static func summarizeCrash(_ log: String, exitCode: Int32) -> String {
+        let trimmed = log.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return "exit code \(exitCode)" }
+        let lines = trimmed.split(whereSeparator: \.isNewline).map(String.init)
+
+        // Our own pre-flight already emits a clean, actionable line — prefer it.
+        if let l = lines.last(where: { $0.contains("Insufficient memory to load model") }) {
+            return l
+        }
+        // A Metal GPU out-of-memory crash → friendly, actionable message. Match
+        // the Metal/IOGPU marker specifically so we don't catch unrelated lines
+        // that merely contain "insufficient memory".
+        if lines.contains(where: {
+            $0.contains("kIOGPUCommandBufferCallbackErrorOutOfMemory")
+                || ($0.contains("[METAL]") && $0.localizedCaseInsensitiveContains("Insufficient Memory"))
+        }) {
+            return "Out of GPU memory while loading the model — free memory (close other models/apps) and try again."
+        }
+        // Otherwise surface the most meaningful fatal line, scanning from the end.
+        let needles = ["terminating due to", "MLX error", "MISSING WEIGHT", "[fatal]", "panic", "error:"]
+        for line in lines.reversed() {
+            if needles.contains(where: { line.localizedCaseInsensitiveContains($0) }) {
+                // Strip the C++ "...uncaught exception of type T: " preamble.
+                if let r = line.range(of: "std::runtime_error: ") {
+                    return String(line[r.upperBound...])
+                }
+                return line
+            }
+        }
+        return lines.last ?? "exit code \(exitCode)"
+    }
+
     private func handleTermination(exitCode: Int32) {
         pollSource?.cancel()
         pollSource = nil
@@ -187,7 +224,7 @@ class ServerManager: ObservableObject {
         // made it to @Published.
         let errSnippet = currentServerLogSnapshot()
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let shortErr = errSnippet.isEmpty ? "exit code \(exitCode)" : String(errSnippet.suffix(200))
+        let shortErr = Self.summarizeCrash(errSnippet, exitCode: exitCode)
         let fullLog = errSnippet.isEmpty ? "(no stderr captured — exit code \(exitCode))" : errSnippet
 
         if case .running = status {

--- a/app/Tests/MLXCoreTests/ServerLogBufferTests.swift
+++ b/app/Tests/MLXCoreTests/ServerLogBufferTests.swift
@@ -178,4 +178,44 @@ final class ServerLogBufferTests: XCTestCase {
         XCTAssertEqual(calls, callsAtStop,
                        "Stopped poller must not invoke its snapshot closure")
     }
+
+    // MARK: - Crash summary (menu-bar error text)
+    //
+    // The menu bar used to show `String(stderr.suffix(200))`, which on a crash
+    // lands mid-native-backtrace ("…wqthread + 8") and hides the real cause.
+    // `summarizeCrash` extracts the meaningful line instead.
+
+    func testSummarizeCrashSurfacesGpuOOM() {
+        let log = """
+        MoE routing compiled (kernel fusion enabled)
+        GDN gate compiled (kernel fusion enabled)
+        25  libsystem_pthread.dylib  0x0000  start_wqthread + 8
+        libc++abi: terminating due to uncaught exception of type std::runtime_error: [METAL] Command buffer execution failed: Insufficient Memory (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory)
+        """
+        let msg = ServerManager.summarizeCrash(log, exitCode: 134)
+        XCTAssertTrue(msg.localizedCaseInsensitiveContains("GPU memory"), "got: \(msg)")
+        XCTAssertFalse(msg.contains("wqthread"), "must not surface a backtrace frame: \(msg)")
+    }
+
+    func testSummarizeCrashSurfacesPreflightRefusal() {
+        let log = "Loading...\nInsufficient memory to load model: weights ~41.8 GB but only 12.0 GB free. Close other models/apps..."
+        let msg = ServerManager.summarizeCrash(log, exitCode: 1)
+        XCTAssertTrue(msg.hasPrefix("Insufficient memory to load model"), "got: \(msg)")
+    }
+
+    func testSummarizeCrashStripsCppPreambleForGenericFatal() {
+        let log = "boot\nlibc++abi: terminating due to uncaught exception of type std::runtime_error: something specific went wrong"
+        let msg = ServerManager.summarizeCrash(log, exitCode: 134)
+        XCTAssertEqual(msg, "something specific went wrong")
+    }
+
+    func testSummarizeCrashMissingWeight() {
+        let log = "Loading model.safetensors...\nMISSING WEIGHT: model.layers.0.foo.weight"
+        let msg = ServerManager.summarizeCrash(log, exitCode: 1)
+        XCTAssertTrue(msg.contains("MISSING WEIGHT"), "got: \(msg)")
+    }
+
+    func testSummarizeCrashEmptyFallsBackToExitCode() {
+        XCTAssertEqual(ServerManager.summarizeCrash("   \n  ", exitCode: 9), "exit code 9")
+    }
 }

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -49,6 +49,7 @@ const arch_ds4 = @import("arch/ds4.zig");
 const arch_llama = @import("arch/llama.zig");
 const log = @import("log.zig");
 const io_util = @import("io_util.zig");
+const status = @import("status.zig");
 
 const Transformer = transformer_mod.Transformer;
 const KVCache = transformer_mod.KVCache;
@@ -1690,6 +1691,46 @@ fn doLoadLlamaOnInferenceThread(sch: *Scheduler, params: anytype) !void {
     sch.hot_prefix_cache = null;
 }
 
+/// Sum of `*.safetensors` bytes in `model_dir` — the MLX weight footprint used
+/// by the load pre-flight. Returns 0 if the dir can't be read (treated as
+/// "unknown" by the caller, which then skips the check).
+fn modelDiskBytes(io: std.Io, model_dir: []const u8) u64 {
+    var dir = std.Io.Dir.openDirAbsolute(io, model_dir, .{ .iterate = true }) catch return 0;
+    defer dir.close(io);
+    var it = dir.iterate();
+    var total: u64 = 0;
+    while (it.next(io) catch null) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".safetensors")) continue;
+        const st = dir.statFile(io, entry.name, .{}) catch continue;
+        total += @intCast(st.size);
+    }
+    return total;
+}
+
+/// Pure: would loading `weights_bytes` of model with `avail_bytes` free RAM risk
+/// a Metal OOM? Requires the weights plus ~1/7 (≈15%) + 1 GB headroom for the
+/// warmup KV cache + compute buffers. Returns false (allow the load) when either
+/// figure is 0 — a failed memory query must never block a load.
+fn memInsufficientForLoad(weights_bytes: u64, avail_bytes: u64) bool {
+    if (weights_bytes == 0 or avail_bytes == 0) return false;
+    const headroom: u64 = weights_bytes / 7 + 1024 * 1024 * 1024;
+    return avail_bytes < weights_bytes + headroom;
+}
+
+test "memInsufficientForLoad: headroom + unknown-query guards" {
+    const GB: u64 = 1024 * 1024 * 1024;
+    // Restart-into-pressure: 42 GB weights, only 44 GB free → needs ~49, refuse.
+    try std.testing.expect(memInsufficientForLoad(42 * GB, 44 * GB));
+    // Plenty of headroom → allow.
+    try std.testing.expect(!memInsufficientForLoad(42 * GB, 86 * GB));
+    // Exactly weights, no headroom → refuse.
+    try std.testing.expect(memInsufficientForLoad(42 * GB, 42 * GB));
+    // Unknown figures (query failed / size unknown) → never block.
+    try std.testing.expect(!memInsufficientForLoad(0, 44 * GB));
+    try std.testing.expect(!memInsufficientForLoad(42 * GB, 0));
+}
+
 /// Phase A1 → Plan 05: do the full model load on the inference thread.
 /// mlx ops here bind to this thread's GPU stream from t0; subsequent
 /// forwards stay on the same thread.
@@ -1731,6 +1772,25 @@ fn doLoadOnInferenceThread(sch: *Scheduler, params: anytype) !void {
     if (@hasField(Inner, "llama_path") and params.llama_path.len > 0) {
         try doLoadLlamaOnInferenceThread(sch, params);
         return;
+    }
+
+    // GPU-memory pre-flight (MLX path). A Metal OOM during weight load / warmup
+    // is thrown by MLX as a C++ exception that can't be caught across the C ABI,
+    // so it terminates the whole process. Refuse the load up front instead, with
+    // an actionable error, when free RAM clearly can't hold the weights + warmup
+    // headroom — catches the common "restarted before the prior server released
+    // its memory" case. Bypass with MLX_SERVE_SKIP_MEM_PREFLIGHT=1.
+    if (std.c.getenv("MLX_SERVE_SKIP_MEM_PREFLIGHT") == null) {
+        const weights_bytes = modelDiskBytes(sch.io, params.model_dir);
+        const avail_bytes = status.getAvailableMemBytes();
+        if (memInsufficientForLoad(weights_bytes, avail_bytes)) {
+            const gb = 1024.0 * 1024.0 * 1024.0;
+            log.err("Insufficient memory to load model: weights ~{d:.1} GB but only {d:.1} GB free. Close other models/apps (or wait for a prior mlx-serve to fully exit) and retry; set MLX_SERVE_SKIP_MEM_PREFLIGHT=1 to override.\n", .{
+                @as(f64, @floatFromInt(weights_bytes)) / gb,
+                @as(f64, @floatFromInt(avail_bytes)) / gb,
+            });
+            return error.InsufficientMemory;
+        }
     }
 
     // Allocate the drafter_path dupe up front so the post-publish step

--- a/src/status.zig
+++ b/src/status.zig
@@ -79,6 +79,27 @@ pub fn getAppRssMb() u32 {
     return @intCast(info.resident_size / (1024 * 1024));
 }
 
+/// Bytes of physical memory available for new allocation without heavy
+/// swapping: total minus the resident-and-non-reclaimable set (active + wired +
+/// compressed). Free/inactive/speculative/purgeable pages count as available.
+/// Returns 0 if the query fails (callers treat 0 as "unknown — don't block").
+pub fn getAvailableMemBytes() u64 {
+    var total_mem: u64 = 0;
+    var len: usize = @sizeOf(u64);
+    if (sysctlbyname("hw.memsize", @ptrCast(&total_mem), &len, null, 0) != 0) return 0;
+
+    var page: usize = 0;
+    if (host_page_size(mach_host_self(), &page) != 0) return 0;
+
+    var vm = std.mem.zeroes(VmStats64);
+    var count: u32 = @sizeOf(VmStats64) / @sizeOf(i32);
+    if (host_statistics64(mach_host_self(), 4, @ptrCast(&vm), &count) != 0) return 0;
+
+    const used: u64 = (@as(u64, vm.active_count) + vm.wire_count + vm.compressor_page_count) * page;
+    if (total_mem == 0 or used >= total_mem) return 0;
+    return total_mem - used;
+}
+
 pub fn getSysMemPct() u32 {
     var total_mem: u64 = 0;
     var len: usize = @sizeOf(u64);


### PR DESCRIPTION
Fixes #44.

A Metal OOM during weight load / warmup is thrown by MLX as a C++ exception that can't be caught across the C ABI, so it terminates the whole server. It happens when free RAM is too low for the model — most often when restarting before a prior mlx-serve has released its weights, leaving the new process to load + warm up into a depleted pool. Separately, the app's menu-bar error showed a useless backtrace fragment (`ead + 8…`) rather than the cause.

## Changes
**Server (Zig):** GPU-memory pre-flight before the MLX weight load (`doLoadOnInferenceThread`, covering both startup and on-demand loads). If free physical RAM clearly can't hold the weights + warmup headroom (`weights + weights/7 + 1 GB`), refuse with `error.InsufficientMemory` and an actionable log line instead of crashing in warmup. Bypass with `MLX_SERVE_SKIP_MEM_PREFLIGHT=1`.
- Free RAM via a new `status.getAvailableMemBytes()` (total − active − wired − compressed, reusing the existing mach machinery).
- The threshold decision `memInsufficientForLoad` is pure and unit-tested (refuses 42 GB-into-44 GB; allows 42-into-86; never blocks on a 0/unknown query).
- ds4 / llama.cpp paths are unaffected (they return before the check).

**App (Swift):** `ServerManager.summarizeCrash` replaces `String(stderr.suffix(200))` for the menu-bar error. It surfaces the meaningful line — GPU OOM → "Out of GPU memory…", the pre-flight refusal verbatim, or a recognized fatal signature (stripping the C++ `uncaught exception of type T:` preamble) — falling back to the last non-empty line. Unit-tested against the real crash tail.

## Testing
- New unit tests: `memInsufficientForLoad` (Zig), `summarizeCrash` (Swift, incl. the actual OOM backtrace, pre-flight refusal, MISSING WEIGHT, empty→exit-code).
- Live: a normal 42 GB load with ample free RAM is **not** blocked (no false-positive); it loads and serves.
- Full `zig build test` + `swift test` green.

The Metal OOM exception itself can't be caught across the C ABI, so this is prevention (refuse early) + legibility (clear error) rather than recovery.