### PR TITLE
Fix double-free SIGSEGV on the GPU-OOM pre-flight refusal path (#45/#47)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -545,7 +545,10 @@ pub fn main(init: std.process.Init) !void {
     // explicit defer on `config_storage`.
     const config_storage = try allocator.create(model_mod.ModelConfig);
     var config_owned_by_registry = false;
-    errdefer if (!config_owned_by_registry) allocator.destroy(config_storage);
+    // defer-only, NOT errdefer + defer: a plain `defer` already runs on the
+    // error-return path, so pairing it with an errdefer that has the same body
+    // frees the resource twice on error (double-free / SIGSEGV). The runtime
+    // `owned_by_registry` guard makes the single defer correct on every exit.
     defer if (!config_owned_by_registry) allocator.destroy(config_storage);
     config_storage.* = try model_mod.parseConfig(io, allocator, model_dir);
     const config = config_storage;
@@ -564,10 +567,8 @@ pub fn main(init: std.process.Init) !void {
     log.info("Loading tokenizer...\n", .{});
     const tok = try allocator.create(tokenizer_mod.Tokenizer);
     var tok_owned_by_registry = false;
-    errdefer if (!tok_owned_by_registry) {
-        tok.deinit();
-        allocator.destroy(tok);
-    };
+    // defer-only (see config note above): errdefer + defer with the same body
+    // double-frees on the error-return path.
     defer if (!tok_owned_by_registry) {
         tok.deinit();
         allocator.destroy(tok);
@@ -577,10 +578,9 @@ pub fn main(init: std.process.Init) !void {
     // Load chat config — heap-allocated, ownership transfers to registry on serve_mode.
     const chat_config = try allocator.create(chat_mod.ChatConfig);
     var chat_config_owned_by_registry = false;
-    errdefer if (!chat_config_owned_by_registry) {
-        chat_config.deinit();
-        allocator.destroy(chat_config);
-    };
+    // defer-only (see config note above): errdefer + defer with the same body
+    // double-frees on the error-return path — this is the one that crashed in
+    // the #45 GPU-OOM pre-flight refusal (ChatConfig.deinit ran twice).
     defer if (!chat_config_owned_by_registry) {
         chat_config.deinit();
         allocator.destroy(chat_config);

--- a/tests/test_oom_preflight.sh
+++ b/tests/test_oom_preflight.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Regression test for the GPU-OOM pre-flight refusal path (issue #47).
+#
+# When the #45 memory pre-flight refuses a load (error.InsufficientMemory),
+# main() returns the error and unwinds its defers. A redundant errdefer+defer
+# pair (identical bodies) for config/tok/chat_config used to free each twice on
+# that error path → double-free → SIGSEGV during shutdown, AFTER the legible
+# error was printed. This pins the fix: the refusal must exit cleanly (no
+# signal-11), not crash.
+#
+# The pre-flight sums *.safetensors sizes via statFile (it never opens them), so
+# a SPARSE dummy .safetensors inflates the apparent weight size past free RAM
+# and forces a deterministic refusal — no real memory pressure required.
+#
+# Usage: ./tests/test_oom_preflight.sh [model_dir] [port]
+#   Needs any loadable model dir for CPU-side setup (config.json + tokenizer).
+
+set -u
+
+MODEL="${1:-$HOME/.mlx-serve/models/mlx-community/gemma-4-e2b-it-8bit}"
+PORT="${2:-11293}"
+BINARY="${BINARY:-./zig-out/bin/mlx-serve}"
+FAKE="/tmp/test_oom_preflight_model"
+LOG=/tmp/test_oom_preflight.log
+PASS=0
+FAIL=0
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+check() {
+    local desc="$1" ok="$2"
+    if [ "$ok" = "1" ]; then PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $desc"
+    else FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $desc"; fi
+}
+
+if [ ! -d "$MODEL" ]; then
+    echo "SKIP: model dir not found: $MODEL"
+    exit 0
+fi
+if [ ! -x "$BINARY" ]; then
+    echo "SKIP: binary not found: $BINARY (build with: zig build -Doptimize=ReleaseFast)"
+    exit 0
+fi
+
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
+sleep 1
+
+# Build the fake-OOM model: symlink the real (small) files so CPU-side setup
+# succeeds, then add a huge SPARSE dummy weight file to trip the pre-flight.
+rm -rf "$FAKE"; mkdir -p "$FAKE"
+for f in "$MODEL"/*; do ln -sf "$f" "$FAKE/$(basename "$f")"; done
+truncate -s 80G "$FAKE/zzz_oom_dummy.safetensors" 2>/dev/null || \
+    mkfile -n 80g "$FAKE/zzz_oom_dummy.safetensors"
+
+echo ""
+echo "── #47: pre-flight refusal must exit cleanly (no SIGSEGV) ──"
+
+# Run WITHOUT the bypass so the pre-flight fires. The model never loads (refused
+# on the apparent 80 GB weights), so this returns within a couple seconds.
+"$BINARY" --model "$FAKE" --serve --port "$PORT" --no-pld --log-level info > "$LOG" 2>&1
+CODE=$?
+
+# 139 = 128 + SIGSEGV(11) — the bug. Any non-139 (clean error exit, typically 1)
+# is the fix.
+check "pre-flight refusal does NOT segfault (exit != 139), got $CODE" \
+    "$([ "$CODE" != "139" ] && echo 1 || echo 0)"
+check "process exited non-zero (load correctly refused)" \
+    "$([ "$CODE" != "0" ] && echo 1 || echo 0)"
+check "legible pre-flight error was printed before exit" \
+    "$(grep -qi "Insufficient memory to load model" "$LOG" && echo 1 || echo 0)"
+check "no crash signature in output" \
+    "$(grep -qiE "Segmentation fault|panic|EXC_BAD_ACCESS" "$LOG" && echo 0 || echo 1)"
+
+rm -rf "$FAKE"
+
+echo ""
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+    echo -e "${GREEN}PASS${NC} $TOTAL/$TOTAL tests passed"
+    exit 0
+else
+    echo -e "${RED}FAIL${NC} $FAIL/$TOTAL tests failed"
+    echo "--- server log (last 15 lines) ---"; tail -15 "$LOG" 2>/dev/null || true
+    exit 1
+fi


### PR DESCRIPTION
Fixes #47.

## Problem

When the #45 GPU-memory pre-flight refuses a load (`error.InsufficientMemory`), `serve()` returns the error and `main()` unwinds its defers — and the process **segfaults during shutdown**, *after* printing the intended legible error:

```
mem.Allocator.rawFree
mem.Allocator.free__anon_2651
chat.ChatConfig.deinit
main.main
```

It's `EXC_BAD_ACCESS / SIGSEGV` (exit 139) — the process dies with a crash signal instead of exiting cleanly with an error code, so a supervisor reports a crash rather than a graceful refusal.

## Root cause

The serve-path cleanup for `config`, `tok`, and `chat_config` in `main.zig` was registered as **both an `errdefer` and a `defer` with identical bodies**, e.g.:

```zig
errdefer if (!chat_config_owned_by_registry) { chat_config.deinit(); allocator.destroy(chat_config); };
defer    if (!chat_config_owned_by_registry) { chat_config.deinit(); allocator.destroy(chat_config); };
```

On an **error** return Zig runs *both* the `errdefer` and the `defer`, so each resource is freed twice → double-free. `chat_config` crashes first because it's registered last (LIFO unwind), matching the backtrace.

This was latent before #45: the success path exits via the signal handler and never unwinds these defers, so the redundant pair was never exercised until the pre-flight gave `serve()` an error to return.

## Fix

Drop the redundant `errdefer` for all three resources. A plain `defer` already runs on the error-return path, and the existing `*_owned_by_registry` runtime guard keeps the single cleanup correct on every exit:

- serve-mode → registry takes ownership, guard skips the free;
- offline mode (`--prompt`) → normal return, `defer` frees;
- error return (incl. the pre-flight refusal) → `defer` frees exactly once.

The other serve helpers (ds4 / llama stubs) already use `errdefer`-only and are unaffected.

## Reproducer (no memory pressure needed)

The pre-flight sums `*.safetensors` sizes via `statFile` (it never opens them), so a **sparse** dummy weight forces a deterministic refusal:

```bash
REAL=~/.mlx-serve/models/<any-model>
FAKE=/tmp/fake-oom; rm -rf $FAKE; mkdir -p $FAKE
for f in "$REAL"/*; do ln -sf "$f" "$FAKE/$(basename "$f")"; done
truncate -s 80G "$FAKE/zzz_dummy.safetensors"

./zig-out/bin/mlx-serve --model "$FAKE" --serve --port 11296
echo "exit: $?"   # before: 139 (SIGSEGV) ;  after: 1 (clean error exit)
```

## Verification

- Added `tests/test_oom_preflight.sh` (model-gated like the other integration tests, so it skips in CI without a model). Verified **red-on-revert**: reverting only `main.zig` brings back exit 139; with the fix, exit 1.
- `zig build test` green; `zig build -Doptimize=ReleaseFast` clean.

## Note (separate, pre-existing — not addressed here)

Those same `defer`s call `.deinit()` on memory that is only initialized on the *next* line (`chat_config.* = try loadChatConfig(...)`). If `loadChatConfig` / `loadTokenizer` / `parseConfig` themselves fail, the `defer` runs `deinit()` on an uninitialized struct. This is pre-existing and a different trigger than #47 (this change actually halves the exposure, 2 deinits → 1); happy to address it in a follow-up if you'd like.