### PR TITLE
Expose ds4 SSD weight-streaming via --ssd-streaming (#39)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -188,6 +188,10 @@ fn addDs4Sources(b: *std.Build, module: *std.Build.Module) void {
     // ds4_gpu.h is implemented in ds4_metal.m; ds4_kvstore/web/help/agent.c are
     // CLI/server-only and not part of the library path mlx-serve embeds.
     module.addCSourceFile(.{ .file = b.path("lib/ds4/ds4_distributed.c"), .flags = c_flags });
+    // SSD weight-streaming (issue #39): ds4_ssd.c is a standalone TU (#includes
+    // only ds4_ssd.h) implementing the streaming expert cache the engine_options
+    // ssd_streaming_* fields drive. Added upstream after the previous pin.
+    module.addCSourceFile(.{ .file = b.path("lib/ds4/ds4_ssd.c"), .flags = c_flags });
 
     const objc_flags = &[_][]const u8{
         "-O3",

--- a/src/arch/ds4.zig
+++ b/src/arch/ds4.zig
@@ -188,6 +188,14 @@ pub const OpenOptions = struct {
     mtp_path: ?[:0]const u8 = null,
     mtp_draft_tokens: c_int = 0,
     mtp_margin: f32 = 0,
+    /// SSD weight-streaming (issue #39): skip full model residency + warmup and
+    /// stream expert weights from disk, with an in-RAM cache. Lets DeepSeek-V4-Flash
+    /// run on machines whose RAM can't hold the full model. 0 cache fields = ds4 auto.
+    ssd_streaming: bool = false,
+    ssd_streaming_cold: bool = false,
+    ssd_streaming_cache_experts: u32 = 0,
+    ssd_streaming_cache_bytes: u64 = 0,
+    ssd_streaming_preload_experts: u32 = 0,
 };
 
 pub const Ds4Engine = struct {
@@ -217,6 +225,11 @@ pub const Ds4Engine = struct {
             .directional_steering_ffn = 0,
             .warm_weights = opts.warm_weights,
             .quality = opts.quality,
+            .ssd_streaming = opts.ssd_streaming,
+            .ssd_streaming_cold = opts.ssd_streaming_cold,
+            .ssd_streaming_cache_experts = opts.ssd_streaming_cache_experts,
+            .ssd_streaming_cache_bytes = opts.ssd_streaming_cache_bytes,
+            .ssd_streaming_preload_experts = opts.ssd_streaming_preload_experts,
         };
 
         var raw: ?*ffi.Engine = null;

--- a/src/ds4_ffi.zig
+++ b/src/ds4_ffi.zig
@@ -72,19 +72,31 @@ pub const DistributedOptions = extern struct {
     debug: bool = false,
 };
 
+// Mirrors `ds4_engine_options` in lib/ds4/ds4.h EXACTLY (field order + types are
+// the C ABI contract; a mismatch silently corrupts the struct at open time).
+// The ssd_streaming_* / prefill_chunk / expert_profile_path / simulate_used_memory_bytes
+// fields were added upstream alongside SSD weight-streaming (issue #39).
 pub const EngineOptions = extern struct {
     model_path: ?[*:0]const u8 = null,
     mtp_path: ?[*:0]const u8 = null,
     backend: Backend = .metal,
     n_threads: c_int = 0,
+    prefill_chunk: u32 = 0,
     mtp_draft_tokens: c_int = 0,
     mtp_margin: f32 = 0,
     directional_steering_file: ?[*:0]const u8 = null,
+    expert_profile_path: ?[*:0]const u8 = null,
     directional_steering_attn: f32 = 0,
     directional_steering_ffn: f32 = 0,
     power_percent: c_int = 0,
+    ssd_streaming_cache_experts: u32 = 0,
+    ssd_streaming_cache_bytes: u64 = 0,
+    ssd_streaming_preload_experts: u32 = 0,
+    simulate_used_memory_bytes: u64 = 0,
     warm_weights: bool = false,
     quality: bool = false,
+    ssd_streaming: bool = false,
+    ssd_streaming_cold: bool = false,
     inspect_only: bool = false,
     load_slice: bool = false,
     load_layer_start: u32 = 0,

--- a/src/main.zig
+++ b/src/main.zig
@@ -23,6 +23,11 @@ pub const VERSION: []const u8 = build_options.version;
 
 const DEFAULT_MODEL_DIR = ""; // pass --model <path> to specify
 
+// --ssd-streaming (issue #39): ds4 weight-streaming toggle. Set during arg
+// parsing, read by the ds4 serve + offline open paths. Module-level to avoid
+// threading it through runDs4Serve's already-long parameter list.
+var ds4_ssd_streaming: bool = false;
+
 fn printUsage(io: std.Io) void {
     var stdout_buf: [4096]u8 = undefined;
     var stdout_w = std.Io.File.stdout().writer(io, &stdout_buf);
@@ -112,6 +117,11 @@ fn printUsage(io: std.Io) void {
         \\                        Override when auto-detection is wrong
         \\                        (e.g. an unusual ds4 quant whose metadata
         \\                        layout differs).
+        \\  --ssd-streaming     ds4 / DeepSeek-V4-Flash only: stream expert
+        \\                        weights from SSD instead of holding the whole
+        \\                        model in RAM (skips full residency + warmup).
+        \\                        Use when the model is larger than available
+        \\                        memory. Ignored by the MLX + llama.cpp engines.
         \\  --model-dir <dir>   Directory of MLX models to discover at startup.
         \\                        Discovered siblings appear in /v1/models and
         \\                        can be loaded on-demand via /v1/load-model
@@ -404,6 +414,8 @@ pub fn main(init: std.process.Init) !void {
                 log.err("--engine: expected one of {{auto, ds4, llama}}; got '{s}'\n", .{args[i]});
                 std.process.exit(1);
             }
+        } else if (std.mem.eql(u8, args[i], "--ssd-streaming")) {
+            ds4_ssd_streaming = true;
         } else if (std.mem.eql(u8, args[i], "--kv-attn-mode") and i + 1 < args.len) {
             i += 1;
             if (std.mem.eql(u8, args[i], "dense")) {
@@ -1042,6 +1054,7 @@ fn runDs4Offline(
     var engine = ds4_arch.Ds4Engine.open(allocator, gguf_path, .{
         .backend = .metal,
         .warm_weights = true,
+        .ssd_streaming = ds4_ssd_streaming,
     }) catch |err| {
         log.err("[ds4] engine open failed: {s}\n", .{@errorName(err)});
         return err;
@@ -1280,6 +1293,7 @@ fn runDs4Serve(
         // Iteration 2: tokenize cache for ds4 too.
         .tokenize_cache_entries = server_mod.tokenize_cache_entries,
         .ds4_path = gguf_path_owned,
+        .ds4_ssd_streaming = ds4_ssd_streaming,
     };
 
     try server_mod.serve(io, allocator, params, config_storage, host, port, .{

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -165,6 +165,9 @@ pub const LoadParams = struct {
     /// still moved onto the entry so server-side reads of `lm.config.?`
     /// (e.g. `eosTokenSlice`, `getEffectiveContextLength`) keep working.
     ds4_path: []const u8 = "",
+    /// SSD weight-streaming for the ds4 engine (issue #39): stream experts from
+    /// disk instead of requiring the full model resident in RAM.
+    ds4_ssd_streaming: bool = false,
     /// Like `ds4_path` but for the generic llama.cpp engine (any GGUF except
     /// DeepSeek-V4-Flash). The inference thread opens a `LlamaEngine` and
     /// installs it on the entry's `llama_engine` field. Mutually exclusive with
@@ -737,6 +740,9 @@ pub const LoadRequest = struct {
     /// Borrowed paths. Conn thread keeps the buffers alive until `done`.
     model_dir: []const u8,
     drafter_dir: []const u8 = "",
+    /// SSD weight-streaming for cold-loaded ds4 models (issue #39). The CLI
+    /// startup path supplies this via LoadParams; cold-load defaults it off.
+    ds4_ssd_streaming: bool = false,
     /// Auto-load the Qwen native MTP sidecar when the model dir ships one.
     mtp_enabled: bool = true,
     /// Default MTP draft depth (CLI --mtp-depth).
@@ -1562,6 +1568,7 @@ fn doLoadDs4OnInferenceThread(sch: *Scheduler, params: anytype) !void {
     const engine = try arch_ds4.Ds4Engine.open(sch.allocator, params.ds4_path, .{
         .backend = .metal,
         .warm_weights = true,
+        .ssd_streaming = params.ds4_ssd_streaming,
     });
     errdefer engine.close();
     log.info("[ds4] engine ready (EOS={d}, has_mtp={})\n", .{ engine.eosToken(), engine.hasMtp() });

--- a/tests/test_ds4_ssd_streaming.sh
+++ b/tests/test_ds4_ssd_streaming.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Integration test for ds4 SSD weight-streaming (issue #39).
+#
+# DeepSeek-V4-Flash is larger than RAM on many machines; without streaming the
+# ds4 engine maps + warms the full model and OOMs ("metal failed to map model
+# views; aborting startup"). `--ssd-streaming` makes ds4 skip full residency and
+# stream expert weights from SSD with an in-RAM cache, so it loads + serves.
+#
+# This pins: with --ssd-streaming the engine reports streaming mode, loads, and
+# generates coherent text over the OpenAI API.
+#
+# Usage: DS4_GGUF_MODEL=/path/to/DeepSeek-V4-Flash-*.gguf ./tests/test_ds4_ssd_streaming.sh [port]
+#   Needs a DeepSeek-V4-Flash GGUF + a machine where the ds4 engine runs (Metal).
+
+set -u
+
+MODEL="${DS4_GGUF_MODEL:-$HOME/.mlx-serve/models/antirez/deepseek-v4-gguf/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2.gguf}"
+PORT="${1:-11298}"
+BASE="http://127.0.0.1:$PORT"
+BINARY="${BINARY:-./zig-out/bin/mlx-serve}"
+LOG=/tmp/test_ds4_ssd_streaming.log
+PASS=0
+FAIL=0
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+check() {
+    local desc="$1" ok="$2"
+    if [ "$ok" = "1" ]; then PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $desc"
+    else FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $desc"; fi
+}
+
+if [ ! -f "$MODEL" ]; then
+    echo "SKIP: ds4 GGUF not found: $MODEL (set DS4_GGUF_MODEL)"
+    exit 0
+fi
+if [ ! -x "$BINARY" ]; then
+    echo "SKIP: binary not found: $BINARY (build: zig build -Doptimize=ReleaseFast)"
+    exit 0
+fi
+
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
+sleep 1
+
+echo ""
+echo "── ds4 --ssd-streaming: load + generate (issue #39) ──"
+# Force the ds4 engine and enable SSD streaming.
+"$BINARY" --model "$MODEL" --serve --port "$PORT" --engine ds4 --ssd-streaming \
+    --log-level info > "$LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+
+# ds4 streaming skips warmup so startup is fast, but allow generous time for the
+# initial metal map on a big model.
+ok=0
+for _ in $(seq 1 240); do
+    curl -sf "$BASE/health" >/dev/null 2>&1 && { ok=1; break; }
+    kill -0 "$SERVER_PID" 2>/dev/null || break  # server died
+    sleep 1
+done
+check "server became healthy with --ssd-streaming" "$ok"
+
+# ds4 prints "SSD streaming mode enabled" (residency + warmup skipped) when the
+# flag reaches the engine. This is the proof the flag is wired through.
+check "ds4 reports SSD streaming mode enabled" \
+    "$(grep -qiE "SSD streaming.*enabled|streaming mode enabled|residency.*skipped" "$LOG" && echo 1 || echo 0)"
+check "no OOM / metal-map abort in startup" \
+    "$(grep -qiE "failed to map model views|OutOfMemory|Insufficient Memory|EngineOpenFailed" "$LOG" && echo 0 || echo 1)"
+
+if [ "$ok" = "1" ]; then
+    RESP=$(curl -s -X POST "$BASE/v1/chat/completions" -H 'Content-Type: application/json' \
+        -d '{"model":"mlx-serve","messages":[{"role":"user","content":"In one short sentence, what is the capital of France?"}],"max_tokens":40,"temperature":0}')
+    check "chat completion returned choices" \
+        "$(echo "$RESP" | grep -q '"choices"' && echo 1 || echo 0)"
+    # Coherence canary: the answer should mention Paris.
+    check "response is coherent (mentions Paris)" \
+        "$(echo "$RESP" | grep -qi "paris" && echo 1 || echo 0)"
+fi
+
+echo ""
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+    echo -e "${GREEN}PASS${NC} $TOTAL/$TOTAL tests passed"
+    exit 0
+else
+    echo -e "${RED}FAIL${NC} $FAIL/$TOTAL tests failed"
+    echo "--- server log (last 25 lines) ---"; tail -25 "$LOG" 2>/dev/null || true
+    exit 1
+fi


### PR DESCRIPTION
Fixes #39.

## Problem

DeepSeek-V4-Flash is larger than RAM on many machines. The embedded ds4 engine maps + warms the full model at load and OOMs:

```
ds4: Metal model warmup failed: Insufficient Memory (...OutOfMemory)
ds4: metal failed to map model views; aborting startup.
[scheduler] model load failed: EngineOpenFailed
error: LoadFailed
```

Standalone `ds4-server --ssd-streaming` already solves this (skips full residency/warmup, streams experts from SSD with an in-RAM cache), but mlx-serve had no way to enable it — and the pinned ds4 (`477c0e8`) predated the feature.

## Change

- **Bump the ds4 submodule `477c0e8 → 80ebbc3`** — adds the SSD-streaming engine and the `ds4_engine_options.ssd_streaming*` fields. The C API delta is purely additive (no changed signatures).
- **build.zig**: compile the new standalone `ds4_ssd.c`.
- **ds4_ffi.zig**: mirror the new `ds4_engine_options` layout exactly (ABI field order).
- **arch/ds4.zig**: thread `ssd_streaming` (+ cache tuning) through `OpenOptions`.
- **scheduler.zig / main.zig**: new `--ssd-streaming` CLI flag, wired to both the startup (`LoadParams`) and cold-load (`LoadRequest`) ds4 open paths. `warm_weights` stays true — ds4 skips warmup internally when streaming, matching `ds4-server`.
- **tests/test_ds4_ssd_streaming.sh**: model-gated integration test.

Net diff is small (additive); the +14k lines are the upstream ds4 submodule advancing, not hand-edits.

## Validation

Runtime-tested on an **M5 Max / 128 GB** with the real **DeepSeek-V4-Flash IQ2XXS** GGUF (80.7 GB):

```
[ds4] opening engine: .../DeepSeek-V4-Flash-IQ2XXS-...-chat-v2.gguf
ds4: Metal SSD streaming mode enabled; full model residency and warmup are skipped
ds4:   using 80% total for model + cached experts: 86.02 GiB
ds4:   cached expert count: 11008 (72.56 GiB)
[ds4] engine ready (EOS=1, has_mtp=false)
```

`tests/test_ds4_ssd_streaming.sh` → **5/5**: server healthy with `--ssd-streaming`, engine reports streaming mode, no OOM/metal-map abort, chat completion returns choices, and the answer is coherent ("capital of France" → mentions Paris).

`zig build test` green; `zig build -Doptimize=ReleaseFast` clean.

## Usage

```
mlx-serve --model DeepSeek-V4-Flash-*.gguf --serve --ssd-streaming
```
Ignored by the MLX + llama.cpp engines (ds4-only).