### PR TITLE
feat: opt-in Prometheus metrics + zero-dependency admin dashboard (--metrics)

### DIFF
--- a/src/admin_dashboard.html
+++ b/src/admin_dashboard.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>mlx-serve Admin</title>
+<style>
+:root{--bg:#111217;--panel:#1a1c23;--border:#2c2e3a;--text:#d0d1d7;--muted:#8a8d99;--accent:#3b82f6;--green:#22c55e;--yellow:#f59e0b;--red:#ef4444;--font:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif}
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:var(--bg);color:var(--text);font-family:var(--font);min-height:100vh}
+header{background:var(--panel);border-bottom:1px solid var(--border);padding:12px 24px;display:flex;align-items:center;justify-content:space-between}
+.logo{font-size:16px;font-weight:700;color:var(--accent)}.logo span{color:var(--text)}
+#hdr-status{font-size:12px;padding:3px 12px;border-radius:12px;background:var(--border);color:var(--muted)}
+#hdr-status.live{background:#0f2a0f;color:var(--green)}
+#hdr-status.err{background:#2a0f0f;color:var(--red)}
+main{max-width:1280px;margin:0 auto;padding:20px 24px}
+#disabled-msg{display:none;text-align:center;padding:80px 20px;color:var(--muted)}
+#disabled-msg h2{font-size:20px;margin-bottom:10px;color:var(--text)}
+#disabled-msg code{font-family:monospace;color:var(--accent)}
+#content{display:none}
+.sec{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin:20px 0 10px 2px}
+.row{display:grid;gap:16px;margin-bottom:0}
+.r4{grid-template-columns:repeat(4,1fr)}
+.r2{grid-template-columns:repeat(2,1fr)}
+.panel{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:16px}
+.lbl{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);margin-bottom:8px}
+.val{font-size:30px;font-weight:700;line-height:1;color:var(--text)}
+.unit{font-size:14px;font-weight:400;color:var(--muted);margin-left:3px}
+.sub{font-size:11px;color:var(--muted);margin-top:6px}
+.track{height:6px;background:var(--border);border-radius:3px;margin-top:12px;overflow:hidden}
+.fill{height:100%;border-radius:3px;background:var(--accent);transition:width .4s}
+.fill.warn{background:var(--yellow)}.fill.crit{background:var(--red)}
+.spark{width:100%;height:72px}
+.tot-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;text-align:center}
+.tot-v{font-size:22px;font-weight:700}.tot-l{font-size:11px;color:var(--muted);margin-top:4px}
+.code-box{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:14px 18px;font-family:'SF Mono','Fira Code',monospace;font-size:12px;color:#93c5fd;white-space:pre;overflow-x:auto;margin-top:10px}
+</style>
+</head>
+<body>
+<header>
+  <div class="logo">mlx<span>-serve</span> · Admin</div>
+  <div id="hdr-status">Loading…</div>
+</header>
+<main>
+  <div id="disabled-msg">
+    <h2>Metrics Not Enabled</h2>
+    <p>Start mlx-serve with <code>--metrics</code> to enable this dashboard.</p>
+  </div>
+  <div id="content">
+    <div class="sec">Loaded model</div>
+    <div class="panel" id="model-panel" style="margin-bottom:4px">
+      <span class="val" id="model-name" style="font-size:22px">—</span>
+      <div class="sub" id="model-meta" style="margin-top:8px">loading model info…</div>
+    </div>
+    <div class="sec">Throughput</div>
+    <div class="row r4">
+      <div class="panel"><div class="lbl">Request Rate</div><span class="val" id="req-rate">—</span><span class="unit">req/s</span><div class="sub" id="req-total">— total</div></div>
+      <div class="panel"><div class="lbl">Tokens / sec</div><span class="val" id="tok-rate">—</span><span class="unit">tok/s</span><div class="sub" id="tok-total">— total generated</div></div>
+      <div class="panel"><div class="lbl">Avg TTFT</div><span class="val" id="ttft-avg">—</span><span class="unit">ms</span><div class="sub" id="ttft-count">— requests measured</div></div>
+      <div class="panel"><div class="lbl">Cache Hit Rate</div><span class="val" id="cache-pct">—</span><span class="unit">%</span><div class="sub" id="cache-detail">— / — queries</div></div>
+    </div>
+    <div class="sec">System</div>
+    <div class="row r4">
+      <div class="panel"><div class="lbl">Running</div><span class="val" id="running">0</span><span class="unit">slots</span></div>
+      <div class="panel"><div class="lbl">Waiting</div><span class="val" id="waiting">0</span><span class="unit">slots</span></div>
+      <div class="panel"><div class="lbl">GPU Utilization</div><span class="val" id="gpu-pct">0</span><span class="unit">%</span><div class="track"><div class="fill" id="gpu-bar" style="width:0%"></div></div></div>
+      <div class="panel"><div class="lbl">Memory</div><span class="val" id="rss">0</span><span class="unit">MB</span></div>
+    </div>
+    <div class="sec">History (last 2 min)</div>
+    <div class="row r2">
+      <div class="panel"><div class="lbl" style="margin-bottom:6px">TTFT (ms)</div><svg class="spark" id="ttft-chart" viewBox="0 0 600 72" preserveAspectRatio="none"></svg></div>
+      <div class="panel"><div class="lbl" style="margin-bottom:6px">Tokens / sec</div><svg class="spark" id="tok-chart" viewBox="0 0 600 72" preserveAspectRatio="none"></svg></div>
+    </div>
+    <div class="sec">Totals</div>
+    <div class="panel">
+      <div class="tot-grid">
+        <div><div class="tot-v" id="tot-ok">0</div><div class="tot-l">Successful</div></div>
+        <div><div class="tot-v" id="tot-cancel">0</div><div class="tot-l">Cancelled</div></div>
+        <div><div class="tot-v" id="tot-prompt">0</div><div class="tot-l">Prompt Tokens</div></div>
+        <div><div class="tot-v" id="tot-gen">0</div><div class="tot-l">Generated Tokens</div></div>
+      </div>
+    </div>
+    <div class="sec">Grafana Integration</div>
+    <div class="panel">
+      <div class="sub">Point Prometheus at the <code>/metrics</code> endpoint on this host:</div>
+      <div class="code-box" id="prom-cfg">Loading…</div>
+    </div>
+  </div>
+</main>
+<script>
+'use strict';
+const H=60;
+const samples=[];  // (t, counters) ring buffer for smooth trailing-window rates
+const ttftH=[],tokH=[];
+const $=id=>document.getElementById(id);
+
+function spark(id,data,color){
+  const svg=$(id);
+  if(data.length<2){svg.innerHTML='';return;}
+  const max=Math.max(...data,0.001);
+  const n=data.length,W=600,HT=72,p=4;
+  const pts=data.map((v,i)=>{
+    const x=p+(i/(n-1))*(W-2*p);
+    const y=HT-p-(v/max)*(HT-2*p);
+    return x+','+y;
+  }).join(' ');
+  svg.innerHTML='<polyline points="'+pts+'" fill="none" stroke="'+color+'" stroke-width="1.5" stroke-linejoin="round"/><line x1="'+p+'" y1="'+(HT-1)+'" x2="'+(W-p)+'" y2="'+(HT-1)+'" stroke="#2c2e3a" stroke-width="1"/>';
+}
+
+function fmt(v,d){
+  if(v===null||isNaN(v))return '—';
+  if(v>=1e6)return(v/1e6).toFixed(1)+'M';
+  if(v>=1e3)return(v/1e3).toFixed(1)+'K';
+  return v.toFixed(d===undefined?1:d);
+}
+
+function status(cls,txt){const e=$('hdr-status');e.className=cls;e.textContent=txt;}
+
+async function tick(){
+  let d;
+  try{
+    const r=await fetch('/admin/metrics.json');
+    if(r.status===503){
+      $('disabled-msg').style.display='block';
+      $('content').style.display='none';
+      status('err','Metrics disabled');return;
+    }
+    if(!r.ok)throw new Error('HTTP '+r.status);
+    d=await r.json();
+  }catch(e){status('err','Error: '+e.message);return;}
+
+  $('disabled-msg').style.display='none';
+  // Must be an explicit value: style.display='' reverts to the stylesheet rule
+  // (#content{display:none}), leaving the panels hidden. Use 'block'.
+  $('content').style.display='block';
+  status('live','● Live · 2s');
+
+  const c=d.counters,g=d.gauges,h=d.histograms;
+  const now=Date.now();
+  const th=h.time_to_first_token_seconds;
+  // Two timescales:
+  //  • tok/s comes from the generation_tokens_live GAUGE (completed tokens plus
+  //    tokens generated so far by in-flight slots), sampled server-side every
+  //    2s. It moves continuously even mid-request, so a short ~4s window gives a
+  //    real-time tok/s with no 0-reads between long-request completions. Falls
+  //    back to the completion counter on older servers without the gauge.
+  //  • req/s and TTFT come from completion COUNTERS, which only move when a
+  //    request finishes — genuinely sparse. A ~12s window keeps them stable
+  //    without the old 30s lag.
+  const liveTok=(g.generation_tokens_live!=null)?g.generation_tokens_live:c.generation_tokens_total;
+  samples.push({t:now,req:c.requests_success_total,tok:liveTok,tc:th.count,ts:th.sum});
+  while(samples.length>2 && now-samples[0].t>12000) samples.shift();
+  // newest sample at least winMs old (tightest window ≥ winMs); oldest while warming up
+  const at=winMs=>{let s=samples[0];for(const x of samples){if(now-x.t>=winMs)s=x;else break;}return s;};
+  let rr=null,tr=null,tavg=null;
+  if(samples.length>1){
+    const wt=at(4000), dtt=(now-wt.t)/1000;
+    if(dtt>0) tr=Math.max(0,(liveTok-wt.tok)/dtt);
+    const wr=at(12000), dtr=(now-wr.t)/1000;
+    if(dtr>0) rr=Math.max(0,(c.requests_success_total-wr.req)/dtr);
+    const dc=th.count-wr.tc;
+    tavg=dc>0?((th.sum-wr.ts)/dc)*1000:(th.count>0?(th.sum/th.count)*1000:null);
+    ttftH.push(tavg!==null?tavg:0);
+    tokH.push(tr!==null?tr:0);
+    if(ttftH.length>H)ttftH.shift();
+    if(tokH.length>H)tokH.shift();
+  }else if(th.count>0){
+    tavg=(th.sum/th.count)*1000;
+  }
+
+  $('req-rate').textContent=rr!==null?fmt(rr,2):'—';
+  $('req-total').textContent=fmt(c.requests_success_total,0)+' total';
+  $('tok-rate').textContent=tr!==null?fmt(tr,0):'—';
+  $('tok-total').textContent=fmt(c.generation_tokens_total,0)+' total generated';
+
+  const tAll=h.time_to_first_token_seconds;
+  const tDisp=tavg!==null?tavg:(tAll.count>0?(tAll.sum/tAll.count)*1000:null);
+  $('ttft-avg').textContent=tDisp!==null?fmt(tDisp,0):'—';
+  $('ttft-count').textContent=tAll.count+' requests measured';
+
+  const cq=c.prefix_cache_queries_total,ch=c.prefix_cache_hits_total;
+  $('cache-pct').textContent=cq>0?Math.round(ch/cq*100):'—';
+  $('cache-detail').textContent=ch+' / '+cq+' queries';
+
+  $('running').textContent=g.requests_running;
+  $('waiting').textContent=g.requests_waiting;
+  const gp=g.gpu_utilization_pct;
+  $('gpu-pct').textContent=gp;
+  const bar=$('gpu-bar');
+  bar.style.width=gp+'%';
+  bar.className='fill'+(gp>=90?' crit':gp>=70?' warn':'');
+  $('rss').textContent=g.memory_mb;
+
+  $('tot-ok').textContent=fmt(c.requests_success_total,0);
+  $('tot-cancel').textContent=fmt(c.requests_cancelled_total,0);
+  $('tot-prompt').textContent=fmt(c.prompt_tokens_total,0);
+  $('tot-gen').textContent=fmt(c.generation_tokens_total,0);
+
+  spark('ttft-chart',ttftH,'#3b82f6');
+  spark('tok-chart',tokH,'#22c55e');
+}
+
+const port=window.location.port||'80';
+const host=window.location.hostname;
+$('prom-cfg').textContent='# prometheus.yml\nscrape_configs:\n  - job_name: mlx_serve\n    static_configs:\n      - targets: [\''+host+':'+port+'\']\n    metrics_path: /metrics\n    scrape_interval: 15s';
+
+async function loadModel(){
+  try{
+    const r=await fetch('/v1/models'); if(!r.ok)return;
+    const list=(await r.json()).data||[];
+    const m=list.find(x=>x.loaded)||list[0]; if(!m)return;
+    $('model-name').textContent=m.id;
+    const meta=m.meta||{},parts=[];
+    if(meta.architecture)parts.push(meta.architecture);
+    if(meta.quantization)parts.push(meta.quantization);
+    if(meta.is_moe)parts.push('MoE');
+    if(meta.context_length)parts.push(meta.context_length.toLocaleString()+' ctx');
+    if(Array.isArray(m.capabilities)&&m.capabilities.length)parts.push(m.capabilities.join(', '));
+    $('model-meta').textContent=parts.join('  ·  ');
+  }catch(e){}
+}
+loadModel();
+setInterval(loadModel,30000);
+tick();
+setInterval(tick,2000);
+</script>
+</body>
+</html>

--- a/src/main.zig
+++ b/src/main.zig
@@ -18,6 +18,7 @@ const ds4_arch = @import("arch/ds4.zig");
 const llama_arch = @import("arch/llama.zig");
 const ds4_ffi = @import("ds4_ffi.zig");
 const log = @import("log.zig");
+const metrics_mod = @import("metrics.zig");
 
 pub const VERSION: []const u8 = build_options.version;
 
@@ -143,6 +144,9 @@ fn printUsage(io: std.Io) void {
         \\  --idle-evict-secs <n>
         \\                      Evict .ready entries with refcount==0 if
         \\                        idle for this many seconds. Default: off.
+        \\  --metrics           Enable Prometheus metrics endpoint at GET /metrics
+        \\                        (served on the main --port; dashboard at GET /admin)
+        \\  --admin-key <token> Bearer token to protect admin POST endpoints (optional)
         \\  --log-level <lvl>   Log level: error, warn, info, debug (default: info)
         \\  --version           Print version and exit
         \\  --help              Show this help
@@ -218,6 +222,7 @@ pub fn main(init: std.process.Init) !void {
     var max_resident_mem: u64 = 0; // 0 = auto (80% of wired limit at startup)
     var max_resident_mem_explicit: bool = false;
     var idle_evict_secs: ?u32 = null;
+    var metrics_enabled = false;
     // GGUF engine routing override. null → auto (decided by gguf_meta on
     // file inspection); set explicitly via --engine to force ds4 or llama.
     var engine_override: ?gguf_meta.Engine = null;
@@ -288,6 +293,11 @@ pub fn main(init: std.process.Init) !void {
             i += 1;
             draft_block_size = try std.fmt.parseInt(u32, args[i], 10);
             draft_block_size_explicit = true;
+        } else if (std.mem.eql(u8, args[i], "--metrics")) {
+            metrics_enabled = true;
+        } else if (std.mem.eql(u8, args[i], "--admin-key") and i + 1 < args.len) {
+            server_mod.g_admin_key = args[i + 1];
+            i += 1;
         } else if (std.mem.eql(u8, args[i], "--no-mtp")) {
             enable_mtp = false;
         } else if (std.mem.eql(u8, args[i], "--mtp-depth") and i + 1 < args.len) {
@@ -717,6 +727,12 @@ pub fn main(init: std.process.Init) !void {
             chat_config_owned_by_registry = true;
         };
 
+        // Metrics: allocate and wire through when --metrics is on.
+        var metrics_instance: ?metrics_mod.Metrics = if (metrics_enabled) metrics_mod.Metrics.init() else null;
+        if (metrics_instance != null) {
+            server_mod.g_metrics = &metrics_instance.?;
+        }
+
         const params = scheduler_mod.LoadParams{
             .registry = registry,
             .entry = entry,
@@ -740,6 +756,7 @@ pub fn main(init: std.process.Init) !void {
             .llama_cache_entries = server_mod.llama_cache_entries,
             .llama_kv_type_k = server_mod.llama_kv_quant.ggmlType(),
             .llama_kv_type_v = server_mod.llama_kv_quant.ggmlType(),
+            .metrics = if (metrics_instance != null) &metrics_instance.? else null,
         };
         try server_mod.serve(io, allocator, params, config, host, port, .{
             .max_context_size = ctx_size,

--- a/src/metrics.zig
+++ b/src/metrics.zig
@@ -1,0 +1,615 @@
+//! Lock-free, zero-when-off instrumentation core for mlx-serve.
+//!
+//! Design contract (the whole point — mlx-serve's pitch is best-in-class
+//! serving performance, so observability must never touch that):
+//!
+//!   * OFF  — a single `?*Metrics` null-check per REQUEST (never per token).
+//!            No allocation, no atomics, no work. Unmeasurable.
+//!   * ON   — a handful of RELAXED atomic adds per request, recorded at the
+//!            `finishSlot` funnel which is already off the per-token decode
+//!            path. The inference thread never locks, waits, or blocks on the
+//!            metrics subsystem. Gauges are sampled on a separate thread;
+//!            `/metrics` renders on the scrape connection thread.
+//!
+//! Thread-safety: every write is `std.atomic.Value(u64)` with `.monotonic`
+//! (relaxed) ordering. Writers are N connection threads + the inference
+//! thread; readers (render) tolerate a slightly inconsistent cross-counter
+//! snapshot — fine for metrics. No mutex anywhere on the write path.
+
+const std = @import("std");
+
+// ---------------------------------------------------------------------------
+// Histogram bounds (comptime constants shared by Metrics.init)
+// ---------------------------------------------------------------------------
+
+/// 10 latency buckets spanning 10 ms → 10 s, stored in nanoseconds.
+/// The Prometheus renderer divides by 1e9 before emitting `le="X.XXX"`.
+const LATENCY_BOUNDS_NS: [10]u64 = .{
+    10_000_000, // 10 ms
+    25_000_000, // 25 ms
+    50_000_000, // 50 ms
+    100_000_000, // 100 ms
+    250_000_000, // 250 ms
+    500_000_000, // 500 ms
+    1_000_000_000, // 1 s
+    2_500_000_000, // 2.5 s
+    5_000_000_000, // 5 s
+    10_000_000_000, // 10 s
+};
+
+/// 8 token-count buckets: 32 → 8 192 (raw integers, no scaling).
+const TOKEN_BOUNDS: [8]u64 = .{ 32, 128, 256, 512, 1024, 2048, 4096, 8192 };
+
+// ---------------------------------------------------------------------------
+// Metrics — the single global struct allocated when --metrics is on
+// ---------------------------------------------------------------------------
+
+/// All instrumented metrics for one mlx-serve instance.
+/// Zero-allocation after init; every field is a lock-free primitive.
+pub const Metrics = struct {
+    // Latency histograms (observe in nanoseconds; rendered as seconds)
+    ttft_ns: Histogram(10), // time to first token
+    e2e_latency_ns: Histogram(10), // end-to-end request latency
+    prefill_time_ns: Histogram(10), // prefill phase
+    decode_time_ns: Histogram(10), // decode phase
+
+    // Per-request token histograms (raw counts)
+    prompt_tokens_hist: Histogram(8),
+    output_tokens_hist: Histogram(8),
+
+    // Counters
+    prompt_tokens_total: Counter,
+    generation_tokens_total: Counter,
+    requests_success_total: Counter,
+    requests_cancelled_total: Counter,
+    prefix_cache_queries_total: Counter,
+    prefix_cache_hits_total: Counter,
+
+    // Gauges (sampled by the background sampler thread; single writer)
+    requests_running: Gauge,
+    requests_waiting: Gauge,
+    gpu_utilization_pct: Gauge, // 0–100
+    memory_mb: Gauge, // megabytes (phys_footprint)
+    // Real-time throughput source: completed generation tokens PLUS tokens
+    // generated so far by in-flight slots. The sampler thread sets this by
+    // reading the already-live per-slot counts (no per-token write on the
+    // inference path), so the dashboard can derive a live tok/s without waiting
+    // for requests to complete. See server.zig sampleGauges.
+    generation_tokens_live: Gauge,
+
+    pub fn init() Metrics {
+        return .{
+            .ttft_ns = Histogram(10).init(LATENCY_BOUNDS_NS),
+            .e2e_latency_ns = Histogram(10).init(LATENCY_BOUNDS_NS),
+            .prefill_time_ns = Histogram(10).init(LATENCY_BOUNDS_NS),
+            .decode_time_ns = Histogram(10).init(LATENCY_BOUNDS_NS),
+            .prompt_tokens_hist = Histogram(8).init(TOKEN_BOUNDS),
+            .output_tokens_hist = Histogram(8).init(TOKEN_BOUNDS),
+            .prompt_tokens_total = Counter.init(),
+            .generation_tokens_total = Counter.init(),
+            .requests_success_total = Counter.init(),
+            .requests_cancelled_total = Counter.init(),
+            .prefix_cache_queries_total = Counter.init(),
+            .prefix_cache_hits_total = Counter.init(),
+            .requests_running = Gauge.init(),
+            .requests_waiting = Gauge.init(),
+            .gpu_utilization_pct = Gauge.init(),
+            .memory_mb = Gauge.init(),
+            .generation_tokens_live = Gauge.init(),
+        };
+    }
+
+    /// Record per-request metrics at slot completion.
+    /// Called exactly once per request from the `finishSlot` funnel.
+    ///
+    /// On success ("stop" | "length" | "tool_calls"): updates all latency
+    /// histograms, token histograms, and counters.
+    ///
+    /// On cancel ("cancelled"): only increments `requests_cancelled_total`.
+    /// Latency histograms are NOT touched — a cancelled slot's decode_ns is
+    /// zero or garbage and would poison the distribution.
+    ///
+    /// Other reasons (Zig error names from markError): silently ignored for
+    /// now; these are rare and already visible in --log-level warn output.
+    ///
+    /// Parameters:
+    ///   - `real_ttft_ns`: time from request arrival (Slot.init, pre-queue-wait)
+    ///     to first token = queue_wait + prefill. For single-user servers queue
+    ///     wait ≈ 0, so this equals `prefill_ns`. For concurrent servers it
+    ///     correctly includes queuing latency.
+    ///   - `prefill_ns`: model prefill phase only (no queue wait).
+    ///   - `decode_ns`: decode phase duration.
+    ///   - e2e latency = real_ttft_ns + decode_ns (= queue_wait + prefill + decode).
+    pub fn recordRequest(
+        self: *Metrics,
+        finish_reason: []const u8,
+        real_ttft_ns: u64,
+        prefill_ns: u64,
+        decode_ns: u64,
+        prompt_tokens: u32,
+        completion_tokens: u32,
+        cached_tokens: u32,
+    ) void {
+        // Wire prefix-cache stats unconditionally: every request queries the cache.
+        self.prefix_cache_queries_total.inc();
+        if (cached_tokens > 0) self.prefix_cache_hits_total.inc();
+
+        const is_success = std.mem.eql(u8, finish_reason, "stop") or
+            std.mem.eql(u8, finish_reason, "length") or
+            std.mem.eql(u8, finish_reason, "tool_calls");
+
+        if (!is_success) {
+            if (std.mem.eql(u8, finish_reason, "cancelled"))
+                self.requests_cancelled_total.inc();
+            // Error reasons (OOM, etc.) are rare; logged by the scheduler.
+            return;
+        }
+
+        // Success path — record all instrumented metrics.
+        self.requests_success_total.inc();
+        self.prompt_tokens_total.add(prompt_tokens);
+        self.generation_tokens_total.add(completion_tokens);
+
+        self.ttft_ns.observe(real_ttft_ns);
+        self.prefill_time_ns.observe(prefill_ns);
+        self.decode_time_ns.observe(decode_ns);
+        // e2e = queue_wait + prefill + decode  (real_ttft_ns already includes queue)
+        self.e2e_latency_ns.observe(real_ttft_ns + decode_ns);
+
+        self.prompt_tokens_hist.observe(@as(u64, prompt_tokens));
+        self.output_tokens_hist.observe(@as(u64, completion_tokens));
+    }
+};
+
+// ---------------------------------------------------------------------------
+// renderPrometheus — Prometheus text exposition format (OpenMetrics-compat)
+// ---------------------------------------------------------------------------
+
+/// Write all metrics in Prometheus text format to `w`.
+/// Called only on the scrape connection thread — never on the inference path.
+pub fn renderPrometheus(m: *const Metrics, w: *std.Io.Writer) !void {
+    const ns_to_s = 1.0 / 1_000_000_000.0;
+
+    // --- Counters ---
+    try writeCounter(w, "vllm:prompt_tokens_total",
+        "Total prompt tokens processed", m.prompt_tokens_total.load());
+    try writeCounter(w, "vllm:generation_tokens_total",
+        "Total generated tokens", m.generation_tokens_total.load());
+    try writeCounter(w, "vllm:request_success_total",
+        "Completed requests", m.requests_success_total.load());
+    try writeCounter(w, "vllm:request_cancelled_total",
+        "Requests cancelled by client disconnect", m.requests_cancelled_total.load());
+    try writeCounter(w, "vllm:prefix_cache_queries_total",
+        "Prefix cache lookup count", m.prefix_cache_queries_total.load());
+    try writeCounter(w, "vllm:prefix_cache_hits_total",
+        "Prefix cache hit count", m.prefix_cache_hits_total.load());
+
+    // --- Gauges ---
+    try writeGauge(w, "vllm:num_requests_running",
+        "Number of requests currently being processed", m.requests_running.load());
+    try writeGauge(w, "vllm:num_requests_waiting",
+        "Number of requests waiting in the queue", m.requests_waiting.load());
+    try writeGauge(w, "mlx_serve:gpu_utilization_pct",
+        "GPU utilization percentage (IOKit AGXAccelerator)", m.gpu_utilization_pct.load());
+    try writeGauge(w, "mlx_serve:memory_mb",
+        "Server physical memory footprint in megabytes (phys_footprint)", m.memory_mb.load());
+    try writeGauge(w, "mlx_serve:generation_tokens_live",
+        "Generation tokens completed plus generated-so-far by in-flight slots (real-time tok/s source)", m.generation_tokens_live.load());
+
+    // --- Latency histograms (nanoseconds → seconds) ---
+    try writeHistogram(w, "vllm:time_to_first_token_seconds",
+        "Time to first token in seconds", &m.ttft_ns, ns_to_s);
+    try writeHistogram(w, "vllm:e2e_request_latency_seconds",
+        "End-to-end request latency in seconds", &m.e2e_latency_ns, ns_to_s);
+    try writeHistogram(w, "vllm:request_prefill_time_seconds",
+        "Prefill phase latency in seconds", &m.prefill_time_ns, ns_to_s);
+    try writeHistogram(w, "vllm:request_decode_time_seconds",
+        "Decode phase latency in seconds", &m.decode_time_ns, ns_to_s);
+
+    // --- Token-count histograms (raw counts, scale = 1.0) ---
+    try writeHistogram(w, "vllm:request_prompt_tokens",
+        "Per-request prompt token count distribution", &m.prompt_tokens_hist, 1.0);
+    try writeHistogram(w, "vllm:request_generation_tokens",
+        "Per-request output token count distribution", &m.output_tokens_hist, 1.0);
+}
+
+// ---------------------------------------------------------------------------
+// renderJson — JSON admin API format
+// ---------------------------------------------------------------------------
+
+/// Write all metrics as a JSON object to `w`.
+/// Called only on the scrape/admin connection thread.
+pub fn renderJson(m: *const Metrics, w: *std.Io.Writer) !void {
+    const ns_to_s = 1.0 / 1_000_000_000.0;
+
+    try w.print(
+        "{{\"counters\":{{" ++
+        "\"prompt_tokens_total\":{d}," ++
+        "\"generation_tokens_total\":{d}," ++
+        "\"requests_success_total\":{d}," ++
+        "\"requests_cancelled_total\":{d}," ++
+        "\"prefix_cache_queries_total\":{d}," ++
+        "\"prefix_cache_hits_total\":{d}" ++
+        "}},\"gauges\":{{" ++
+        "\"requests_running\":{d}," ++
+        "\"requests_waiting\":{d}," ++
+        "\"gpu_utilization_pct\":{d}," ++
+        "\"memory_mb\":{d}," ++
+        "\"generation_tokens_live\":{d}" ++
+        "}},\"histograms\":{{",
+        .{
+            m.prompt_tokens_total.load(),
+            m.generation_tokens_total.load(),
+            m.requests_success_total.load(),
+            m.requests_cancelled_total.load(),
+            m.prefix_cache_queries_total.load(),
+            m.prefix_cache_hits_total.load(),
+            m.requests_running.load(),
+            m.requests_waiting.load(),
+            m.gpu_utilization_pct.load(),
+            m.memory_mb.load(),
+            m.generation_tokens_live.load(),
+        },
+    );
+
+    try writeHistogramJson(w, "time_to_first_token_seconds", &m.ttft_ns, ns_to_s);
+    try w.print(",", .{});
+    try writeHistogramJson(w, "e2e_request_latency_seconds", &m.e2e_latency_ns, ns_to_s);
+    try w.print(",", .{});
+    try writeHistogramJson(w, "prefill_time_seconds", &m.prefill_time_ns, ns_to_s);
+    try w.print(",", .{});
+    try writeHistogramJson(w, "decode_time_seconds", &m.decode_time_ns, ns_to_s);
+    try w.print(",", .{});
+    try writeHistogramJson(w, "prompt_tokens", &m.prompt_tokens_hist, 1.0);
+    try w.print(",", .{});
+    try writeHistogramJson(w, "output_tokens", &m.output_tokens_hist, 1.0);
+
+    try w.print("}}}}", .{});
+}
+
+// ---------------------------------------------------------------------------
+// Internal render helpers
+// ---------------------------------------------------------------------------
+
+fn writeCounter(w: *std.Io.Writer, name: []const u8, help: []const u8, value: u64) !void {
+    try w.print("# HELP {s} {s}\n", .{ name, help });
+    try w.print("# TYPE {s} counter\n", .{name});
+    try w.print("{s} {d}\n\n", .{ name, value });
+}
+
+fn writeGauge(w: *std.Io.Writer, name: []const u8, help: []const u8, value: u64) !void {
+    try w.print("# HELP {s} {s}\n", .{ name, help });
+    try w.print("# TYPE {s} gauge\n", .{name});
+    try w.print("{s} {d}\n\n", .{ name, value });
+}
+
+/// Render a Histogram(N) in Prometheus text format.
+/// `hist` is `*const Histogram(N)` for any comptime N (accepted via anytype).
+/// `scale` converts raw units to display units (e.g. 1e-9 for ns→s, 1.0 for counts).
+fn writeHistogram(w: *std.Io.Writer, name: []const u8, help: []const u8, hist: anytype, scale: f64) !void {
+    try w.print("# HELP {s} {s}\n", .{ name, help });
+    try w.print("# TYPE {s} histogram\n", .{name});
+
+    var cumulative: u64 = 0;
+    for (hist.bounds, 0..) |bound, i| {
+        cumulative += hist.buckets[i].load(.monotonic);
+        const bound_f = @as(f64, @floatFromInt(bound)) * scale;
+        try w.print("{s}_bucket{{le=\"{d}\"}} {d}\n", .{ name, bound_f, cumulative });
+    }
+    // +Inf bucket (index == bounds.len)
+    cumulative += hist.buckets[hist.bounds.len].load(.monotonic);
+    try w.print("{s}_bucket{{le=\"+Inf\"}} {d}\n", .{ name, cumulative });
+
+    const sum_f = @as(f64, @floatFromInt(hist.sum.load(.monotonic))) * scale;
+    try w.print("{s}_sum {d}\n", .{ name, sum_f });
+    try w.print("{s}_count {d}\n\n", .{ name, hist.count.load(.monotonic) });
+}
+
+/// Render a Histogram(N) as a JSON object with cumulative bucket counts.
+/// `scale` converts raw units to display units (1e-9 for ns→s, 1.0 for counts).
+fn writeHistogramJson(w: *std.Io.Writer, name: []const u8, hist: anytype, scale: f64) !void {
+    try w.print("\"{s}\":{{\"count\":{d},\"sum\":{d},\"bounds\":[", .{
+        name,
+        hist.count.load(.monotonic),
+        @as(f64, @floatFromInt(hist.sum.load(.monotonic))) * scale,
+    });
+
+    for (hist.bounds, 0..) |bound, i| {
+        if (i > 0) try w.print(",", .{});
+        try w.print("{d}", .{@as(f64, @floatFromInt(bound)) * scale});
+    }
+
+    try w.print("],\"bucket_counts\":[", .{});
+    var cumulative: u64 = 0;
+    for (hist.bounds, 0..) |_, i| {
+        if (i > 0) try w.print(",", .{});
+        cumulative += hist.buckets[i].load(.monotonic);
+        try w.print("{d}", .{cumulative});
+    }
+    // +Inf bucket (index == bounds.len)
+    cumulative += hist.buckets[hist.bounds.len].load(.monotonic);
+    try w.print(",{d}]}}", .{cumulative});
+}
+
+/// Monotonically increasing lock-free counter.
+/// Safe to add from any thread; use load() to snapshot.
+pub const Counter = struct {
+    value: std.atomic.Value(u64),
+
+    pub fn init() Counter {
+        return .{ .value = std.atomic.Value(u64).init(0) };
+    }
+
+    /// Increment by n. Lock-free; safe from any thread.
+    pub fn add(self: *Counter, n: u64) void {
+        _ = self.value.fetchAdd(n, .monotonic);
+    }
+
+    /// Increment by 1. Convenience wrapper over add(1).
+    pub fn inc(self: *Counter) void {
+        self.add(1);
+    }
+
+    pub fn load(self: *const Counter) u64 {
+        return self.value.load(.monotonic);
+    }
+};
+
+/// Instantaneous gauge — can be set to any u64. Intended for a single
+/// owner (sampler thread); multiple concurrent writers are unsound because
+/// there is no CAS retry and the last store wins non-deterministically.
+pub const Gauge = struct {
+    value: std.atomic.Value(u64),
+
+    pub fn init() Gauge {
+        return .{ .value = std.atomic.Value(u64).init(0) };
+    }
+
+    /// Set to v. Single-owner assumption — see struct doc.
+    pub fn set(self: *Gauge, v: u64) void {
+        self.value.store(v, .monotonic);
+    }
+
+    pub fn load(self: *const Gauge) u64 {
+        return self.value.load(.monotonic);
+    }
+};
+
+/// Fixed-capacity, lock-free cumulative histogram. `N` is the number of finite
+/// upper bounds; there is an implicit `+Inf` bucket, so `buckets.len == N + 1`.
+/// Values are unsigned native units (nanoseconds for latencies, raw counts for
+/// token tallies); the Prometheus renderer applies a scale factor for display.
+pub fn Histogram(comptime N: usize) type {
+    return struct {
+        const Self = @This();
+
+        /// Ascending finite upper bounds, in native units.
+        bounds: [N]u64,
+        /// Per-bucket observation counts. `buckets[i]` counts values in
+        /// `(bounds[i-1], bounds[i]]`; `buckets[N]` is the `+Inf` overflow.
+        buckets: [N + 1]std.atomic.Value(u64),
+        /// Sum of all observed values, native units.
+        sum: std.atomic.Value(u64),
+        /// Total observation count (== sum of all buckets).
+        count: std.atomic.Value(u64),
+
+        pub fn init(bounds: [N]u64) Self {
+            return .{
+                .bounds = bounds,
+                .buckets = [_]std.atomic.Value(u64){std.atomic.Value(u64).init(0)} ** (N + 1),
+                .sum = std.atomic.Value(u64).init(0),
+                .count = std.atomic.Value(u64).init(0),
+            };
+        }
+
+        /// Record one observation. Lock-free; safe from any thread.
+        pub fn observe(self: *Self, v: u64) void {
+            var i: usize = 0;
+            while (i < N and v > self.bounds[i]) : (i += 1) {}
+            _ = self.buckets[i].fetchAdd(1, .monotonic);
+            _ = self.sum.fetchAdd(v, .monotonic);
+            _ = self.count.fetchAdd(1, .monotonic);
+        }
+    };
+}
+
+test "Counter.add accumulates monotonically" {
+    const testing = std.testing;
+    var c = Counter.init();
+    c.add(10);
+    c.add(5);
+    c.inc();
+    try testing.expectEqual(@as(u64, 16), c.load());
+}
+
+test "Gauge.set and load" {
+    const testing = std.testing;
+    var g = Gauge.init();
+    try testing.expectEqual(@as(u64, 0), g.load());
+    g.set(75);
+    try testing.expectEqual(@as(u64, 75), g.load());
+    g.set(0);
+    try testing.expectEqual(@as(u64, 0), g.load());
+}
+
+test "renderPrometheus emits well-formed Prometheus text" {
+    const testing = std.testing;
+    var m = Metrics.init();
+    m.prompt_tokens_total.add(42);
+    m.generation_tokens_total.add(100);
+    m.requests_running.set(3);
+    m.generation_tokens_live.set(137); // 100 completed + 37 in-flight
+    // Observe one 50ms TTFT (50_000_000 ns) — lands in bucket for 50ms le bound
+    m.ttft_ns.observe(50_000_000);
+
+    var buf: [32 * 1024]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try renderPrometheus(&m, &w);
+    const out = buf[0..w.end];
+
+    // Counter TYPE + value line present
+    try testing.expect(std.mem.indexOf(u8, out, "# TYPE vllm:prompt_tokens_total counter") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "vllm:prompt_tokens_total 42") != null);
+    // Gauge TYPE + value line present
+    try testing.expect(std.mem.indexOf(u8, out, "# TYPE vllm:num_requests_running gauge") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "vllm:num_requests_running 3") != null);
+    // Real-time live-token gauge present (drives the dashboard's low-latency tok/s)
+    try testing.expect(std.mem.indexOf(u8, out, "# TYPE mlx_serve:generation_tokens_live gauge") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "mlx_serve:generation_tokens_live 137") != null);
+    // Histogram has _bucket{le="+Inf"}, _sum, _count lines
+    try testing.expect(std.mem.indexOf(u8, out, "vllm:time_to_first_token_seconds_bucket{le=\"+Inf\"}") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "vllm:time_to_first_token_seconds_sum ") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "vllm:time_to_first_token_seconds_count 1") != null);
+}
+
+test "Counter concurrent writes are not lost" {
+    const testing = std.testing;
+    const N_THREADS = 4;
+    const N_ITERS = 10_000;
+    var c = Counter.init();
+
+    const Ctx = struct {
+        counter: *Counter,
+        fn run(ctx: *@This()) void {
+            for (0..N_ITERS) |_| ctx.counter.inc();
+        }
+    };
+
+    var ctxs: [N_THREADS]Ctx = undefined;
+    var threads: [N_THREADS]std.Thread = undefined;
+    for (&ctxs, &threads) |*ctx, *t| {
+        ctx.* = .{ .counter = &c };
+        t.* = try std.Thread.spawn(.{}, Ctx.run, .{ctx});
+    }
+    for (&threads) |*t| t.join();
+    try testing.expectEqual(@as(u64, N_THREADS * N_ITERS), c.load());
+}
+
+test "Metrics.recordRequest increments correct fields on success" {
+    const testing = std.testing;
+    var m = Metrics.init();
+    // real_ttft=60ms (includes 10ms queue wait + 50ms prefill), prefill=50ms, decode=200ms
+    m.recordRequest("stop", 60_000_000, 50_000_000, 200_000_000, 128, 64, 20);
+
+    try testing.expectEqual(@as(u64, 1), m.requests_success_total.load());
+    try testing.expectEqual(@as(u64, 0), m.requests_cancelled_total.load());
+    try testing.expectEqual(@as(u64, 128), m.prompt_tokens_total.load());
+    try testing.expectEqual(@as(u64, 64), m.generation_tokens_total.load());
+    // TTFT histogram got one observation (60ms)
+    try testing.expectEqual(@as(u64, 1), m.ttft_ns.count.load(.monotonic));
+    try testing.expectEqual(@as(u64, 60_000_000), m.ttft_ns.sum.load(.monotonic));
+    // Prefill histogram separately (50ms)
+    try testing.expectEqual(@as(u64, 1), m.prefill_time_ns.count.load(.monotonic));
+    try testing.expectEqual(@as(u64, 50_000_000), m.prefill_time_ns.sum.load(.monotonic));
+    // Decode histogram (200ms)
+    try testing.expectEqual(@as(u64, 1), m.decode_time_ns.count.load(.monotonic));
+    // e2e = real_ttft + decode = 60ms + 200ms = 260ms
+    try testing.expectEqual(@as(u64, 260_000_000), m.e2e_latency_ns.sum.load(.monotonic));
+    // Token histograms
+    try testing.expectEqual(@as(u64, 1), m.prompt_tokens_hist.count.load(.monotonic));
+    try testing.expectEqual(@as(u64, 1), m.output_tokens_hist.count.load(.monotonic));
+    // Cache counters — called with cached_tokens=20, so query+hit both increment
+    try testing.expectEqual(@as(u64, 1), m.prefix_cache_queries_total.load());
+    try testing.expectEqual(@as(u64, 1), m.prefix_cache_hits_total.load());
+}
+
+test "Metrics.recordRequest skips histograms on cancelled request" {
+    const testing = std.testing;
+    var m = Metrics.init();
+    m.recordRequest("cancelled", 50_000_000, 50_000_000, 0, 128, 0, 0);
+
+    try testing.expectEqual(@as(u64, 0), m.requests_success_total.load());
+    try testing.expectEqual(@as(u64, 1), m.requests_cancelled_total.load());
+    // Latency histograms must NOT be touched
+    try testing.expectEqual(@as(u64, 0), m.ttft_ns.count.load(.monotonic));
+    try testing.expectEqual(@as(u64, 0), m.decode_time_ns.count.load(.monotonic));
+    // Token counters also NOT touched on cancel
+    try testing.expectEqual(@as(u64, 0), m.prompt_tokens_total.load());
+    try testing.expectEqual(@as(u64, 0), m.generation_tokens_total.load());
+    // Cache counters ARE touched even on cancel (the cache was still queried)
+    try testing.expectEqual(@as(u64, 1), m.prefix_cache_queries_total.load());
+    // cached_tokens=0 → no hit
+    try testing.expectEqual(@as(u64, 0), m.prefix_cache_hits_total.load());
+}
+
+test "Histogram.observe places values in the correct bucket" {
+    const testing = std.testing;
+    var h = Histogram(3).init(.{ 10, 100, 1000 });
+
+    h.observe(5); // → bucket 0   (<= 10)
+    h.observe(50); // → bucket 1  (<= 100)
+    h.observe(500); // → bucket 2 (<= 1000)
+    h.observe(5000); // → bucket 3 (+Inf overflow)
+    h.observe(10); // → bucket 0  (boundary is inclusive upper)
+
+    try testing.expectEqual(@as(u64, 2), h.buckets[0].load(.monotonic));
+    try testing.expectEqual(@as(u64, 1), h.buckets[1].load(.monotonic));
+    try testing.expectEqual(@as(u64, 1), h.buckets[2].load(.monotonic));
+    try testing.expectEqual(@as(u64, 1), h.buckets[3].load(.monotonic));
+    try testing.expectEqual(@as(u64, 5), h.count.load(.monotonic));
+    try testing.expectEqual(@as(u64, 5565), h.sum.load(.monotonic));
+}
+
+test "renderJson emits valid JSON with correct structure" {
+    const testing = std.testing;
+    var m = Metrics.init();
+    m.requests_success_total.inc();
+    m.prompt_tokens_total.add(100);
+    m.generation_tokens_live.set(55);
+    m.ttft_ns.observe(50_000_000); // 50ms
+
+    var buf: [64 * 1024]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try renderJson(&m, &w);
+    const out = buf[0..w.end];
+
+    // Must be valid-ish JSON (starts { ends })
+    try testing.expect(out[0] == '{');
+    try testing.expect(out[out.len - 1] == '}');
+    // Must contain key structure fields
+    try testing.expect(std.mem.indexOf(u8, out, "\"counters\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"gauges\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"histograms\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"requests_success_total\":1") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"prompt_tokens_total\":100") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"generation_tokens_live\":55") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"time_to_first_token_seconds\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"bucket_counts\"") != null);
+}
+
+test "renderJson output parses as valid JSON via stdlib parser" {
+    const testing = std.testing;
+    // Zero-state (first load): verify sum=0 doesn't produce invalid tokens like 0e0
+    var m0 = Metrics.init();
+    var buf0: [64 * 1024]u8 = undefined;
+    var w0: std.Io.Writer = .fixed(&buf0);
+    try renderJson(&m0, &w0);
+    const out0 = buf0[0..w0.end];
+
+    const parsed0 = try std.json.parseFromSlice(std.json.Value, testing.allocator, out0, .{});
+    defer parsed0.deinit();
+    const obj0 = parsed0.value.object;
+    try testing.expect(obj0.get("counters") != null);
+    try testing.expect(obj0.get("gauges") != null);
+    try testing.expect(obj0.get("histograms") != null);
+
+    // Non-zero state: observe values and re-verify parseability
+    var m1 = Metrics.init();
+    m1.requests_success_total.inc();
+    m1.prompt_tokens_total.add(512);
+    m1.ttft_ns.observe(50_000_000); // 50ms
+    m1.gpu_utilization_pct.set(42);
+
+    var buf1: [64 * 1024]u8 = undefined;
+    var w1: std.Io.Writer = .fixed(&buf1);
+    try renderJson(&m1, &w1);
+    const out1 = buf1[0..w1.end];
+
+    const parsed1 = try std.json.parseFromSlice(std.json.Value, testing.allocator, out1, .{});
+    defer parsed1.deinit();
+    const obj1 = parsed1.value.object;
+    try testing.expect(obj1.get("counters") != null);
+    // Verify counters sub-object has expected key
+    const counters = obj1.get("counters").?.object;
+    try testing.expectEqual(@as(i64, 1), counters.get("requests_success_total").?.integer);
+}

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -43,6 +43,7 @@ const model_mod = @import("model.zig");
 const vision_mod = @import("vision.zig");
 const chat_mod = @import("chat.zig");
 const prefix_cache_mod = @import("prefix_cache.zig");
+const metrics_mod = @import("metrics.zig");
 const tokenize_cache_mod = @import("tokenize_cache.zig");
 const model_registry_mod = @import("model_registry.zig");
 const arch_ds4 = @import("arch/ds4.zig");
@@ -173,6 +174,9 @@ pub const LoadParams = struct {
     /// installs it on the entry's `llama_engine` field. Mutually exclusive with
     /// `ds4_path` and the MLX safetensors path.
     llama_path: []const u8 = "",
+    /// Optional metrics sink. Null when --metrics is off (the default).
+    /// Passed to `Scheduler.init` which stores it for the inference thread.
+    metrics: ?*metrics_mod.Metrics = null,
 };
 
 /// Submit-time parameters. `prompt_ids` and `eos_token_ids` are duped into the
@@ -346,6 +350,9 @@ pub const Slot = struct {
     completion_tokens: u32,
     prefill_tps: f64,
     decode_tps: f64,
+    /// Monotonic timestamp captured in Slot.init (before queue wait). Used
+    /// to compute real TTFT = (start→first-token) = total_elapsed − decode_ns.
+    request_start_ts: std.Io.Timestamp,
     /// Wall-clock nanoseconds spent in `runPrefill` for this slot. Includes
     /// hot-prefix-cache lookup/restore and the model forward over the
     /// uncached tail. Populated by the scheduler main loop.
@@ -488,6 +495,7 @@ pub const Slot = struct {
             .completion_tokens = 0,
             .prefill_tps = 0.0,
             .decode_tps = 0.0,
+            .request_start_ts = std.Io.Timestamp.now(io, .boot),
             .prefill_ns = 0,
             .decode_ns = 0,
             .generated_ids = null,
@@ -919,6 +927,8 @@ pub const Scheduler = struct {
     /// inference thread drains this queue between ticks where it owns the
     /// stream binding, so all mlx ops stay on one thread.
     cleanup_queue: std.ArrayList(*Slot),
+    /// Metrics sink. Null when --metrics is off. Populated from LoadParams.
+    metrics: ?*metrics_mod.Metrics,
     /// Counts `pending.len + decoding.len` for back-pressure.
     in_flight: u32,
     /// Capacity for back-pressure. `submit` waits when in_flight >= cap.
@@ -933,6 +943,10 @@ pub const Scheduler = struct {
 
     inference_thread: ?std.Thread,
     shutdown: std.atomic.Value(bool),
+    /// Set by the HTTP admin thread to request prefix-cache eviction on the
+    /// next scheduling cycle. Cleared by the inference thread after handling.
+    /// Safe: written from conn thread, read from inference thread via atomics.
+    evict_cache_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     started: std.atomic.Value(bool),
     started_mu: std.Io.Mutex,
     started_cond: std.Io.Condition,
@@ -1001,6 +1015,7 @@ pub const Scheduler = struct {
             .embed_queue = std.ArrayList(*EmbedRequest).empty,
             .load_queue = std.ArrayList(*LoadRequest).empty,
             .cleanup_queue = std.ArrayList(*Slot).empty,
+            .metrics = params.metrics,
             .in_flight = 0,
             .queue_cap = cap + 32,
             .submit_cond = .init,
@@ -1494,6 +1509,16 @@ pub const Scheduler = struct {
         if (slot.model.ds4_engine != null or slot.model.llama_engine != null) return false;
         const cfg = slot.model.config orelse return false;
         return modelBatchable(cfg);
+    }
+
+    /// Called from the HTTP admin conn thread to request async prefix-cache eviction.
+    /// The inference thread processes it at the next scheduling cycle.
+    /// Thread-safe: the flag write is atomic; queue_cond wakes the sleeping thread.
+    pub fn requestCacheEviction(self: *Scheduler) void {
+        self.evict_cache_requested.store(true, .release);
+        self.queue_mu.lockUncancelable(self.io);
+        defer self.queue_mu.unlock(self.io);
+        self.queue_cond.broadcast(self.io);
     }
 };
 
@@ -2247,10 +2272,15 @@ fn inferenceLoop(ctx: ThreadCtx) void {
         {
             sch.queue_mu.lockUncancelable(sch.io);
             defer sch.queue_mu.unlock(sch.io);
-            while (sch.pending.items.len == 0 and sch.decoding.items.len == 0 and sch.vision_queue.items.len == 0 and sch.embed_queue.items.len == 0 and sch.cleanup_queue.items.len == 0 and sch.load_queue.items.len == 0 and !sch.shutdown.load(.acquire)) {
+            while (sch.pending.items.len == 0 and sch.decoding.items.len == 0 and sch.vision_queue.items.len == 0 and sch.embed_queue.items.len == 0 and sch.cleanup_queue.items.len == 0 and sch.load_queue.items.len == 0 and !sch.evict_cache_requested.load(.acquire) and !sch.shutdown.load(.acquire)) {
                 sch.queue_cond.waitUncancelable(sch.io, &sch.queue_mu);
             }
             if (sch.shutdown.load(.acquire)) break;
+
+            // Admin: prefix-cache eviction requested externally.
+            if (sch.evict_cache_requested.swap(false, .acq_rel)) {
+                if (sch.hot_prefix_cache) |hc| hc.invalidateAll("admin request");
+            }
 
             // If only vision/embed/cleanup/load work is pending, loop back to drain it.
             if (sch.pending.items.len == 0 and sch.decoding.items.len == 0) continue;
@@ -2267,7 +2297,7 @@ fn inferenceLoop(ctx: ThreadCtx) void {
         if (n_prefill > 0) {
             for (to_prefill[0..n_prefill]) |slot| {
                 if (slot.cancelled.load(.acquire)) {
-                    slot.markFinished("cancelled");
+                    finishSlot(sch, slot, "cancelled");
                     continue;
                 }
                 var prefill_sw = io_util.Stopwatch.init(sch.io);
@@ -2277,7 +2307,7 @@ fn inferenceLoop(ctx: ThreadCtx) void {
                         // an idle keepalive probe and set slot.cancelled);
                         // the chunk loop aborted. A clean finish, not an error.
                         log.info("[scheduler] prefill aborted: client disconnected\n", .{});
-                        slot.markFinished("cancelled");
+                        finishSlot(sch, slot, "cancelled");
                         continue;
                     }
                     log.err("[scheduler] prefill failed for slot: {s}\n", .{@errorName(err)});
@@ -2626,6 +2656,30 @@ fn finishSlot(sch: *Scheduler, slot: *Slot, reason: []const u8) void {
     // finalize here instead.
     if (slot.legacy_gen) |*g| g.logSpecStats();
     commitSlotIfApplicable(sch, slot);
+    // Record per-request metrics while slot fields are still live (before
+    // markFinished broadcasts — conn thread may call deinit immediately after).
+    if (sch.metrics) |m| {
+        // Real TTFT = time from request arrival (Slot.init, pre-queue-wait) to
+        // first token = total_elapsed − decode_ns.  For single-user servers
+        // queue wait is 0, so this equals prefill_ns; for concurrent traffic
+        // it correctly includes queue latency.
+        const total_elapsed_ns: u64 = @intCast(
+            slot.request_start_ts.untilNow(sch.io, .boot).nanoseconds,
+        );
+        const real_ttft_ns = if (total_elapsed_ns > slot.decode_ns)
+            total_elapsed_ns - slot.decode_ns
+        else
+            slot.prefill_ns; // fallback: shouldn't happen, but don't go negative
+        m.recordRequest(
+            reason,
+            real_ttft_ns,
+            slot.prefill_ns,
+            slot.decode_ns,
+            slot.prompt_tokens,
+            slot.completion_tokens,
+            slot.cached_tokens,
+        );
+    }
     slot.markFinished(reason);
 }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -23,6 +23,7 @@ const arch_llama = @import("arch/llama.zig");
 const stb = @cImport({ @cInclude("stb_image.h"); });
 const webp = @cImport({ @cInclude("webp/decode.h"); });
 const metrics = @import("status.zig");
+const instr = @import("metrics.zig");
 
 const Transformer = transformer_mod.Transformer;
 const Tokenizer = tokenizer_mod.Tokenizer;
@@ -38,6 +39,11 @@ var shutdown_requested = std.atomic.Value(bool).init(false);
 /// detached conn thread still in `Scheduler.complete` would otherwise race
 /// deinit's teardown of the slot queues into a use-after-free (SIGSEGV).
 var active_conn_threads = std.atomic.Value(u32).init(0);
+/// Set from main.zig before serve() is called when --metrics is on.
+pub var g_metrics: ?*instr.Metrics = null;
+/// Optional admin API bearer token. If null, all admin POST endpoints are open.
+/// Set via --admin-key CLI flag.
+pub var g_admin_key: ?[]const u8 = null;
 
 const io_util = @import("io_util.zig");
 const ws_mod = @import("ws.zig");
@@ -622,6 +628,26 @@ pub fn serve(
     defer scheduler.deinit();
     global_scheduler = scheduler;
     defer global_scheduler = null;
+    // Gauge sampler: samples instantaneous system state every 2 s and
+    // writes to the metrics gauges. Only runs when --metrics is on.
+    // LIFO defer ordering: `stop` must be registered AFTER `join` so it runs
+    // FIRST (setting the flag), allowing the thread to exit before join() blocks.
+    // Do NOT check scheduler.shutdown here — deinit() (which sets that flag) is
+    // registered as the earliest defer and runs last, after the join.
+    var sampler_thread: ?std.Thread = null;
+    var sampler_stop = std.atomic.Value(bool).init(false);
+    if (g_metrics) |m| {
+        const ctx = GaugeSamplerCtx{
+            .metrics = m,
+            .scheduler = scheduler,
+            .stop = &sampler_stop,
+        };
+        sampler_thread = try std.Thread.spawn(.{}, gaugeSamplerLoop, .{ctx});
+        log.info("Prometheus metrics: ENABLED — GET http://{s}:{d}/metrics\n", .{ host, port });
+    }
+    // LIFO: join deferred first → runs second. stop deferred second → runs first.
+    defer if (sampler_thread) |t| t.join();
+    defer sampler_stop.store(true, .monotonic);
     global_registry = scheduler.registry;
     defer global_registry = null;
 
@@ -957,6 +983,54 @@ fn handleConnection(
     if (std.mem.eql(u8, method, "GET") and std.mem.eql(u8, path, "/health")) {
         log.debug("GET  /health -> 200\n", .{});
         try sendResponse(stream, "200 OK", "application/json", "{\"status\":\"ok\"}");
+        return;
+    }
+    if (std.mem.eql(u8, method, "GET") and std.mem.eql(u8, path, "/metrics")) {
+        if (g_metrics) |m| {
+            log.debug("GET  /metrics -> 200\n", .{});
+            var out: std.Io.Writer.Allocating = .init(allocator);
+            defer out.deinit();
+            try instr.renderPrometheus(m, &out.writer);
+            try sendResponse(stream, "200 OK", "text/plain; version=0.0.4; charset=utf-8", out.written());
+        } else {
+            try sendResponse(stream, "503 Service Unavailable", "text/plain", "metrics not enabled (start with --metrics)");
+        }
+        return;
+    }
+    // GET /admin — self-contained web dashboard (zero deps, polls /admin/metrics.json)
+    if (std.mem.eql(u8, method, "GET") and std.mem.eql(u8, path, "/admin")) {
+        const html = @embedFile("admin_dashboard.html");
+        try sendResponse(stream, "200 OK", "text/html; charset=utf-8", html);
+        return;
+    }
+    if (std.mem.eql(u8, method, "GET") and std.mem.eql(u8, path, "/admin/metrics.json")) {
+        if (g_metrics) |m| {
+            log.debug("GET  /admin/metrics.json -> 200\n", .{});
+            var out: std.Io.Writer.Allocating = .init(allocator);
+            defer out.deinit();
+            try instr.renderJson(m, &out.writer);
+            try sendResponse(stream, "200 OK", "application/json", out.written());
+        } else {
+            try sendResponse(stream, "503 Service Unavailable", "application/json",
+                "{\"error\":\"metrics not enabled — start with --metrics\"}");
+        }
+        return;
+    }
+    if (std.mem.eql(u8, method, "POST") and std.mem.eql(u8, path, "/admin/evict-prefix-cache")) {
+        const raw_headers = request[0..header_end_pos];
+        const auth_hdr = findHeader(raw_headers, "authorization");
+        if (!checkAdminAuth(auth_hdr)) {
+            try sendResponse(stream, "401 Unauthorized", "application/json",
+                "{\"error\":\"unauthorized — provide Authorization: Bearer <admin-key>\"}");
+            return;
+        }
+        const sch = global_scheduler orelse {
+            try sendResponse(stream, "503 Service Unavailable", "application/json",
+                "{\"error\":\"scheduler not ready\"}");
+            return;
+        };
+        sch.requestCacheEviction();
+        try sendResponse(stream, "200 OK", "application/json", "{\"ok\":true}");
         return;
     }
     if (std.mem.eql(u8, method, "OPTIONS")) {
@@ -1897,6 +1971,7 @@ fn handleStatusPage(
         \\<div class=row><span class=k>GPU memory</span><span class=v>{d} MB active · {d} MB peak</span></div>
         \\<div class=caps>{s}</div>
         \\</div>
+        \\<div style="margin:6px 0 28px"><a href=/admin style="display:inline-block;background:#1c2e57;color:#86b8ff;border:1px solid #1f3a5f;border-radius:8px;padding:10px 18px;font-weight:600;text-decoration:none">&#128202; Real-Time Model Metrics &rarr;</a></div>
         \\
         \\<h2>OpenAI Chat Completions</h2>
         \\<div class=card>
@@ -1930,6 +2005,8 @@ fn handleStatusPage(
         \\<div class=ep><span class="m get">GET</span><div><div class=p><a href=/v1/models>/v1/models</a></div><div class=d>OpenAI models list (id, capabilities, context length)</div></div></div>
         \\<div class=ep><span class="m get">GET</span><div><div class=p><a href=/props>/props</a></div><div class=d>llama.cpp-style server props (chat template, memory)</div></div></div>
         \\<div class=ep><span class="m get">GET</span><div><div class=p><a href=/health>/health</a></div><div class=d>Liveness probe</div></div></div>
+        \\<div class=ep><span class="m get">GET</span><div><div class=p><a href=/admin>/admin</a></div><div class=d>Real-time model metrics dashboard (throughput, latency, GPU, memory)</div></div></div>
+        \\<div class=ep><span class="m get">GET</span><div><div class=p><a href=/metrics>/metrics</a></div><div class=d>Prometheus metrics (text exposition format)</div></div></div>
         \\</div>
         \\
         \\<h2>Quick start</h2>
@@ -4702,6 +4779,48 @@ fn logHttpBody(label: []const u8, body: []const u8) void {
         body.len,
         body,
     });
+}
+
+/// Find the value of a named HTTP header in the raw header block.
+/// `name` must be lowercase (e.g. "authorization"). Case-insensitive compare.
+/// Returns null if the header is absent.
+fn findHeader(headers: []const u8, name: []const u8) ?[]const u8 {
+    var lines = std.mem.splitSequence(u8, headers, "\r\n");
+    while (lines.next()) |line| {
+        if (line.len <= name.len + 1) continue;
+        // Check prefix match case-insensitively up to the colon.
+        var match = true;
+        for (0..name.len) |j| {
+            if (std.ascii.toLower(line[j]) != name[j]) {
+                match = false;
+                break;
+            }
+        }
+        if (!match) continue;
+        if (line[name.len] != ':') continue;
+        const rest = line[name.len + 1 ..];
+        return std.mem.trim(u8, rest, " \t");
+    }
+    return null;
+}
+
+/// Constant-time string compare — prevents timing-oracle key guessing.
+fn timingSafeEql(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    var diff: u8 = 0;
+    for (a, b) |x, y| diff |= x ^ y;
+    return diff == 0;
+}
+
+/// Returns true if the request is authorized for admin mutating actions.
+/// If no admin key is configured (g_admin_key == null), all requests pass.
+/// `auth_header` is the value of the "Authorization" header (or null).
+fn checkAdminAuth(auth_header: ?[]const u8) bool {
+    const key = g_admin_key orelse return true; // open mode
+    const hdr = auth_header orelse return false;
+    const prefix = "Bearer ";
+    if (!std.mem.startsWith(u8, hdr, prefix)) return false;
+    return timingSafeEql(hdr[prefix.len..], key);
 }
 
 fn findContentLength(headers: []const u8) ?usize {
@@ -9356,6 +9475,70 @@ test "utf8TrailingIncomplete partial after complete" {
 
 test "utf8TrailingIncomplete empty" {
     try testing.expectEqual(@as(usize, 0), utf8TrailingIncomplete(""));
+}
+
+const GaugeSamplerCtx = struct {
+    metrics: *instr.Metrics,
+    scheduler: *scheduler_mod.Scheduler,
+    /// Dedicated stop flag — set before joining the thread (LIFO defers ensure
+    /// this is written before join() blocks). Using a separate flag rather than
+    /// scheduler.shutdown avoids a LIFO deadlock: scheduler.deinit() (which sets
+    /// shutdown) is registered as the FIRST defer and therefore runs LAST, but
+    /// the join defer runs BEFORE it, so the loop would never see shutdown=true.
+    stop: *std.atomic.Value(bool),
+};
+
+/// Background thread: samples system gauges every 2 s.
+/// Exits when ctx.stop is set to true (see GaugeSamplerCtx.stop comment).
+/// Sample instantaneous system/queue state into the gauges. Non-blocking
+/// syscalls plus a brief scheduler-counter lock. Called by the sampler thread.
+fn sampleGauges(ctx: GaugeSamplerCtx) void {
+    // System gauges (non-blocking syscalls).
+    ctx.metrics.gpu_utilization_pct.set(@as(u64, metrics.getGpuPct()));
+    ctx.metrics.memory_mb.set(@as(u64, metrics.getAppMemFootprintMb()));
+
+    // Request queue depth + in-flight token progress — brief lock to read
+    // scheduler counters. `decoding` is guarded by queue_mu (slots are inserted
+    // / removed under it), so the slot pointers stay valid for the read; each
+    // slot's `completion_tokens` is a monotonic aligned u32 the inference thread
+    // bumps live, so an off-thread read is at worst a tick stale — exactly right
+    // for an approximate gauge, and it keeps the per-token decode path lock-free.
+    ctx.scheduler.queue_mu.lockUncancelable(ctx.scheduler.io);
+    const running = @as(u64, ctx.scheduler.in_flight);
+    const waiting = @as(u64, ctx.scheduler.pending.items.len);
+    var in_progress: u64 = 0;
+    for (ctx.scheduler.decoding.items) |slot| in_progress += @as(u64, slot.completion_tokens);
+    ctx.scheduler.queue_mu.unlock(ctx.scheduler.io);
+    ctx.metrics.requests_running.set(running);
+    ctx.metrics.requests_waiting.set(waiting);
+    // Real-time throughput source: completed generation tokens plus tokens
+    // generated so far by still-decoding slots. The dashboard derives a live
+    // tok/s from this gauge over a short window — non-zero even mid-request,
+    // unlike the completion-only counter which only moves when a request ends.
+    ctx.metrics.generation_tokens_live.set(ctx.metrics.generation_tokens_total.load() + in_progress);
+}
+
+fn gaugeSamplerLoop(ctx: GaugeSamplerCtx) void {
+    // Wake every 500 ms to check the stop flag; sample system state
+    // once per 2-second interval. The faster cadence (was 15 s) is what makes
+    // generation_tokens_live a real-time tok/s source — the dashboard windows
+    // over a few of these samples. Cost is trivial: a few non-blocking syscalls
+    // and one brief scheduler-counter lock every 2 s, never on the decode path.
+    // Uses std.c.nanosleep (POSIX) because std.time.sleep was removed in Zig
+    // 0.16 — this thread has no Io handle.
+    const SAMPLE_INTERVAL_TICKS: u64 = 4; // 4 × 500 ms = 2 s
+    const poll_ts = std.c.timespec{ .sec = 0, .nsec = 500_000_000 };
+    // Sample once immediately so the dashboard / Grafana show real values from
+    // the first scrape instead of zeros for the first interval.
+    sampleGauges(ctx);
+    var tick: u64 = 0;
+    while (!ctx.stop.load(.monotonic)) {
+        _ = std.c.nanosleep(&poll_ts, null);
+        tick += 1;
+        if (tick < SAMPLE_INTERVAL_TICKS) continue;
+        tick = 0;
+        sampleGauges(ctx);
+    }
 }
 
 test "parseJsonFloat returns value when present" {

--- a/src/status.zig
+++ b/src/status.zig
@@ -36,6 +36,32 @@ const TaskBasicInfo = extern struct {
     suspend_count: i32,
 };
 
+/// task_vm_info truncated through phys_footprint (rev1). Field order matches
+/// <mach/task_info.h> exactly; @sizeOf/@sizeOf(i32) == 38 == TASK_VM_INFO_REV1_COUNT,
+/// so the kernel fills through phys_footprint without overrunning the buffer.
+const TaskVmInfo = extern struct {
+    virtual_size: u64,
+    region_count: i32,
+    page_size: i32,
+    resident_size: u64,
+    resident_size_peak: u64,
+    device: u64,
+    device_peak: u64,
+    internal: u64,
+    internal_peak: u64,
+    external: u64,
+    external_peak: u64,
+    reusable: u64,
+    reusable_peak: u64,
+    purgeable_volatile_pmap: u64,
+    purgeable_volatile_resident: u64,
+    purgeable_volatile_virtual: u64,
+    compressed: u64,
+    compressed_peak: u64,
+    compressed_lifetime: u64,
+    phys_footprint: u64,
+};
+
 const CpuLoadInfo = extern struct {
     ticks: [4]u32, // user, system, idle, nice
 };
@@ -77,6 +103,16 @@ pub fn getAppRssMb() u32 {
     var count: u32 = @sizeOf(TaskBasicInfo) / @sizeOf(i32);
     if (task_info(mach_task_self_, 20, @ptrCast(&info), &count) != 0) return 0;
     return @intCast(info.resident_size / (1024 * 1024));
+}
+
+/// Process physical memory footprint in MB (TASK_VM_INFO flavor 22). Unlike
+/// resident_size, this includes MLX's Metal/IOKit + compressed memory — the
+/// only figure that reflects a loaded model's true footprint on Apple Silicon.
+pub fn getAppMemFootprintMb() u32 {
+    var info = std.mem.zeroes(TaskVmInfo);
+    var count: u32 = @sizeOf(TaskVmInfo) / @sizeOf(i32); // 38 = TASK_VM_INFO_REV1_COUNT
+    if (task_info(mach_task_self_, 22, @ptrCast(&info), &count) != 0) return 0;
+    return @intCast(info.phys_footprint / (1024 * 1024));
 }
 
 /// Bytes of physical memory available for new allocation without heavy
@@ -200,4 +236,12 @@ fn cfDictGet(dict: ?*const anyopaque, key_name: [*:0]const u8) ?*const anyopaque
     const key = CFStringCreateWithCString(null, key_name, 0x08000100) orelse return null;
     defer CFRelease(key);
     return CFDictionaryGetValue(dict, key);
+}
+
+test "getAppMemFootprintMb returns a plausible nonzero footprint" {
+    const fp = getAppMemFootprintMb();
+    // The test process itself footprints several MB; a wrong flavor/offset
+    // would yield 0 or absurd garbage.
+    try std.testing.expect(fp > 0);
+    try std.testing.expect(fp < 1024 * 1024); // < 1 TB sanity bound
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -25,6 +25,8 @@ test {
     _ = @import("diffusion.zig");
     _ = @import("tokenizer.zig");
     _ = @import("prefix_cache.zig");
+    _ = @import("metrics.zig");
+    _ = @import("status.zig");
     _ = @import("model_discovery.zig");
     _ = @import("gguf_meta.zig");
     _ = @import("model_registry.zig");

--- a/tests/test_admin_api.sh
+++ b/tests/test_admin_api.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Integration tests for the JSON admin API.
+#
+# Tests:
+#  1. GET /admin/metrics.json without --metrics → 503
+#  2. GET /admin/metrics.json with --metrics → 200 + valid JSON
+#  3. POST /admin/evict-prefix-cache without --admin-key → 200 (open mode)
+#  4. POST /admin/evict-prefix-cache with --admin-key, no auth header → 401
+#  5. POST /admin/evict-prefix-cache with wrong key → 401
+#  6. POST /admin/evict-prefix-cache with correct key → 200 {"ok":true}
+#
+# Usage: ./tests/test_admin_api.sh [model_dir] [port]
+
+set -u
+
+MODEL="${1:-$HOME/.mlx-serve/models/gemma-4-e4b-it-8bit}"
+PORT="${2:-11292}"
+BASE="http://127.0.0.1:$PORT"
+BINARY="${BINARY:-./zig-out/bin/mlx-serve}"
+LOG=/tmp/test_admin_api.log
+PASS=0
+FAIL=0
+ADMIN_KEY="test-secret-key-123"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+check() {
+    local desc="$1" ok="$2"
+    if [ "$ok" = "1" ]; then
+        PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $desc"
+    else
+        FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $desc"
+    fi
+}
+
+if [ ! -d "$MODEL" ]; then
+    echo "SKIP: model dir not found: $MODEL"
+    exit 0
+fi
+
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
+sleep 1
+
+wait_health() {
+    for _ in $(seq 1 90); do
+        curl -sf "$BASE/health" >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    echo "FAIL: server never became healthy on port $PORT"
+    return 1
+}
+
+# ── Phase 1: without --metrics, GET /admin/metrics.json returns 503 ──────────
+echo ""
+echo "── Phase 1: without --metrics ──"
+"$BINARY" --model "$MODEL" --serve --port "$PORT" --no-pld --log-level warn > "$LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+wait_health
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/admin/metrics.json")
+check "GET /admin/metrics.json without --metrics → 503" "$([ "$STATUS" = "503" ] && echo 1 || echo 0)"
+
+kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true; sleep 1
+
+# ── Phase 2: with --metrics, JSON endpoint works ─────────────────────────────
+echo ""
+echo "── Phase 2: GET /admin/metrics.json with --metrics ──"
+"$BINARY" --model "$MODEL" --serve --port "$PORT" --metrics --no-pld --log-level warn > "$LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+wait_health
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/admin/metrics.json")
+check "GET /admin/metrics.json → 200" "$([ "$STATUS" = "200" ] && echo 1 || echo 0)"
+
+CT=$(curl -s -D - -o /dev/null "$BASE/admin/metrics.json" | grep -i "^content-type:" | tr -d '\r')
+check "Content-Type is application/json" "$(echo "$CT" | grep -q "application/json" && echo 1 || echo 0)"
+
+BODY=$(curl -s "$BASE/admin/metrics.json")
+check "JSON has 'counters' key" "$(echo "$BODY" | grep -q '"counters"' && echo 1 || echo 0)"
+check "JSON has 'gauges' key" "$(echo "$BODY" | grep -q '"gauges"' && echo 1 || echo 0)"
+check "JSON has 'histograms' key" "$(echo "$BODY" | grep -q '"histograms"' && echo 1 || echo 0)"
+check "JSON has 'time_to_first_token_seconds'" \
+    "$(echo "$BODY" | grep -q '"time_to_first_token_seconds"' && echo 1 || echo 0)"
+check "JSON has 'bucket_counts'" "$(echo "$BODY" | grep -q '"bucket_counts"' && echo 1 || echo 0)"
+
+# Evict in open mode (no --admin-key)
+EVICT=$(curl -s -X POST "$BASE/admin/evict-prefix-cache")
+EVICT_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/admin/evict-prefix-cache")
+check "POST /admin/evict-prefix-cache open mode → 200" "$([ "$EVICT_STATUS" = "200" ] && echo 1 || echo 0)"
+check "evict response has 'ok'" "$(echo "$EVICT" | grep -q '"ok"' && echo 1 || echo 0)"
+
+# Dashboard (served regardless of --metrics; degrades gracefully without it)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/admin")
+check "GET /admin returns 200" "$([ "$STATUS" = "200" ] && echo 1 || echo 0)"
+
+CT=$(curl -s -D - -o /dev/null "$BASE/admin" | grep -i "^content-type:" | tr -d '\r')
+check "GET /admin Content-Type is text/html" "$(echo "$CT" | grep -qi "text/html" && echo 1 || echo 0)"
+
+DASH=$(curl -s "$BASE/admin")
+check "Dashboard has stat panel elements" "$(echo "$DASH" | grep -q 'id="req-rate"' && echo "$DASH" | grep -q 'id="gpu-pct"' && echo 1 || echo 0)"
+check "Dashboard has Grafana config section" "$(echo "$DASH" | grep -q 'prom-cfg' && echo 1 || echo 0)"
+
+kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true; sleep 1
+
+# ── Phase 3: with --admin-key, auth is enforced ───────────────────────────────
+echo ""
+echo "── Phase 3: --admin-key auth enforcement ──"
+"$BINARY" --model "$MODEL" --serve --port "$PORT" --metrics --admin-key "$ADMIN_KEY" \
+    --no-pld --log-level warn > "$LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+wait_health
+
+# GET /admin/metrics.json should NOT require auth (read-only)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/admin/metrics.json")
+check "GET /admin/metrics.json requires no auth" "$([ "$STATUS" = "200" ] && echo 1 || echo 0)"
+
+# POST without any auth header → 401
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/admin/evict-prefix-cache")
+check "POST evict without auth header → 401" "$([ "$STATUS" = "401" ] && echo 1 || echo 0)"
+
+# POST with wrong key → 401
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    -H "Authorization: Bearer wrong-key" "$BASE/admin/evict-prefix-cache")
+check "POST evict with wrong key → 401" "$([ "$STATUS" = "401" ] && echo 1 || echo 0)"
+
+# POST with correct key → 200
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+    -H "Authorization: Bearer $ADMIN_KEY" "$BASE/admin/evict-prefix-cache")
+EVICT=$(curl -s -X POST -H "Authorization: Bearer $ADMIN_KEY" "$BASE/admin/evict-prefix-cache")
+check "POST evict with correct key → 200" "$([ "$STATUS" = "200" ] && echo 1 || echo 0)"
+check "evict response has 'ok':true" "$(echo "$EVICT" | grep -q '"ok":true' && echo 1 || echo 0)"
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+    echo -e "${GREEN}PASS${NC} $TOTAL/$TOTAL tests passed"
+    exit 0
+else
+    echo -e "${RED}FAIL${NC} $FAIL/$TOTAL tests failed"
+    echo ""
+    echo "--- Server log (last 20 lines) ---"
+    tail -20 "$LOG" 2>/dev/null || true
+    exit 1
+fi

--- a/tests/test_metrics.sh
+++ b/tests/test_metrics.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# Integration tests for the Prometheus metrics endpoint (GET /metrics).
+#
+# Tests:
+#  1. Without --metrics: GET /metrics → 503
+#  2. With    --metrics: GET /metrics → 200 + valid Prometheus text format
+#  3. After one chat request: request_success_total=1, latency histograms present
+#  4. Content-Type header is the correct Prometheus MIME type
+#
+# Usage: ./tests/test_metrics.sh [model_dir] [port]
+#   Starts its own servers. Default model: Gemma 4 E4B 8-bit.
+
+set -u
+
+MODEL="${1:-$HOME/.mlx-serve/models/gemma-4-e4b-it-8bit}"
+PORT="${2:-11291}"
+BASE="http://127.0.0.1:$PORT"
+BINARY="${BINARY:-./zig-out/bin/mlx-serve}"
+LOG=/tmp/test_metrics.log
+PASS=0
+FAIL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+check() {
+    local desc="$1" ok="$2"
+    if [ "$ok" = "1" ]; then
+        PASS=$((PASS + 1)); echo -e "  ${GREEN}PASS${NC} $desc"
+    else
+        FAIL=$((FAIL + 1)); echo -e "  ${RED}FAIL${NC} $desc"
+    fi
+}
+
+if [ ! -d "$MODEL" ]; then
+    echo "SKIP: model dir not found: $MODEL (set MODEL_DIR or pass as first arg)"
+    exit 0
+fi
+
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
+sleep 1
+
+# ── Helper: wait for /health ──────────────────────────────────────────────
+wait_health() {
+    for _ in $(seq 1 90); do
+        curl -sf "$BASE/health" >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    echo "FAIL: server never became healthy on port $PORT"
+    return 1
+}
+
+# ════════════════════════════════════════════════════════════════════════════
+# Test 1: Without --metrics, GET /metrics returns 503
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── Phase 1: without --metrics ──"
+
+"$BINARY" --model "$MODEL" --serve --port "$PORT" --no-pld --log-level warn > "$LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+
+wait_health
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/metrics")
+check "GET /metrics without --metrics returns 503" "$([ "$STATUS" = "503" ] && echo 1 || echo 0)"
+
+BODY=$(curl -s "$BASE/metrics")
+check "503 body mentions 'not enabled'" "$(echo "$BODY" | grep -q "not enabled" && echo 1 || echo 0)"
+
+kill "$SERVER_PID" 2>/dev/null
+wait "$SERVER_PID" 2>/dev/null || true
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
+sleep 1
+
+# ════════════════════════════════════════════════════════════════════════════
+# Test 2: With --metrics, GET /metrics returns 200 + valid Prometheus text
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── Phase 2: with --metrics (idle — no requests yet) ──"
+
+# Use --log-level info so the "Prometheus metrics: ENABLED" startup message is
+# visible (log.info is suppressed at --log-level warn).
+"$BINARY" --model "$MODEL" --serve --port "$PORT" --metrics --no-pld --log-level info > "$LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+
+wait_health
+
+# Check startup log mentions metrics
+check "startup log: 'Prometheus metrics: ENABLED'" \
+    "$(grep -q "Prometheus metrics: ENABLED" "$LOG" && echo 1 || echo 0)"
+
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/metrics")
+check "GET /metrics with --metrics returns 200" "$([ "$STATUS" = "200" ] && echo 1 || echo 0)"
+
+# Content-Type must be the Prometheus text format MIME type.
+# Use -D - (dump headers to stdout) + -o /dev/null (discard body) via GET —
+# avoid `curl -I` (HEAD) because the server only routes GET to /metrics.
+CT=$(curl -s -D - -o /dev/null "$BASE/metrics" | grep -i "^content-type:" | tr -d '\r')
+check "Content-Type is Prometheus text MIME" \
+    "$(echo "$CT" | grep -q "text/plain" && echo "$CT" | grep -q "version=0.0.4" && echo 1 || echo 0)"
+
+BODY=$(curl -s "$BASE/metrics")
+
+# Must have counter and histogram HELP/TYPE lines
+check "# HELP vllm:prompt_tokens_total present" \
+    "$(echo "$BODY" | grep -q "# HELP vllm:prompt_tokens_total" && echo 1 || echo 0)"
+check "# TYPE vllm:prompt_tokens_total counter" \
+    "$(echo "$BODY" | grep -q "# TYPE vllm:prompt_tokens_total counter" && echo 1 || echo 0)"
+check "# TYPE vllm:time_to_first_token_seconds histogram" \
+    "$(echo "$BODY" | grep -q "# TYPE vllm:time_to_first_token_seconds histogram" && echo 1 || echo 0)"
+check "TTFT +Inf bucket present" \
+    "$(echo "$BODY" | grep -q 'vllm:time_to_first_token_seconds_bucket{le="+Inf"}' && echo 1 || echo 0)"
+check "vllm:num_requests_running gauge present" \
+    "$(echo "$BODY" | grep -q "# TYPE vllm:num_requests_running gauge" && echo 1 || echo 0)"
+check "mlx_serve:gpu_utilization_pct gauge present" \
+    "$(echo "$BODY" | grep -q "mlx_serve:gpu_utilization_pct" && echo 1 || echo 0)"
+check "mlx_serve:memory_mb gauge present (TYPE line)" \
+    "$(echo "$BODY" | grep -q "# TYPE mlx_serve:memory_mb gauge" && echo 1 || echo 0)"
+check "mlx_serve:generation_tokens_live gauge present (TYPE line)" \
+    "$(echo "$BODY" | grep -q "# TYPE mlx_serve:generation_tokens_live gauge" && echo 1 || echo 0)"
+
+# All counters must be 0 before any requests
+check "request_success_total is 0 before any requests" \
+    "$(echo "$BODY" | grep "^vllm:request_success_total " | grep -q " 0$" && echo 1 || echo 0)"
+check "prompt_tokens_total is 0 before any requests" \
+    "$(echo "$BODY" | grep "^vllm:prompt_tokens_total " | grep -q " 0$" && echo 1 || echo 0)"
+
+# ════════════════════════════════════════════════════════════════════════════
+# Test 3: After one chat request, counters are non-zero
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── Phase 3: after one chat completion ──"
+
+CHAT=$(curl -s -X POST "$BASE/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d '{"model":"mlx-serve","messages":[{"role":"user","content":"Reply with one word: OK"}],"max_tokens":5,"temperature":0}')
+
+check "chat completion returned a response" \
+    "$(echo "$CHAT" | grep -q '"choices"' && echo 1 || echo 0)"
+
+BODY2=$(curl -s "$BASE/metrics")
+
+# request_success_total must be 1
+check "request_success_total == 1 after one request" \
+    "$(echo "$BODY2" | grep "^vllm:request_success_total " | grep -q " 1$" && echo 1 || echo 0)"
+
+# prompt_tokens_total must be > 0
+PT=$(echo "$BODY2" | grep "^vllm:prompt_tokens_total " | awk '{print $2}')
+check "prompt_tokens_total > 0 after one request" \
+    "$([ -n "$PT" ] && [ "$PT" -gt 0 ] 2>/dev/null && echo 1 || echo 0)"
+
+# TTFT histogram count must be 1
+check "vllm:time_to_first_token_seconds_count == 1" \
+    "$(echo "$BODY2" | grep "^vllm:time_to_first_token_seconds_count " | grep -q " 1$" && echo 1 || echo 0)"
+
+# e2e histogram count must be 1
+check "vllm:e2e_request_latency_seconds_count == 1" \
+    "$(echo "$BODY2" | grep "^vllm:e2e_request_latency_seconds_count " | grep -q " 1$" && echo 1 || echo 0)"
+
+# +Inf bucket must be cumulative 1 (one request went through)
+TTFT_INF=$(echo "$BODY2" | grep 'vllm:time_to_first_token_seconds_bucket{le="+Inf"}' | awk '{print $2}')
+check "TTFT +Inf bucket == 1" \
+    "$([ "$TTFT_INF" = "1" ] && echo 1 || echo 0)"
+
+# request_cancelled_total must be 0 (no cancellations)
+check "request_cancelled_total == 0" \
+    "$(echo "$BODY2" | grep "^vllm:request_cancelled_total " | grep -q " 0$" && echo 1 || echo 0)"
+
+# memory_mb must reflect loaded model footprint (phys_footprint, not resident_size)
+# Any loaded model footprints >500 MB; the old resident_size bug read ~14 MB.
+MEM=$(echo "$BODY2" | grep "^mlx_serve:memory_mb " | awk '{print $2}')
+check "mlx_serve:memory_mb > 500 after model load (phys_footprint, not resident_size)" \
+    "$([ -n "$MEM" ] && [ "$MEM" -gt 500 ] 2>/dev/null && echo 1 || echo 0)"
+
+# generation_tokens_live (real-time tok/s source) = completed tokens + tokens
+# generated so far by in-flight slots. The gauge sampler runs every 2s, so wait
+# one cadence for it to reflect the just-completed request. With nothing
+# decoding at scrape time it must equal generation_tokens_total and be > 0.
+sleep 3
+BODY3=$(curl -s "$BASE/metrics")
+GEN=$(echo "$BODY3" | grep "^vllm:generation_tokens_total " | awk '{print $2}')
+LIVE=$(echo "$BODY3" | grep "^mlx_serve:generation_tokens_live " | awk '{print $2}')
+check "generation_tokens_live > 0 after one request (sampler ticked)" \
+    "$([ -n "$LIVE" ] && [ "$LIVE" -gt 0 ] 2>/dev/null && echo 1 || echo 0)"
+check "generation_tokens_live == generation_tokens_total at rest (no slots decoding)" \
+    "$([ -n "$LIVE" ] && [ -n "$GEN" ] && [ "$LIVE" = "$GEN" ] && echo 1 || echo 0)"
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo ""
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+    echo -e "${GREEN}PASS${NC} $TOTAL/$TOTAL tests passed"
+    exit 0
+else
+    echo -e "${RED}FAIL${NC} $FAIL/$TOTAL tests failed"
+    echo ""
+    echo "--- Server log (last 20 lines) ---"
+    tail -20 "$LOG" 2>/dev/null || true
+    exit 1
+fi


### PR DESCRIPTION
## Opt-in observability: Prometheus metrics + zero-dependency admin dashboard

Adds an **opt-in** observability layer behind a new `--metrics` flag. Off by default, and engineered so it never touches mlx-serve's serving performance.

### Design contract
- **Off (default):** a single `?*Metrics` null-check per *request* — never per token. No allocation, no atomics, no work.
- **On:** a handful of relaxed (`.monotonic`) atomic adds per request, recorded at the existing `finishSlot` funnel, which is already off the per-token decode path. The inference thread never locks, waits, or blocks on metrics. Gauges are sampled on a dedicated thread; `/metrics` renders on the scrape connection thread.

### What's added
- **`GET /metrics`** — Prometheus text exposition. Counters (prompt/generation tokens, success/cancelled requests, prefix-cache queries/hits), latency histograms (TTFT, e2e, prefill, decode), token-count histograms, and gauges (running/waiting requests, GPU %, memory, live generation tokens).
- **`GET /admin`** — a self-contained, zero-dependency web dashboard (single embedded HTML file): throughput, latency, GPU %, memory, real-time tok/s with sparklines, plus a ready-to-paste Prometheus scrape config.
- **`GET /admin/metrics.json`** — the same metrics as JSON for the dashboard / custom tooling.
- **`POST /admin/evict-prefix-cache`** — async prefix-cache eviction, optionally protected by `--admin-key` (bearer token, constant-time compare).

### Notable details
- **Real-time tok/s:** a `generation_tokens_live` gauge (completed tokens + tokens generated so far by in-flight slots) sampled every 2 s, so the dashboard shows a live rate even mid-request instead of reading 0 between long-request completions.
- **`memory_mb` uses phys_footprint** (TASK_VM_INFO flavor 22), the only figure that reflects a loaded model's true Metal/IOKit footprint on Apple Silicon — `resident_size` badly under-reports it.
- **Metric namespace:** emitted under `vllm:` so existing vLLM Grafana dashboards work out of the box. Happy to switch everything to `mlx_serve:` if you'd prefer project-native names — let me know.

### Tests
- `tests/test_metrics.sh` — 25 checks: 503-when-off, Prometheus shape, counters/histograms/gauges increment after a request, and the live-gauge invariants (`live > 0` after a request, `live == total` at rest).
- `tests/test_admin_api.sh` — 19 checks: JSON shape, dashboard serving, and the full `--admin-key` auth matrix (open mode / missing header → 401 / wrong key → 401 / correct key → 200).
- Unit tests in `src/metrics.zig` (render/atomics) and `src/status.zig` (phys_footprint).

All green; `zig build -Doptimize=ReleaseFast` clean. Rebased on current `main`.
