### PR TITLE
fix: hot prefix cache never enabled in headless serve mode

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1485,9 +1485,19 @@ fn runHeadlessServe(
         .warmup_eager = false,
         .draft_block_size = 0,
         .kv_quant_config = transformer_mod.KVQuantConfig.dense,
-        .prefix_cache_capacity = 0,
-        .prefix_cache_mem_bytes = 0,
-        .tokenize_cache_entries = 0,
+        // Seed the scheduler's prefix-cache config from the server globals so
+        // on-demand (headless/discover-mode) loads get the SAME hot prefix
+        // cache as a `--model` startup load. Previously hardcoded to 0, which
+        // left `Scheduler.prefix_cache_capacity == 0` → every model loaded via
+        // `ensureLoaded` skipped `HotPrefixCache` init → cross-turn KV reuse
+        // was silently dead for the entire headless serving mode (the default
+        // `serve` path). Mirrors the LoadParams built in `main()`.
+        .prefix_cache_capacity = server_mod.prefix_cache_capacity,
+        .prefix_cache_mem_bytes = server_mod.prefix_cache_mem_bytes,
+        .prefix_cache_disk_bytes = server_mod.prefix_cache_disk_bytes,
+        .ssm_checkpoint_stride = server_mod.ssm_checkpoint_stride,
+        .ssm_checkpoint_max = server_mod.ssm_checkpoint_max,
+        .tokenize_cache_entries = server_mod.tokenize_cache_entries,
         .metrics = server_mod.g_metrics,
     };
 


### PR DESCRIPTION
## Summary

In **headless serve mode** (`mlx-serve serve` with no `--model`, i.e. the default discover-and-load-by-name path used by the app), the **hot prefix cache is never created for any model**. Every request cold-prefills the entire prompt, even when a stable prefix (system prompt, prior turns, a re-sent file) is byte-identical to the previous request. Cross-turn KV reuse — the whole point of `--prefix-cache-mem` / `--prefix-cache-disk` — is silently dead.

A server started **with** `--model X` is unaffected; only headless mode is broken.

## Expected vs actual

- **Expected:** second identical request reuses the cached prefix (`cached_n > 0`, near-zero prefill).
- **Actual (headless):** `cached_n = 0` on every request, forever. `Hot prefix cache: ENABLED` is never logged; only `Hot prefix cache: requested capacity=N but disabled by scheduler` appears (once per boot).

## Root cause

`runHeadlessServe()` (`src/main.zig`) builds its bootstrap `LoadParams` with the prefix-cache fields hardcoded to `0`:

```zig
.prefix_cache_capacity = 0,
.prefix_cache_mem_bytes = 0,
.tokenize_cache_entries = 0,
```

`Scheduler.init` seeds `self.prefix_cache_capacity` from these params (→ `0`). On-demand loads go through `ensureLoaded`, which (correctly) inherits `self.prefix_cache_capacity` for cold loads:

```zig
// scheduler.zig — "Cold loads get the SAME prefix-cache configuration as the startup model"
.prefix_cache_capacity = self.prefix_cache_capacity,  // == 0 in headless
```

So the load-time gate in `loadModelOnInferenceThread` never fires:

```zig
if (params.prefix_cache_capacity > 0 and HotPrefixCache.shouldUse(...)) {
    entry.prefix_cache = HotPrefixCache.initWithMem(...);   // skipped: capacity == 0
}
```

`entry.prefix_cache` stays `null`, so both the lookup (prefill) and commit (post-generation) paths early-return — no `[hot-cache]` activity, `cached_n` always `0`.

`main()` builds its `LoadParams` with `.prefix_cache_capacity = server_mod.prefix_cache_capacity` (default 32) and the matching mem/disk/ssm fields — which is why `--model` startup works. The headless bootstrap just never mirrored it.

> Note: the `Hot prefix cache: … disabled by scheduler` line (`server.zig`) is emitted at startup, before any on-demand model has loaded (`hot_prefix_cache` is null at boot), so it is cosmetic and unrelated to the per-model outcome. It cannot log `ENABLED` in headless mode even after the fix, because no model is resident at that point.

## Fix

Mirror `main()`: seed the scheduler's cache config from the server globals in the headless bootstrap `LoadParams` (also enables the tokenize-render cache, same class of headless-only regression).

```zig
.prefix_cache_capacity = server_mod.prefix_cache_capacity,
.prefix_cache_mem_bytes = server_mod.prefix_cache_mem_bytes,
.prefix_cache_disk_bytes = server_mod.prefix_cache_disk_bytes,
.ssm_checkpoint_stride = server_mod.ssm_checkpoint_stride,
.ssm_checkpoint_max = server_mod.ssm_checkpoint_max,
.tokenize_cache_entries = server_mod.tokenize_cache_entries,
```

## Verification

Built `-Doptimize=ReleaseFast`, ran the patched binary headless (`serve --ctx-size 262144 --kv-quant 8 --pld --prefix-cache-disk 10GB --max-resident-models 1`), repeated an identical ~14k-token prompt:

| turn | `cached_n` | `prompt_ms` | reuse |
|------|-----------|------------|-------|
| cold | 0 | 12945 | 0% |
| warm (identical) | 14274 / 14275 | **28** | **100%** |
| warm (+ short new tail) | 14270 | 117 | ~100% |

`[hot-cache] reused 14274/14275 tokens` now logs; warm-turn prefill drops **~460×** (12945 ms → 28 ms). Same behavior confirmed for both a pure-attention model (`Qwen3-Coder-30B-A3B` / `qwen3_moe`) and a hybrid model (`qwen3_5_moe`, via the default SSM checkpoint stride).

`zig build test` passes (exit 0).

## Environment

- macOS 26.2, Apple M4 Max, Apple clang 16
- Zig 0.16.0
- mlx-c 0.6.0, mlx 0.31.2 (Homebrew)
- Models: `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit-dwq-v2`, `Litwein/Qwen3.6-35B-A3B-...-MLX`

## Scope

One function, six field assignments; no behavior change for `--model` startups. `runGenServe` (media) is intentionally left as-is — image/audio/video slots skip the prefix cache anyway.
