### PR TITLE
fix: honor --kv-quant in headless serve mode

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -779,7 +779,7 @@ pub fn main(init: std.process.Init) !void {
         if (model_dir.len == 0) {
             const discovery_for_registry = discovery_storage;
             discovery_storage = null; // ownership moves to the registry
-            try runHeadlessServe(io, allocator, discovery_for_registry, host, port, ctx_size, timeout, reasoning_budget, max_resident_models, max_resident_mem, max_resident_mem_explicit, idle_evict_secs);
+            try runHeadlessServe(io, allocator, discovery_for_registry, host, port, ctx_size, timeout, reasoning_budget, max_resident_models, max_resident_mem, max_resident_mem_explicit, idle_evict_secs, kv_quant_config);
             return;
         }
 
@@ -1419,6 +1419,7 @@ fn runHeadlessServe(
     max_resident_mem: u64,
     max_resident_mem_explicit: bool,
     idle_evict_secs: ?u32,
+    kv_quant_config: transformer_mod.KVQuantConfig,
 ) !void {
     log.info("mlx-serve {s} (headless — models load on demand)\n", .{VERSION});
     log.info("[args] serve: {s}:{d}\n", .{ host, port });
@@ -1484,7 +1485,7 @@ fn runHeadlessServe(
         .load_vision = false,
         .warmup_eager = false,
         .draft_block_size = 0,
-        .kv_quant_config = transformer_mod.KVQuantConfig.dense,
+        .kv_quant_config = kv_quant_config,
         // Seed the scheduler's prefix-cache config from the server globals so
         // on-demand (headless/discover-mode) loads get the SAME hot prefix
         // cache as a `--model` startup load. Previously hardcoded to 0, which


### PR DESCRIPTION
## Summary

In **headless serve mode** (`mlx-serve serve` with no `--model`, the default discover-and-load-by-name path the app uses), `--kv-quant {4,8,turbo2,turbo4}` is **silently ignored**. Every model loaded on demand via the registry runs a **dense bf16 KV cache** regardless of the flag, so the memory saving and long-context headroom the flag exists to provide never apply in the mode most sessions actually use.

A server started **with** `--model X` is unaffected — that path already threads the parsed value through.

## Expected vs actual

- **Expected:** `serve --kv-quant 8` (headless) → on-demand-loaded models use an 8-bit quantized KV cache.
- **Actual (headless):** models always load with a dense bf16 KV cache; the flag has no effect.

## Root cause

`runHeadlessServe()` (`src/main.zig`) hand-builds its bootstrap `LoadParams` with the KV-quant field hardcoded:

```zig
.kv_quant_config = transformer_mod.KVQuantConfig.dense,
```

`Scheduler.init` seeds itself from these params, so the scheduler persists `.dense`. Cold loads that go through `ensureLoaded` (and `/v1/load-model` / model switches) inherit the scheduler's config → every on-demand model is dense, no matter what `--kv-quant` was parsed to. `main()`'s `--model` startup path passes the parsed `kv_quant_config` into its `LoadParams`, which is why only headless mode is broken — the bootstrap just never mirrored it.

## Fix

Thread the parsed `kv_quant_config` into `runHeadlessServe` and use it in the bootstrap `LoadParams`, mirroring the `--model` startup path:

```zig
.kv_quant_config = kv_quant_config,
```

so the scheduler persists it and cold-load `LoadRequest`s (`ensureLoaded` / `/v1/load-model` / model switches) inherit it.

## Verification

Built `-Doptimize=ReleaseFast`. A headless server started with `--kv-quant 8` now applies an 8-bit quantized KV cache to on-demand-loaded models (previously dense bf16), matching the `--model` startup path. `zig build test` passes (exit 0).

## Environment

- macOS 26.2, Apple M4 Max, Apple clang 16
- Zig 0.16.0
- mlx-c 0.6.0, mlx 0.31.2 (Homebrew)

## Scope

One function, one threaded parameter, one field assignment; no behavior change for `--model` startups. Mirrors #67, which did the same for the hot prefix cache. Companion to #69 (both fix headless / long-context serving); independent diffs.
