### PR TITLE
fix: carry MTP + embedded-llama.cpp launch flags onto cold model loads

### DIFF
--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -955,6 +955,18 @@ pub const Scheduler = struct {
     prefix_cache_disk_bytes: u64,
     ssm_checkpoint_stride: u32,
     ssm_checkpoint_max: u32,
+    /// Launch-flag MTP + embedded-llama.cpp settings, retained (same rationale
+    /// as the prefix-cache fields above) so COLD-LOADED models — on-demand
+    /// `/v1/load-model`, model switches — honor `--no-mtp` / `--mtp-depth` /
+    /// `--llama-cache-entries` / `--llama-kv-quant` like the `--model` primary.
+    /// Pre-plumbing, the cold-load `LoadRequest` used its struct defaults
+    /// (mtp on, default depth, 4 llama sessions, F16 KV), silently ignoring
+    /// these flags on every on-demand load and model switch.
+    mtp_enabled: bool,
+    mtp_depth: u32,
+    llama_cache_entries: u32,
+    llama_kv_type_k: i32,
+    llama_kv_type_v: i32,
 
     // ── Borrowed refs (CPU-only state owned by the LoadedModel). ──
     config: *const ModelConfig,
@@ -1105,6 +1117,11 @@ pub const Scheduler = struct {
             .prefix_cache_disk_bytes = params.prefix_cache_disk_bytes,
             .ssm_checkpoint_stride = params.ssm_checkpoint_stride,
             .ssm_checkpoint_max = params.ssm_checkpoint_max,
+            .mtp_enabled = params.mtp_enabled,
+            .mtp_depth = params.mtp_depth,
+            .llama_cache_entries = params.llama_cache_entries,
+            .llama_kv_type_k = params.llama_kv_type_k,
+            .llama_kv_type_v = params.llama_kv_type_v,
             // Initial borrowed-view refs point at the (heap-allocated) CPU
             // state carried on LoadParams; once the inference thread
             // installs them on `entry`, the views still resolve to the
@@ -1537,6 +1554,16 @@ pub const Scheduler = struct {
             .prefix_cache_disk_bytes = self.prefix_cache_disk_bytes,
             .ssm_checkpoint_stride = self.ssm_checkpoint_stride,
             .ssm_checkpoint_max = self.ssm_checkpoint_max,
+            // Cold loads honor the launch-flag MTP + embedded-llama.cpp
+            // settings too (same reason as prefix-cache above) — pre-plumbing
+            // these were LoadRequest defaults, so --no-mtp / --mtp-depth /
+            // --llama-cache-entries / --llama-kv-quant were silently dropped
+            // on every on-demand load and model switch.
+            .mtp_enabled = self.mtp_enabled,
+            .mtp_depth = self.mtp_depth,
+            .llama_cache_entries = self.llama_cache_entries,
+            .llama_kv_type_k = self.llama_kv_type_k,
+            .llama_kv_type_v = self.llama_kv_type_v,
             .evict_entries = victims_buf[0..n_victims],
             .allocator = self.allocator,
         };


### PR DESCRIPTION
## Summary

The `Scheduler` persists a subset of launch-flag settings so that **cold loads** — models brought up after startup through `ensureLoaded` (`--model` model-switches, and on-demand `/v1/load-model`) — inherit the same configuration as the `--model` primary. The Qwen MTP head and the embedded llama.cpp KV settings were left out of that mechanism, so these flags are dropped on every cold load and silently fall back to defaults:

- `--no-mtp` / `--mtp-depth` (→ `mtp_enabled` / `mtp_depth`)
- `--llama-cache-entries` (→ `llama_cache_entries`)
- `--llama-kv-quant` (→ `llama_kv_type_k` / `llama_kv_type_v`)

## Root cause

`ensureLoaded` builds the cold-load `LoadRequest` by copying launch-flag settings from fields persisted on the `Scheduler` — this is how the prefix-cache / SSM config survives a cold load:

```zig
// scheduler.zig — cold-load LoadRequest
.kv_quant_config = self.kv_quant_config,
.prefix_cache_capacity = self.prefix_cache_capacity,
.ssm_checkpoint_stride = self.ssm_checkpoint_stride,
// ... but nothing for mtp_* / llama_*
```

The `Scheduler` struct never carried `mtp_enabled` / `mtp_depth` / `llama_cache_entries` / `llama_kv_type_k` / `llama_kv_type_v`, so the `LoadRequest` used its struct defaults (MTP on, default depth, 4 llama sessions, F16 KV) regardless of what the CLI parsed. `doLoadOnInferenceThread` then reads those defaulted values.

## Fix

Extend the existing `prefix_cache_*` / `ssm_*` precedent to the MTP + llama fields:

1. Add the five fields to the `Scheduler` struct.
2. Seed them in `Scheduler.init` from the incoming `LoadParams` (the same source the prefix-cache fields use).
3. Read `self.*` for them in the `ensureLoaded` cold-load `LoadRequest`, alongside `kv_quant` / prefix / ssm.

Scheduler-only, +27 lines; no new fields on `LoadParams` / `LoadRequest` (they already existed). The `--model` startup `LoadParams` already populates all five, so **model-switch cold loads on a `--model` server now honor these flags**, closing the same per-switch inconsistency #67 fixed for the prefix cache.

> **Headless follow-up (out of scope here):** the headless bootstrap `LoadParams` in `runHeadlessServe` seeds only kv-quant / prefix-cache / ssm from the server globals (added by #67 / #68); it does not yet thread the MTP + llama fields. For on-demand loads in headless (`serve` without `--model`) mode to also honor `--no-mtp` / `--mtp-depth` / `--llama-*`, that bootstrap needs the matching mirror (`.llama_cache_entries = server_mod.llama_cache_entries`, `.llama_kv_type_k/v = server_mod.llama_kv_quant.ggmlType()`, and threading `enable_mtp` / `mtp_depth`). That edit lives in the same `runHeadlessServe` LoadParams literal / signature #68 touches, so it is intentionally left as a separate change to keep this one scheduler-scoped and conflict-free. This PR is the prerequisite: it is the piece that makes the Scheduler actually forward those values to cold loads.

## Verification

- `zig build` — clean (exit 0).
- Reloaded the launchd headless server on the rebuilt binary; `/v1/models` → `200`.
- On-demand cold load (`Litwein/Qwen3.6-35B-A3B-...-MTP-MLX`, `max_tokens:1`) → `200`, `mtp_loaded=false`; then a model switch to `mlx-community/Qwen3-Coder-30B-A3B-Instruct-4bit-dwq-v2` (`max_tokens:1`) → `200`, server stays healthy. Both exercise the shared cold-load path this PR touches — no regression.

(A live positive flip of these flags on the cold path isn't observable with the current local model set: no resident model ships the `mtp/weights.safetensors` sidecar layout `hasMtpSidecar` gates on, and the llama-cache / llama-kv fields apply only to GGUF/llama.cpp models, none resident. The change is validated by construction against the prefix-cache precedent plus the no-regression checks above.)

## Environment

- macOS, Apple M4 Max
- Zig 0.16.0

## Scope

One struct, `Scheduler.init`, and one cold-load `LoadRequest` — five field assignments each, all reads of values the CLI already parses. No behavior change for `--model` startups.
