### PR TITLE
fix: calibrate adaptive MTP depth for q4 M5 NAX

### DIFF
--- a/src/generate.zig
+++ b/src/generate.zig
@@ -1260,7 +1260,10 @@ pub const Generator = struct {
             try mlx.check(mlx.mlx_array_item_int32(&first_val, sample_lazy));
             _ = mlx.mlx_array_free(sample_lazy);
 
-            const mtp_nax_profile = mtp_active and options.mtp.?.m5NaxCostProfileEnabled(xfm);
+            const mtp_cost_profile: mtp_mod.MtpCostProfile = if (mtp_active)
+                options.mtp.?.m5NaxCostProfile(xfm)
+            else
+                .generic;
             var gen = Generator{
                 .xfm = xfm,
                 .ctx = ctx,
@@ -1286,8 +1289,8 @@ pub const Generator = struct {
                 .drafter_block_size = options.drafter_block_size,
                 .mtp = if (mtp_active) options.mtp else null,
                 .mtp_cache = mtp_cache,
-                .mtp_depth = resolveMtpDepthCap(options.mtp_depth, mtp_nax_profile),
-                .mtp_ev_costs = mtpEvCosts(mtp_nax_profile),
+                .mtp_depth = resolveMtpDepthCapForProfile(options.mtp_depth, mtp_cost_profile),
+                .mtp_ev_costs = mtpEvCosts(mtp_cost_profile),
                 // Start at depth 1 and climb with evidence: the cheap depth
                 // is the safe default (1.11x on cold/creative content), and
                 // hot workloads promote within ~8 rounds.
@@ -3330,6 +3333,21 @@ pub const Generator = struct {
         .nax_from = 7,
         .per_pos_nax = 0.04,
     };
+    /// M5 Max/G17 affine-4/gs-32 sidecar refit (2026-07-18). A saturated
+    /// fixed-depth sweep gave T(1)=36.04, T(3)=43.01, T(6)=62.56, and
+    /// T(8)=66.06 ms. The fitted composite marginals (`draft + verify`) are
+    /// .107/.200/.054; depths 4 and 5 independently validate the rounded
+    /// .11/.20/.05 surface after matching-baseline correction. The split
+    /// between draft and verify is not separately identifiable.
+    pub const MTP_EV_G17_NAX_Q4_GS32_COSTS: MtpEvCosts = .{
+        .draft = 0.03,
+        .per_pos_lo = 0.08,
+        .per_pos_hi = 0.17,
+        .flat_max = 3,
+        .sync = 0.02,
+        .nax_from = 7,
+        .per_pos_nax = 0.02,
+    };
 
     /// Marginal round cost of draft position k (1-based).
     pub fn mtpEvMarginalCost(costs: MtpEvCosts, k: u32) f32 {
@@ -3351,17 +3369,32 @@ pub const Generator = struct {
     };
 
     /// Resolve the configured depth cap. 0 = auto (`--mtp-depth` not passed):
-    /// MTP_ADAPTIVE_NAX_CAP only when the EV controller and the target's NAX
+    /// MTP_ADAPTIVE_NAX_CAP only when the EV controller and a calibrated G17
     /// cost profile are both active, MTP_ADAPTIVE_DEFAULT_CAP otherwise, and
     /// DEFAULT_DEPTH in fixed mode. Explicit values always win.
-    pub fn mtpDepthCapFor(configured: u32, adaptive: bool, nax_profile: bool) u32 {
+    pub fn mtpDepthCapForProfile(configured: u32, adaptive: bool, profile: mtp_mod.MtpCostProfile) u32 {
         if (configured != 0) return @min(mtp_mod.MAX_DEPTH, @max(1, configured));
         if (!adaptive) return mtp_mod.DEFAULT_DEPTH;
-        return if (nax_profile) MTP_ADAPTIVE_NAX_CAP else MTP_ADAPTIVE_DEFAULT_CAP;
+        return switch (profile) {
+            .generic => MTP_ADAPTIVE_DEFAULT_CAP,
+            .g17_nax_q8_gs32, .g17_nax_q4_gs32 => MTP_ADAPTIVE_NAX_CAP,
+        };
     }
 
+    pub fn resolveMtpDepthCapForProfile(configured: u32, profile: mtp_mod.MtpCostProfile) u32 {
+        return mtpDepthCapForProfile(configured, mtpAdaptiveEnabled(), profile);
+    }
+
+    /// Legacy q8 boolean selector retained for source compatibility.
+    pub fn mtpDepthCapFor(configured: u32, adaptive: bool, nax_profile: bool) u32 {
+        const profile: mtp_mod.MtpCostProfile = if (nax_profile) .g17_nax_q8_gs32 else .generic;
+        return mtpDepthCapForProfile(configured, adaptive, profile);
+    }
+
+    /// Legacy q8 boolean selector retained for source compatibility.
     pub fn resolveMtpDepthCap(configured: u32, nax_profile: bool) u32 {
-        return mtpDepthCapFor(configured, mtpAdaptiveEnabled(), nax_profile);
+        const profile: mtp_mod.MtpCostProfile = if (nax_profile) .g17_nax_q8_gs32 else .generic;
+        return resolveMtpDepthCapForProfile(configured, profile);
     }
 
     /// Expected committed tokens for an m-deep round: the always-committed t1
@@ -3568,17 +3601,27 @@ pub const Generator = struct {
     /// profile), so a value copied from an M1-M4 tuning run means the same
     /// thing on M5. Empty/partial/malformed values are ignored atomically;
     /// they must not silently leave an auto-cap-8 target on generic costs.
-    pub fn mtpEvCostsFor(nax_profile: bool, override: ?[]const u8) MtpEvCosts {
-        const selected = if (nax_profile) MTP_EV_G17_NAX_COSTS else MTP_EV_DEFAULT_COSTS;
+    pub fn mtpEvCostsForProfile(profile: mtp_mod.MtpCostProfile, override: ?[]const u8) MtpEvCosts {
+        const selected = switch (profile) {
+            .generic => MTP_EV_DEFAULT_COSTS,
+            .g17_nax_q8_gs32 => MTP_EV_G17_NAX_COSTS,
+            .g17_nax_q4_gs32 => MTP_EV_G17_NAX_Q4_GS32_COSTS,
+        };
         if (override) |raw| {
             return parseMtpEvCostsOverride(raw) orelse selected;
         }
         return selected;
     }
 
-    fn mtpEvCosts(nax_profile: bool) MtpEvCosts {
-        return mtpEvCostsFor(
-            nax_profile,
+    /// Legacy q8 boolean selector retained for source compatibility.
+    pub fn mtpEvCostsFor(nax_profile: bool, override: ?[]const u8) MtpEvCosts {
+        const profile: mtp_mod.MtpCostProfile = if (nax_profile) .g17_nax_q8_gs32 else .generic;
+        return mtpEvCostsForProfile(profile, override);
+    }
+
+    fn mtpEvCosts(profile: mtp_mod.MtpCostProfile) MtpEvCosts {
+        return mtpEvCostsForProfile(
+            profile,
             if (std.c.getenv("MLX_SERVE_MTP_EV_COSTS")) |p| std.mem.span(p) else null,
         );
     }
@@ -6160,22 +6203,30 @@ test "MTP EV seed defaults on and explicit zero disables" {
     try testing.expect(!Generator.mtpEvSeedEnabledFromEnv("0-disabled"));
 }
 
-test "mtpDepthCapFor: auto cap follows the selected NAX profile; explicit always wins" {
+test "mtpDepthCapFor: auto cap follows the selected cost profile; explicit always wins" {
     // 0 = auto (--mtp-depth not passed).
-    try testing.expectEqual(Generator.MTP_ADAPTIVE_DEFAULT_CAP, Generator.mtpDepthCapFor(0, true, false));
-    try testing.expectEqual(@as(u32, 6), Generator.mtpDepthCapFor(0, true, false));
-    try testing.expectEqual(Generator.MTP_ADAPTIVE_NAX_CAP, Generator.mtpDepthCapFor(0, true, true));
-    try testing.expectEqual(@as(u32, 8), Generator.mtpDepthCapFor(0, true, true));
-    try testing.expectEqual(mtp_mod.DEFAULT_DEPTH, Generator.mtpDepthCapFor(0, false, false));
-    try testing.expectEqual(mtp_mod.DEFAULT_DEPTH, Generator.mtpDepthCapFor(0, false, true));
+    try testing.expectEqual(Generator.MTP_ADAPTIVE_DEFAULT_CAP, Generator.mtpDepthCapForProfile(0, true, .generic));
+    try testing.expectEqual(@as(u32, 6), Generator.mtpDepthCapForProfile(0, true, .generic));
+    for ([_]mtp_mod.MtpCostProfile{ .g17_nax_q8_gs32, .g17_nax_q4_gs32 }) |profile| {
+        try testing.expectEqual(Generator.MTP_ADAPTIVE_NAX_CAP, Generator.mtpDepthCapForProfile(0, true, profile));
+        try testing.expectEqual(@as(u32, 8), Generator.mtpDepthCapForProfile(0, true, profile));
+    }
+    for ([_]mtp_mod.MtpCostProfile{ .generic, .g17_nax_q8_gs32, .g17_nax_q4_gs32 }) |profile| {
+        try testing.expectEqual(mtp_mod.DEFAULT_DEPTH, Generator.mtpDepthCapForProfile(0, false, profile));
+    }
     // Explicit values ignore both controller mode and profile, and remain
     // clamped to [1, MAX_DEPTH].
-    try testing.expectEqual(@as(u32, 5), Generator.mtpDepthCapFor(5, true, false));
-    try testing.expectEqual(@as(u32, 5), Generator.mtpDepthCapFor(5, false, true));
-    try testing.expectEqual(@as(u32, 7), Generator.mtpDepthCapFor(7, true, false));
-    try testing.expectEqual(@as(u32, 8), Generator.mtpDepthCapFor(8, true, false));
-    try testing.expectEqual(@as(u32, 2), Generator.mtpDepthCapFor(2, true, true));
-    try testing.expectEqual(mtp_mod.MAX_DEPTH, Generator.mtpDepthCapFor(12, true, false));
+    try testing.expectEqual(@as(u32, 5), Generator.mtpDepthCapForProfile(5, true, .generic));
+    try testing.expectEqual(@as(u32, 5), Generator.mtpDepthCapForProfile(5, false, .g17_nax_q8_gs32));
+    try testing.expectEqual(@as(u32, 7), Generator.mtpDepthCapForProfile(7, true, .generic));
+    try testing.expectEqual(@as(u32, 8), Generator.mtpDepthCapForProfile(8, true, .generic));
+    try testing.expectEqual(@as(u32, 2), Generator.mtpDepthCapForProfile(2, true, .g17_nax_q4_gs32));
+    try testing.expectEqual(mtp_mod.MAX_DEPTH, Generator.mtpDepthCapForProfile(12, true, .generic));
+
+    // The original boolean helpers remain source-compatible and map true to
+    // the pre-existing q8 profile.
+    try testing.expectEqual(@as(u32, 6), Generator.mtpDepthCapFor(0, true, false));
+    try testing.expectEqual(@as(u32, 8), Generator.mtpDepthCapFor(0, true, true));
 }
 
 test "mtpFloorDisableObserve: extension misses do not poison depth one" {
@@ -6295,22 +6346,29 @@ test "mtpEvRoundCost: piecewise marginals (flat verify region, then the GDN widt
     try testing.expectApproxEqAbs(@as(f32, 0.32), Generator.mtpEvMarginalCost(costs, 4), 1e-6);
 }
 
-test "mtpEvCostsFor: G17 NAX profile is explicit and env tuning stays generic" {
-    const generic = Generator.mtpEvCostsFor(false, null);
+test "mtpEvCostsFor: G17 profiles are explicit and env tuning stays generic" {
+    const generic = Generator.mtpEvCostsForProfile(.generic, null);
     try testing.expectEqual(Generator.MTP_EV_DEFAULT_COSTS, generic);
 
-    const nax = Generator.mtpEvCostsFor(true, null);
-    try testing.expectEqual(Generator.MTP_EV_G17_NAX_COSTS, nax);
-    try testing.expectEqual(@as(u32, 7), nax.nax_from);
+    const q8 = Generator.mtpEvCostsForProfile(.g17_nax_q8_gs32, null);
+    try testing.expectEqual(Generator.MTP_EV_G17_NAX_COSTS, q8);
+    try testing.expectEqual(@as(u32, 7), q8.nax_from);
+
+    const q4 = Generator.mtpEvCostsForProfile(.g17_nax_q4_gs32, null);
+    try testing.expectEqual(Generator.MTP_EV_G17_NAX_Q4_GS32_COSTS, q4);
+    try testing.expectEqual(@as(u32, 7), q4.nax_from);
 
     // An explicit four-value override retains its historical meaning instead
-    // of inheriting an implicit hardware-only third region.
-    const tuned = Generator.mtpEvCostsFor(true, "0.10, 0.11, 0.22, 0.03");
-    try testing.expectApproxEqAbs(@as(f32, 0.10), tuned.draft, 1e-6);
-    try testing.expectApproxEqAbs(@as(f32, 0.11), tuned.per_pos_lo, 1e-6);
-    try testing.expectApproxEqAbs(@as(f32, 0.22), tuned.per_pos_hi, 1e-6);
-    try testing.expectApproxEqAbs(@as(f32, 0.03), tuned.sync, 1e-6);
-    try testing.expectEqual(@as(u32, 0), tuned.nax_from);
+    // of inheriting an implicit hardware-only third region, for every profile.
+    for ([_]mtp_mod.MtpCostProfile{ .generic, .g17_nax_q8_gs32, .g17_nax_q4_gs32 }) |profile| {
+        const tuned = Generator.mtpEvCostsForProfile(profile, "0.10, 0.11, 0.22, 0.03");
+        try testing.expectApproxEqAbs(@as(f32, 0.10), tuned.draft, 1e-6);
+        try testing.expectApproxEqAbs(@as(f32, 0.11), tuned.per_pos_lo, 1e-6);
+        try testing.expectApproxEqAbs(@as(f32, 0.22), tuned.per_pos_hi, 1e-6);
+        try testing.expectApproxEqAbs(@as(f32, 0.03), tuned.sync, 1e-6);
+        try testing.expectEqual(@as(u32, 0), tuned.nax_from);
+        try testing.expectApproxEqAbs(@as(f32, 0.0), tuned.per_pos_nax, 1e-6);
+    }
 
     // Invalid overrides are atomic no-ops. In particular, an empty variable
     // must not combine cap 8 with the generic costs that previously starved it.
@@ -6323,8 +6381,13 @@ test "mtpEvCostsFor: G17 NAX profile is explicit and env tuning stays generic" {
         "0.10,-0.11,0.22,0.03",
     };
     for (invalid) |raw| {
-        try testing.expectEqual(Generator.MTP_EV_G17_NAX_COSTS, Generator.mtpEvCostsFor(true, raw));
+        try testing.expectEqual(Generator.MTP_EV_DEFAULT_COSTS, Generator.mtpEvCostsForProfile(.generic, raw));
+        try testing.expectEqual(Generator.MTP_EV_G17_NAX_COSTS, Generator.mtpEvCostsForProfile(.g17_nax_q8_gs32, raw));
+        try testing.expectEqual(Generator.MTP_EV_G17_NAX_Q4_GS32_COSTS, Generator.mtpEvCostsForProfile(.g17_nax_q4_gs32, raw));
     }
+
+    try testing.expectEqual(Generator.MTP_EV_DEFAULT_COSTS, Generator.mtpEvCostsFor(false, null));
+    try testing.expectEqual(Generator.MTP_EV_G17_NAX_COSTS, Generator.mtpEvCostsFor(true, null));
 }
 
 test "MTP_EV_G17_NAX_COSTS reproduces the measured M5 depth-6/depth-8 ratio" {
@@ -6338,7 +6401,20 @@ test "MTP_EV_G17_NAX_COSTS reproduces the measured M5 depth-6/depth-8 ratio" {
     try testing.expectApproxEqAbs(@as(f32, 0.10), Generator.mtpEvMarginalCost(costs, 7), 1e-6);
 }
 
-test "mtpEvPlanFor: M5 NAX surface opens depth 8 from realistic warmup EMAs" {
+test "MTP_EV_G17_NAX_Q4_GS32_COSTS encodes calibrated composite marginals" {
+    const costs = Generator.MTP_EV_G17_NAX_Q4_GS32_COSTS;
+    try testing.expect(costs.draft > 0.0);
+    try testing.expect(costs.per_pos_lo > 0.0);
+    try testing.expect(costs.per_pos_hi > 0.0);
+    try testing.expect(costs.per_pos_nax > 0.0);
+    try testing.expectApproxEqAbs(@as(f32, 0.11), Generator.mtpEvMarginalCost(costs, 3), 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 0.20), Generator.mtpEvMarginalCost(costs, 4), 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 0.05), Generator.mtpEvMarginalCost(costs, 7), 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 1.93), Generator.mtpEvRoundCost(costs, 6, false), 1e-5);
+    try testing.expectApproxEqAbs(@as(f32, 2.03), Generator.mtpEvRoundCost(costs, 8, false), 1e-5);
+}
+
+test "mtpEvPlanFor: M5 NAX surfaces open depth 8 from realistic warmup EMAs" {
     const p = Generator.MTP_EV_PRIOR;
     const a = [_]f32{ 0.97, 0.89, p, p, p, p, p, p };
 
@@ -6349,15 +6425,19 @@ test "mtpEvPlanFor: M5 NAX surface opens depth 8 from realistic warmup EMAs" {
 
     // The M5 fit captures both its cheaper intermediate widths and the NAX
     // takeover at draft position 7, so the same evidence reaches depth 8.
-    const nax = Generator.mtpEvPlanFor(&a, 8, Generator.MTP_EV_G17_NAX_COSTS, 3);
-    try testing.expectEqual(@as(u32, 3), nax.m_lo);
-    try testing.expectEqual(@as(u32, 8), nax.m_hi);
-    try testing.expect(nax.tau_ln < 0.0);
+    for ([_]Generator.MtpEvCosts{ Generator.MTP_EV_G17_NAX_COSTS, Generator.MTP_EV_G17_NAX_Q4_GS32_COSTS }) |costs| {
+        const nax = Generator.mtpEvPlanFor(&a, 8, costs, 3);
+        try testing.expectEqual(@as(u32, 3), nax.m_lo);
+        try testing.expectEqual(@as(u32, 8), nax.m_hi);
+        try testing.expect(nax.tau_ln < 0.0);
+    }
 
     const cold = [_]f32{ 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1 };
-    const cold_plan = Generator.mtpEvPlanFor(&cold, 8, Generator.MTP_EV_G17_NAX_COSTS, 8);
-    try testing.expectEqual(@as(u32, 1), cold_plan.m_lo);
-    try testing.expectEqual(@as(u32, 1), cold_plan.m_hi);
+    for ([_]Generator.MtpEvCosts{ Generator.MTP_EV_G17_NAX_COSTS, Generator.MTP_EV_G17_NAX_Q4_GS32_COSTS }) |costs| {
+        const cold_plan = Generator.mtpEvPlanFor(&cold, 8, costs, 8);
+        try testing.expectEqual(@as(u32, 1), cold_plan.m_lo);
+        try testing.expectEqual(@as(u32, 1), cold_plan.m_hi);
+    }
 }
 
 test "mtpEvPlanFor: mid-decay acceptance picks a shallow base and a confidence-gated extension" {

--- a/src/mtp.zig
+++ b/src/mtp.zig
@@ -51,6 +51,24 @@ const Weights = model_mod.Weights;
 pub const DEFAULT_DEPTH: u32 = 3;
 pub const MAX_DEPTH: u32 = 8;
 
+/// Exact full-round cost surfaces known to the adaptive MTP controller.
+/// Selection is based on runtime tensor geometry, never a model/repository
+/// name. `generic` retains the conservative M1-M4 surface and auto cap.
+pub const MtpCostProfile = enum {
+    generic,
+    g17_nax_q8_gs32,
+    g17_nax_q4_gs32,
+};
+
+fn m5NaxCostProfileForQuant(bits: u32, group_size: u32) MtpCostProfile {
+    if (group_size != 32) return .generic;
+    return switch (bits) {
+        8 => .g17_nax_q8_gs32,
+        4 => .g17_nax_q4_gs32,
+        else => .generic,
+    };
+}
+
 /// Prefill history windowing (OPT-IN via `--mtp-history-window <n>`; mirrors
 /// others `last_window 8192` above a 16384-token threshold): prompts whose
 /// forwarded tail exceeds the threshold only build MTP history for the LAST
@@ -102,6 +120,36 @@ fn m5NaxNormMatches(norm: mlx.mlx_array, len: u32) bool {
     if (len == 0 or len > std.math.maxInt(c_int)) return false;
     const shape = mlx.getShape(norm);
     return shape.len == 1 and shape[0] == @as(c_int, @intCast(len));
+}
+
+const M5NaxDenseSidecarLinears = struct {
+    q: *const QLinear,
+    k: *const QLinear,
+    v: *const QLinear,
+    o: *const QLinear,
+    gate: *const QLinear,
+    up: *const QLinear,
+    down: *const QLinear,
+};
+
+const M5NaxDenseSidecarGeometry = struct {
+    hidden: u32,
+    q_out: u32,
+    kv_out: u32,
+    full_out: u32,
+    intermediate: u32,
+    bits: u32,
+    group_size: u32,
+};
+
+fn m5NaxDenseSidecarMatches(linears: M5NaxDenseSidecarLinears, geom: M5NaxDenseSidecarGeometry) bool {
+    return m5NaxQLinearMatches(linears.q, geom.hidden, geom.q_out, geom.bits, geom.group_size) and
+        m5NaxQLinearMatches(linears.k, geom.hidden, geom.kv_out, geom.bits, geom.group_size) and
+        m5NaxQLinearMatches(linears.v, geom.hidden, geom.kv_out, geom.bits, geom.group_size) and
+        m5NaxQLinearMatches(linears.o, geom.full_out, geom.hidden, geom.bits, geom.group_size) and
+        m5NaxQLinearMatches(linears.gate, geom.hidden, geom.intermediate, geom.bits, geom.group_size) and
+        m5NaxQLinearMatches(linears.up, geom.hidden, geom.intermediate, geom.bits, geom.group_size) and
+        m5NaxQLinearMatches(linears.down, geom.intermediate, geom.hidden, geom.bits, geom.group_size);
 }
 
 fn m5NaxDraftHeadMatches(
@@ -234,14 +282,20 @@ pub const MtpModel = struct {
         return KVCache.init(allocator, 1);
     }
 
-    /// Whether this bound sidecar and target match the complete cost surface
-    /// measured for the M5/G17 depth-8 controller. The cheap draft marginal
-    /// assumes the successful 3-bit/gs-64 draft-only lm_head plus the native
-    /// dense 8-bit/gs-32 Qwen3.6-27B MTP layer. A compatible but differently
-    /// quantized sidecar remains correct, but keeps the conservative profile.
-    pub fn m5NaxCostProfileEnabled(self: *const MtpModel, target: *const Transformer) bool {
-        if (!target.mtpNaxProfileEnabled()) return false;
-        if (self.eh_proj != null or self.quant_bits != 8 or self.quant_group_size != 32) return false;
+    /// Select the exact full-round cost surface for this bound sidecar and
+    /// target. Both G17 profiles require the successfully built 3-bit/gs-64
+    /// draft-only lm_head and a homogeneous dense Qwen3.6-27B sidecar; their
+    /// q8/gs-32 and q4/gs-32 draft costs are calibrated independently.
+    /// Compatible but off-profile geometry remains correct under `generic`.
+    pub fn m5NaxCostProfile(self: *const MtpModel, target: *const Transformer) MtpCostProfile {
+        if (!target.mtpNaxProfileEnabled()) return .generic;
+        if (self.eh_proj != null) return .generic;
+        const profile = m5NaxCostProfileForQuant(self.quant_bits, self.quant_group_size);
+        const sidecar_bits: u32 = switch (profile) {
+            .g17_nax_q8_gs32 => 8,
+            .g17_nax_q4_gs32 => 4,
+            .generic => return .generic,
+        };
 
         const cfg = &target.config;
         const full_out_wide = @as(u64, cfg.num_attention_heads) * cfg.head_dim;
@@ -249,7 +303,7 @@ pub const MtpModel = struct {
         const kv_out_wide = @as(u64, cfg.num_key_value_heads) * cfg.head_dim;
         if (full_out_wide == 0 or full_out_wide > std.math.maxInt(u32) or
             q_out_wide > std.math.maxInt(u32) or
-            kv_out_wide == 0 or kv_out_wide > std.math.maxInt(u32)) return false;
+            kv_out_wide == 0 or kv_out_wide > std.math.maxInt(u32)) return .generic;
         const full_out: u32 = @intCast(full_out_wide);
         const q_out: u32 = @intCast(q_out_wide);
         const kv_out: u32 = @intCast(kv_out_wide);
@@ -258,36 +312,55 @@ pub const MtpModel = struct {
         if (mlx.mlx_array_dtype(self.fc_w_t) != .bfloat16 or
             fc_shape.len != 2 or
             fc_shape[0] != @as(c_int, @intCast(cfg.hidden_size * 2)) or
-            fc_shape[1] != @as(c_int, @intCast(cfg.hidden_size))) return false;
+            fc_shape[1] != @as(c_int, @intCast(cfg.hidden_size))) return .generic;
         if (!m5NaxNormMatches(self.pre_fc_norm_emb, cfg.hidden_size) or
             !m5NaxNormMatches(self.pre_fc_norm_hidden, cfg.hidden_size) or
             !m5NaxNormMatches(self.final_norm, cfg.hidden_size) or
             !m5NaxNormMatches(self.input_norm, cfg.hidden_size) or
             !m5NaxNormMatches(self.post_attn_norm, cfg.hidden_size) or
             !m5NaxNormMatches(self.q_norm, cfg.head_dim) or
-            !m5NaxNormMatches(self.k_norm, cfg.head_dim)) return false;
+            !m5NaxNormMatches(self.k_norm, cfg.head_dim)) return .generic;
 
-        if (!m5NaxQLinearMatches(&self.q, cfg.hidden_size, q_out, 8, 32) or
-            !m5NaxQLinearMatches(&self.k, cfg.hidden_size, kv_out, 8, 32) or
-            !m5NaxQLinearMatches(&self.v, cfg.hidden_size, kv_out, 8, 32) or
-            !m5NaxQLinearMatches(&self.o, full_out, cfg.hidden_size, 8, 32)) return false;
         switch (self.mlp) {
             .dense => |*mlp| {
-                if (!m5NaxQLinearMatches(&mlp.gate, cfg.hidden_size, cfg.intermediate_size, 8, 32) or
-                    !m5NaxQLinearMatches(&mlp.up, cfg.hidden_size, cfg.intermediate_size, 8, 32) or
-                    !m5NaxQLinearMatches(&mlp.down, cfg.intermediate_size, cfg.hidden_size, 8, 32)) return false;
+                if (!m5NaxDenseSidecarMatches(
+                    .{
+                        .q = &self.q,
+                        .k = &self.k,
+                        .v = &self.v,
+                        .o = &self.o,
+                        .gate = &mlp.gate,
+                        .up = &mlp.up,
+                        .down = &mlp.down,
+                    },
+                    .{
+                        .hidden = cfg.hidden_size,
+                        .q_out = q_out,
+                        .kv_out = kv_out,
+                        .full_out = full_out,
+                        .intermediate = cfg.intermediate_size,
+                        .bits = sidecar_bits,
+                        .group_size = 32,
+                    },
+                )) return .generic;
             },
-            .moe => return false,
+            .moe => return .generic,
         }
 
         const draft: ?*const QLinear = if (self.draft_head) |*q| q else null;
-        return m5NaxDraftHeadMatches(
+        return if (m5NaxDraftHeadMatches(
             draft,
             self.draft_head_bits,
             self.draft_head_group,
             cfg.hidden_size,
             cfg.vocab_size,
-        );
+        )) profile else .generic;
+    }
+
+    /// Legacy q8 boolean view retained for source compatibility. New callers
+    /// should use `m5NaxCostProfile` to distinguish q8 and q4 surfaces.
+    pub fn m5NaxCostProfileEnabled(self: *const MtpModel, target: *const Transformer) bool {
+        return self.m5NaxCostProfile(target) == .g17_nax_q8_gs32;
     }
 
     /// Validate the head against the target trunk: dims must line up and the
@@ -1761,7 +1834,7 @@ test "mtp: inferGroupSize geometry" {
     try testing.expectEqual(@as(u32, 32), (5120 / 160));
 }
 
-test "mtp: M5 NAX cost profile requires exact sidecar and draft-head quant geometry" {
+test "mtp: M5 NAX cost profiles require exact sidecar and draft-head quant geometry" {
     const s = mlx.gpuStream();
     const IN: u32 = 128;
     const OUT: u32 = 64;
@@ -1782,6 +1855,12 @@ test "mtp: M5 NAX cost profile requires exact sidecar and draft-head quant geome
         }
     };
 
+    try testing.expectEqual(MtpCostProfile.g17_nax_q8_gs32, m5NaxCostProfileForQuant(8, 32));
+    try testing.expectEqual(MtpCostProfile.g17_nax_q4_gs32, m5NaxCostProfileForQuant(4, 32));
+    try testing.expectEqual(MtpCostProfile.generic, m5NaxCostProfileForQuant(8, 64));
+    try testing.expectEqual(MtpCostProfile.generic, m5NaxCostProfileForQuant(4, 64));
+    try testing.expectEqual(MtpCostProfile.generic, m5NaxCostProfileForQuant(3, 32));
+
     var sidecar = try mk.qlinear(IN, OUT, 8, 32, s);
     defer sidecar.deinit();
     try testing.expect(m5NaxQLinearMatches(&sidecar, IN, OUT, 8, 32));
@@ -1789,12 +1868,56 @@ test "mtp: M5 NAX cost profile requires exact sidecar and draft-head quant geome
     try testing.expect(!m5NaxQLinearMatches(&sidecar, IN, OUT, 4, 32));
     try testing.expect(!m5NaxQLinearMatches(&sidecar, IN, OUT, 8, 64));
 
-    var off_bits = try mk.qlinear(IN, OUT, 4, 32, s);
-    defer off_bits.deinit();
-    try testing.expect(!m5NaxQLinearMatches(&off_bits, IN, OUT, 8, 32));
+    var sidecar_q4 = try mk.qlinear(IN, OUT, 4, 32, s);
+    defer sidecar_q4.deinit();
+    try testing.expect(m5NaxQLinearMatches(&sidecar_q4, IN, OUT, 4, 32));
+    try testing.expect(!m5NaxQLinearMatches(&sidecar_q4, IN, OUT, 8, 32));
+    try testing.expect(!m5NaxQLinearMatches(&sidecar_q4, IN, OUT, 4, 64));
     var off_group = try mk.qlinear(IN, OUT, 8, 64, s);
     defer off_group.deinit();
     try testing.expect(!m5NaxQLinearMatches(&off_group, IN, OUT, 8, 32));
+
+    var q4_set = [_]QLinear{
+        try mk.qlinear(IN, OUT, 4, 32, s),
+        try mk.qlinear(IN, OUT, 4, 32, s),
+        try mk.qlinear(IN, OUT, 4, 32, s),
+        try mk.qlinear(OUT, IN, 4, 32, s),
+        try mk.qlinear(IN, OUT, 4, 32, s),
+        try mk.qlinear(IN, OUT, 4, 32, s),
+        try mk.qlinear(OUT, IN, 4, 32, s),
+    };
+    defer for (&q4_set) |*q| q.deinit();
+    var q8_set = [_]QLinear{
+        try mk.qlinear(IN, OUT, 8, 32, s),
+        try mk.qlinear(IN, OUT, 8, 32, s),
+        try mk.qlinear(IN, OUT, 8, 32, s),
+        try mk.qlinear(OUT, IN, 8, 32, s),
+        try mk.qlinear(IN, OUT, 8, 32, s),
+        try mk.qlinear(IN, OUT, 8, 32, s),
+        try mk.qlinear(OUT, IN, 8, 32, s),
+    };
+    defer for (&q8_set) |*q| q.deinit();
+    const q4_linears: M5NaxDenseSidecarLinears = .{
+        .q = &q4_set[0], .k = &q4_set[1], .v = &q4_set[2], .o = &q4_set[3],
+        .gate = &q4_set[4], .up = &q4_set[5], .down = &q4_set[6],
+    };
+    const q8_linears: M5NaxDenseSidecarLinears = .{
+        .q = &q8_set[0], .k = &q8_set[1], .v = &q8_set[2], .o = &q8_set[3],
+        .gate = &q8_set[4], .up = &q8_set[5], .down = &q8_set[6],
+    };
+    const q4_geom: M5NaxDenseSidecarGeometry = .{
+        .hidden = IN, .q_out = OUT, .kv_out = OUT, .full_out = OUT,
+        .intermediate = OUT, .bits = 4, .group_size = 32,
+    };
+    const q8_geom: M5NaxDenseSidecarGeometry = .{
+        .hidden = IN, .q_out = OUT, .kv_out = OUT, .full_out = OUT,
+        .intermediate = OUT, .bits = 8, .group_size = 32,
+    };
+    try testing.expect(m5NaxDenseSidecarMatches(q4_linears, q4_geom));
+    try testing.expect(m5NaxDenseSidecarMatches(q8_linears, q8_geom));
+    var mixed = q4_linears;
+    mixed.up = &q8_set[5];
+    try testing.expect(!m5NaxDenseSidecarMatches(mixed, q4_geom));
 
     var draft = try mk.qlinear(IN, OUT, 3, 64, s);
     defer draft.deinit();

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -2574,15 +2574,15 @@ fn doLoadOnInferenceThread(sch: *Scheduler, params: anytype) !void {
     // an `mtp/weights.safetensors` sidecar that binds to this trunk; a
     // failed load or bind only disables the head — the model still serves.
     var mtp_ptr: ?*mtp_mod.MtpModel = null;
-    var mtp_nax_profile = false;
+    var mtp_cost_profile: mtp_mod.MtpCostProfile = .generic;
     if (params.mtp_enabled and mtp_mod.hasMtpSidecar(sch.io, params.model_dir)) {
         if (sch.allocator.create(mtp_mod.MtpModel)) |h| {
             if (mtp_mod.loadMtp(sch.io, sch.allocator, mlx.gpuStream(), params.model_dir)) |loaded| {
                 h.* = loaded;
                 if (h.bind(xfm_ptr)) {
                     mtp_ptr = h;
-                    mtp_nax_profile = h.m5NaxCostProfileEnabled(xfm_ptr);
-                    log.info("MTP head ready (depth={d}).\n", .{generate_mod.Generator.resolveMtpDepthCap(params.mtp_depth, mtp_nax_profile)});
+                    mtp_cost_profile = h.m5NaxCostProfile(xfm_ptr);
+                    log.info("MTP head ready (depth={d}).\n", .{generate_mod.Generator.resolveMtpDepthCapForProfile(params.mtp_depth, mtp_cost_profile)});
                 } else |bind_err| {
                     log.warn("MTP sidecar incompatible with target ({s}) — disabled.\n", .{@errorName(bind_err)});
                     h.deinit();
@@ -2631,7 +2631,7 @@ fn doLoadOnInferenceThread(sch: *Scheduler, params: anytype) !void {
     entry.mtp = mtp_ptr;
     // Resolve the auto (0) cap here so every downstream reader of
     // `lm.mtp_depth` (server log lines, slot params) sees the real value.
-    entry.mtp_depth = generate_mod.Generator.resolveMtpDepthCap(params.mtp_depth, mtp_nax_profile);
+    entry.mtp_depth = generate_mod.Generator.resolveMtpDepthCapForProfile(params.mtp_depth, mtp_cost_profile);
     entry.drafter_path = drafter_path_owned;
     drafter_path_owned = &[_]u8{}; // disarm the errdefer
     // Transfer ownership of the heap-allocated CPU state from `params` to


### PR DESCRIPTION
Follow-up to #83.

## Summary

- Select the adaptive MTP cost profile from exact runtime sidecar and draft-head quant geometry.
- Add a separately calibrated G17 NAX profile for homogeneous q4/gs32 MTP sidecars.
- Allow that profile to use the existing adaptive depth-8 cap.
- Preserve the existing q8 profile, generic fallback, environment overrides, and legacy boolean helper APIs.

## Why

The MTPLX q4/gs32 sidecar did not qualify for the existing q8/gs32 calibration, so it fell back to the conservative generic costs and stayed shallow even when NAX made verify widths 7–8 substantially cheaper. The earlier `--mtp-depth 8` experiment only raised the adaptive cap; the generic cost model still kept the realized depth shallow.

A fixed-depth M5 Max sweep with MLX 0.32.0 showed the NAX boundary clearly:

| Depth | NAX enabled | NAX disabled |
|---:|---:|---:|
| 6 | 62.56 ms | 62.47 ms |
| 7 | 64.43 ms | 79.94 ms |
| 8 | 66.06 ms | 91.61 ms |

The q4 profile uses fitted composite marginal costs of approximately `.11 / .20 / .05` for depths `1–3 / 4–6 / 7–8`.

## Results

On an M5 Max (64 GB), using MLX 0.32.0 and `ReleaseFast` builds, a targeted high-acceptance workload improved from:

- Generic q4 profile: realized depth 3, median `92.2 tok/s`
- Calibrated q4 profile: realized depth 8, median `121.3 tok/s`
- Improvement: **+31.6%**

Across repeated `llmprobe@0.2.0 --bench --quick` runs:

- Existing feature branch: approximately `47.6 tok/s`
- Calibrated candidate: approximately `49.8 tok/s`
- Improvement: approximately **+4.7%**

The larger gain is specific to workloads with enough acceptance to reach the inexpensive NAX widths.

## Validation

- `zig build test -Doptimize=ReleaseFast --summary all`: 956 passed, 78 skipped
- Added coverage for q4/q8 profile selection, mixed-quant rejection, missing draft-head fallback, cost selection, and adaptive caps
- The existing q8 profile remains unchanged and continues to select depth 8 (`119.5 / 120.7 / 120.6 tok/s` in the regression smoke test)
