### PR TITLE
fix: honor --pld in headless serve mode

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -836,7 +836,7 @@ pub fn main(init: std.process.Init) !void {
         if (model_dir.len == 0) {
             const discovery_for_registry = discovery_storage;
             discovery_storage = null; // ownership moves to the registry
-            try runHeadlessServe(io, allocator, discovery_for_registry, host, port, ctx_size, timeout, reasoning_budget, max_resident_models, max_resident_mem, max_resident_mem_explicit, idle_evict_secs, kv_quant_config, force_mtp);
+            try runHeadlessServe(io, allocator, discovery_for_registry, host, port, ctx_size, timeout, reasoning_budget, max_resident_models, max_resident_mem, max_resident_mem_explicit, idle_evict_secs, kv_quant_config, force_mtp, enable_pld);
             return;
         }
 
@@ -1497,6 +1497,7 @@ fn runHeadlessServe(
     idle_evict_secs: ?u32,
     kv_quant_config: transformer_mod.KVQuantConfig,
     force_mtp: bool,
+    enable_pld: bool,
 ) !void {
     log.info("mlx-serve {s} (headless — models load on demand)\n", .{VERSION});
     log.info("[args] serve: {s}:{d}\n", .{ host, port });
@@ -1586,7 +1587,12 @@ fn runHeadlessServe(
         .default_temperature = null,
         .default_top_p = null,
         .default_top_k = null,
-        .default_enable_pld = false,
+        // Honor --pld/--no-pld in headless mode. Hardcoding this false meant
+        // the flag's default never reached a headless request — only an
+        // explicit per-request "enable_pld": true did — while MLX Core's own
+        // UI describes Auto as "follow the server's --pld setting". Mirrors
+        // the --model startup path in main().
+        .default_enable_pld = enable_pld,
         .default_pld_draft_len = 5,
         .default_pld_key_len = 3,
         .default_kv_attn_fused = false,


### PR DESCRIPTION
`runHeadlessServe` hardcodes `default_enable_pld = false`, so the `--pld` flag's default never reaches a request in headless mode — the mode used whenever mlx-serve is started over a model directory rather than a single `--model`. Only an explicit per-request `"enable_pld": true` could turn PLD on.

This is easy to miss because nothing reports it: the flag parses fine, `--help` documents it, and the server starts clean. The `PLD speculative decoding: ENABLED` boot line is gated on the same field, so it simply never prints in headless mode.

It also disagrees with MLX Core. The app passes `--pld` from its own settings (`app/Sources/MLXServe/Models/ServerOptions.swift:459`) and describes the Auto setting as "follow the server's `--pld` setting" (`:861`) — which headless mode makes untrue.

## Change

Thread the CLI value into `runHeadlessServe`, mirroring how the `--model` startup path in `main()` already does it. `--no-pld` continues to disable it.

The other serve paths (`runGenServe`, `runDs4Serve`, `runLlamaServe`) keep their hardcoded `false` deliberately: their decode ticks bypass the PLD-capable generator, and gen-modality models reject chat/completions requests outright, so the field is dead weight there.

## Impact

On the host where this surfaced, `--pld` had been set in the launch script for months with no effect.

I want to be precise about the numbers, because the obvious ones aren't attributable to this change alone: that host also carries a local patch letting PLD take over when MTP's runtime gate trips, and the 110 → 182-190 tok/s decode improvement measured there needs both. For a stock server the honest claim is narrower — `--pld` now does what it says, and whether that helps depends on your workload.

## Testing

- `zig build test` — 956/1034 passed, 78 skipped, 0 failed
- `zig build -Doptimize=ReleaseFast` — clean

`cd app && swift test` could not be run: this machine has Command Line Tools rather than a full Xcode install, and the package manifest fails to link against the CLT `PackageDescription` library before any test executes. The change touches no Swift — the diff is 8 added lines and 2 removed in `src/main.zig` — but flagging it rather than implying the suite ran.

Environment: macOS 26.2, M4 Max, Zig 0.16, mlx 0.32.0.
