### PR TITLE
docs: document --ssm-checkpoint-stride and --ssm-checkpoint-max in --help

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -163,6 +163,24 @@ fn printUsage(io: std.Io) void {
         \\                        evictions instead of recomputed. Can use many
         \\                        GB of disk, so it's opt-in; e.g. 10GB. 0/off
         \\                        disables.
+        \\  --ssm-checkpoint-stride <n>
+        \\                      Hybrid SSM architectures only (e.g. Qwen3.5/3.6
+        \\                        GDN): capture an SSM/conv state checkpoint every
+        \\                        <n> tokens during chunked prefill, so a later
+        \\                        request sharing a prefix can restore mid-prompt
+        \\                        instead of re-prefilling (default: 256). 0
+        \\                        disables capture — hybrid models then bypass the
+        \\                        hot prefix cache entirely. On MoE targets the
+        \\                        effective stride is raised to the prefill chunk,
+        \\                        because each checkpoint forces a chunk boundary
+        \\                        and every extra chunk re-streams the expert
+        \\                        weights; see --prefill-chunk.
+        \\  --ssm-checkpoint-max <n>
+        \\                      Cap on SSM checkpoints retained per cache entry
+        \\                        (default: 32). The first stride-aligned position
+        \\                        is always kept; beyond the cap the oldest are
+        \\                        dropped. 0 = unlimited, bounded only by the
+        \\                        prefix cache's byte budget.
         \\  --tokenize-cache-entries <n>
         \\                      Per-model LRU cache of chat-template render +
         \\                        tokenize results (default: 4). Skips re-


### PR DESCRIPTION
Both flags are parsed in `main.zig` and carry real defaults (256 and 32), and the stride materially changes prefix-cache behaviour on hybrid SSM models — but neither appears in `--help`, so the only way to find them is reading the argument parser.

The new entry also records the MoE coarsening, which is the genuinely surprising part: on a MoE target `effectiveSsmCheckpointStride` raises the effective stride to the prefill chunk, so a short prompt gets a single end-of-prompt checkpoint no matter what value was passed. Without that note, someone who sets `--ssm-checkpoint-stride 256` on a MoE model and then sees `hybrid miss (no checkpoint ≤ N)` in the log has no way to tell whether the flag was overridden or simply ignored. I spent a while on exactly that before reading `generate.zig`.

Wording follows the existing `--prefix-cache-disk` and `--tokenize-cache-entries` entries, and cross-references `--prefill-chunk` as the knob that actually moves the clamp floor.

## Testing

- `zig build test` — 956/1034 passed, 78 skipped, 0 failed
- `zig build -Doptimize=ReleaseFast` — clean, and `mlx-serve serve --help` renders both new entries

`cd app && swift test` could not be run: this machine has Command Line Tools rather than a full Xcode install, and the package manifest fails to link against the CLT `PackageDescription` library before any test executes. This change is help text only and touches no Swift, but flagging it rather than implying the suite ran.

Environment: macOS 26.2, M4 Max, Zig 0.16, mlx 0.32.0.
