### PR TITLE
UI QOL

### DIFF
--- a/app/Sources/MLXServe/AppState.swift
+++ b/app/Sources/MLXServe/AppState.swift
@@ -656,6 +656,27 @@ class AppState: ObservableObject {
         saveChatHistory()
     }
 
+    /// Batch delete — the sidebar's multi-select "Delete" action. Mirrors
+    /// `deleteSession` per id (killing background processes, dropping
+    /// bookmarks, stopping orphaned turns) rather than calling it in a loop,
+    /// so history is only saved once at the end.
+    func deleteSessions(_ ids: Set<UUID>) {
+        guard !ids.isEmpty else { return }
+        for id in ids {
+            processRegistry.killSession(id)
+            documentIndexes[id]?.cancel()
+            documentIndexes.removeValue(forKey: id)
+            SecurityScopedBookmark.clear(name: SecurityScopedBookmark.workingFolderName(id))
+            SecurityScopedBookmark.clear(name: SecurityScopedBookmark.attachedFolderName(id))
+        }
+        chatSessions.removeAll { ids.contains($0.id) }
+        chatEngine.stopIfOrphaned()
+        if let active = activeChatId, ids.contains(active) {
+            activeChatId = chatSessions.first?.id
+        }
+        saveChatHistory()
+    }
+
     func updateLastMessage(in sessionId: UUID, content: String? = nil, reasoning: String? = nil, streaming: Bool? = nil, usage: TokenUsage? = nil) {
         guard let sIdx = chatSessions.firstIndex(where: { $0.id == sessionId }),
               !chatSessions[sIdx].messages.isEmpty else { return }

--- a/app/Sources/MLXServe/AppState.swift
+++ b/app/Sources/MLXServe/AppState.swift
@@ -644,6 +644,18 @@ class AppState: ObservableObject {
         saveChatHistory()
     }
 
+    /// Drops every message from `count` onward, keeping only the first `count`.
+    /// Used by regenerate (drop the old user turn + reply so `runTurn` can
+    /// re-append a fresh copy) and by edit-and-resend (drop everything from
+    /// the edited message onward before resubmitting its new text).
+    func truncateMessages(in sessionId: UUID, keepingFirst count: Int) {
+        guard let sIdx = chatSessions.firstIndex(where: { $0.id == sessionId }),
+              count < chatSessions[sIdx].messages.count else { return }
+        chatSessions[sIdx].messages.removeSubrange(count...)
+        chatSessions[sIdx].updatedAt = Date()
+        saveChatHistory()
+    }
+
     func updateLastMessage(in sessionId: UUID, content: String? = nil, reasoning: String? = nil, streaming: Bool? = nil, usage: TokenUsage? = nil) {
         guard let sIdx = chatSessions.firstIndex(where: { $0.id == sessionId }),
               !chatSessions[sIdx].messages.isEmpty else { return }

--- a/app/Sources/MLXServe/MLXServeApp.swift
+++ b/app/Sources/MLXServe/MLXServeApp.swift
@@ -255,6 +255,13 @@ struct MLXCoreApp: App {
         }
         .defaultSize(width: 900, height: 620)
         .commands {
+            CommandGroup(replacing: .newItem) {
+                    Button("New Chat") {
+                        openAndFocus("chat")
+                        _ = appState.newChatSession()
+                    }
+                    .keyboardShortcut("n", modifiers: [.command])
+                }
             CommandMenu("Agent") {
                 Button("Agents…") { openAndFocus("agents") }
                     .keyboardShortcut("a", modifiers: [.command, .shift])

--- a/app/Sources/MLXServe/Services/ChatTurnEngine.swift
+++ b/app/Sources/MLXServe/Services/ChatTurnEngine.swift
@@ -430,6 +430,24 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
         }
     }
 
+    /// Regenerate the last reply: drop the last user turn (and whatever
+    /// followed it — the old assistant reply, any tool-call chain) and
+    /// resubmit that same user text as a fresh turn. Reuses `runTurn` rather
+    /// than duplicating the plain/agent branching, so a regenerated turn is
+    /// indistinguishable from a freshly sent one.
+    func regenerate(sessionId: UUID, config: TurnConfig,
+                     approval: @escaping (APIClient.ToolCall) async -> Bool) {
+        guard let msgs = session(sessionId)?.messages,
+              let lastUserIdx = msgs.lastIndex(where: { $0.role == .user })
+        else { return }
+        let text = msgs[lastUserIdx].content
+        let images = msgs[lastUserIdx].images
+        let audio = msgs[lastUserIdx].audio
+        appState.truncateMessages(in: sessionId, keepingFirst: lastUserIdx)
+        runTurn(sessionId: sessionId, userText: text, images: images, audio: audio,
+                config: config, approval: approval)
+    }
+
     // MARK: - Plain chat
 
     private func runPlainTurn(sessionId: UUID, text: String,

--- a/app/Sources/MLXServe/Services/CustomPromptExamples.swift
+++ b/app/Sources/MLXServe/Services/CustomPromptExamples.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// User-provided prompt examples loaded from `~/.mlx-serve/examples/`.
+/// Drop a `.txt` file into the appropriate subdirectory — each file becomes
+/// a named group in the Examples menu, and each non-empty line becomes a
+/// separate clickable prompt (auto-titled from its first few words).
+///
+/// Directory layout:
+///   ~/.mlx-serve/examples/
+///     video/          → VideoGenView's Examples menu
+///     image/          → ImageGenView's Examples menu (text-to-image mode)
+///     image-edit/     → ImageGenView's Examples menu (edit mode)
+///
+/// File format (one prompt per line):
+///   ~/.mlx-serve/examples/image/PartiPrompts.txt:
+///     A portrait of a kangaroo wearing a purple hoodie
+///     A blue jay standing on a basket of rainbow macarons
+///     A corgi wearing a pirate hat and eyepatch
+struct CustomPromptExamples {
+    let title: String
+    let body: String
+
+    /// Load every `.txt` file from `~/.mlx-serve/examples/<subdirectory>/`.
+    /// Each file becomes its own group (filename minus extension = group name).
+    /// Each non-empty line becomes a prompt with an auto-generated title from
+    /// its first few words. Returns empty when the directory doesn't exist
+    /// or contains no valid prompt files.
+    static func load(for category: String) -> [ImagePromptExampleGroup] {
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".mlx-serve/examples/\(category)")
+
+        guard let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+        else { return [] }
+
+        return files
+            .filter { $0.pathExtension.lowercased() == "txt" }
+            .compactMap { file -> ImagePromptExampleGroup? in
+                guard let content = try? String(contentsOf: file, encoding: .utf8),
+                      !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                else { return nil }
+
+                let prompts = content
+                    .components(separatedBy: .newlines)
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty }
+                    .map { line -> ImagePromptExample in
+                        let title = Self.autoTitle(from: line)
+                        return ImagePromptExample(title: title, body: line)
+                    }
+
+                guard !prompts.isEmpty else { return nil }
+
+                let groupName = file.deletingPathExtension().lastPathComponent
+                return ImagePromptExampleGroup(name: groupName, examples: prompts)
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Generate a short title from the first few words of a prompt line.
+    /// Caps at ~40 characters, adds ellipsis if truncated.
+    private static func autoTitle(from line: String) -> String {
+        let words = line.split(separator: " ")
+        let preview = words.prefix(6).joined(separator: " ")
+        if preview.count > 40 {
+            return String(preview.prefix(40)).trimmingCharacters(in: .whitespaces) + "…"
+        }
+        if words.count > 6 {
+            return preview + "…"
+        }
+        return preview
+    }
+}

--- a/app/Sources/MLXServe/Services/MediaGen.swift
+++ b/app/Sources/MLXServe/Services/MediaGen.swift
@@ -965,11 +965,17 @@ extension ImageModelPreset {
     /// only way to discover that it can produce a depth map or de-rain a photo
     /// is to be shown the sentence that does it.
     func promptExamples(editing: Bool) -> [ImagePromptExampleGroup] {
-        guard editing && supportsReferenceEdit else { return ImagePromptExamples.textToImage }
-        switch variant {
-        case .mageFlowEditTurbo: return ImagePromptExamples.mageFlowEdit
-        default: return ImagePromptExamples.genericEdit
+        let builtin: [ImagePromptExampleGroup]
+        if !(editing && supportsReferenceEdit) {
+            builtin = ImagePromptExamples.textToImage
+        } else {
+            switch variant {
+            case .mageFlowEditTurbo: builtin = ImagePromptExamples.mageFlowEdit
+            default: builtin = ImagePromptExamples.genericEdit
+            }
         }
+        let custom = CustomPromptExamples.load(for: editing && supportsReferenceEdit ? "image-edit" : "image")
+        return builtin + custom
     }
 
     /// The resolution menu for the current mode. In EDIT mode an edit-capable

--- a/app/Sources/MLXServe/Views/ChatView.swift
+++ b/app/Sources/MLXServe/Views/ChatView.swift
@@ -3464,7 +3464,7 @@ fileprivate struct GrowingTextEditor: NSViewRepresentable {
     var isIdle: Bool
     var onSend: () -> Void
 
-    let inset = NSSize(width: 7, height: 8)
+    let inset = NSSize(width: 2, height: 8)
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 

--- a/app/Sources/MLXServe/Views/ChatView.swift
+++ b/app/Sources/MLXServe/Views/ChatView.swift
@@ -1168,6 +1168,12 @@ struct ChatDetailView: View {
         (session?.messages.isEmpty ?? true) && composerState != .generatingHere
     }
 
+    /// Which reply Cmd+R / the footer's Regenerate button targets — the
+    /// last assistant message, so the button only ever shows on that one.
+    private var lastAssistantMessageId: UUID? {
+        session?.messages.last { $0.role == .assistant }?.id
+    }
+
     private var emptyState: some View {
         VStack(spacing: 10) {
             Spacer()
@@ -1206,7 +1212,13 @@ struct ChatDetailView: View {
                                     },
                                     onDelete: {
                                         appState.deleteMessage(in: sessionId, messageId: m.id)
-                                    })
+                                    },
+                                    onEdit: (m.role == .user && session?.isExternalBridge != true)
+                                        ? { newText in editAndResend(messageId: m.id, newText: newText) }
+                                        : nil,
+                                    onRegenerate: (m.role == .assistant && m.id == lastAssistantMessageId)
+                                        ? { regenerateLastResponse() }
+                                        : nil)
                                 .id(m.id)
                             case .toolCall(let call, let results):
                                 ToolCallRow(call: call, results: results).id(call.id)
@@ -1359,6 +1371,18 @@ struct ChatDetailView: View {
             // bottom of an otherwise blank window.
             if isEmptyConversation { Spacer() }
         }
+        // Cmd+R — regenerate the last reply. A zero-size hidden button rather
+        // than a window-level `.commands` entry: it needs THIS tab's session
+        // and toolbar state, and disabling it here (rather than graying out a
+        // menu item elsewhere) is what keeps it from firing mid-stream or on
+        // an empty chat.
+        .background(
+            Button(action: regenerateLastResponse) { EmptyView() }
+                .keyboardShortcut("r", modifiers: .command)
+                .disabled(!canRegenerate)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+        )
         .onDrop(of: [.image, .pdf, .audio], isTargeted: nil) { providers in
             for provider in providers {
                 if provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) {
@@ -2095,9 +2119,18 @@ struct ChatDetailView: View {
             text = text.isEmpty ? pdfText : pdfText + "\n\n" + text
         }
 
-        // The toolbar toggles are this surface's DEFAULTS; the tab's agent (if
-        // any) overrides what it declared. One builder, so no field is read from
-        // a global here — see ChatTurnEngine.TurnConfig.
+        chatEngine.runTurn(sessionId: sessionId, userText: text,
+                           images: attachedImages, audio: attachedAudio,
+                           config: buildTurnConfig(),
+                           approval: { await requestToolApproval($0) })
+    }
+
+    /// The toolbar toggles are this surface's DEFAULTS; the tab's agent (if
+    /// any) overrides what it declared. One builder, so no field is read from
+    /// a global here — see ChatTurnEngine.TurnConfig. Shared by send, Cmd+R
+    /// regenerate, and edit-and-resend so all three run under identical
+    /// settings.
+    private func buildTurnConfig() -> ChatTurnEngine.TurnConfig {
         let resolved = appState.resolvedAgentSettings(
             agentId: session?.agentId,
             toolsEnabled: isAgentMode,
@@ -2106,11 +2139,44 @@ struct ChatDetailView: View {
             autoApprove: false,
             workingDirectory: session?.workingDirectory,
             disabledTools: ChatSession.disabledToolKinds(session?.disabledTools ?? []))
-        let config = ChatTurnEngine.TurnConfig.from(
+        return ChatTurnEngine.TurnConfig.from(
             resolved, documentIndex: appState.documentIndexes[sessionId])
-        chatEngine.runTurn(sessionId: sessionId, userText: text,
-                           images: attachedImages, audio: attachedAudio,
-                           config: config,
+    }
+
+    /// Cmd+R — regenerate the last reply. Mirrors the footer's Regenerate
+    /// button; both funnel through `ChatTurnEngine.regenerate`, which drops
+    /// the last user turn and resubmits it fresh.
+    private var canRegenerate: Bool {
+        server.status == .running && composerState != .generatingHere
+            && session?.isExternalBridge != true
+            && (session?.messages.contains { $0.role == .user } ?? false)
+    }
+
+    private func regenerateLastResponse() {
+        guard canRegenerate else { return }
+        isNearBottom = true
+        chatEngine.regenerate(sessionId: sessionId, config: buildTurnConfig(),
+                               approval: { await requestToolApproval($0) })
+    }
+
+    /// Edit a past user message in place, then resend it: everything from
+    /// that message onward (its old reply, any tool chain) is dropped and the
+    /// edited text runs as a brand-new turn — the standard "edit and resend"
+    /// behaviour rather than silently rewriting history the model already
+    /// answered.
+    private func editAndResend(messageId: UUID, newText: String) {
+        let trimmed = newText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let msgs = session?.messages,
+              let idx = msgs.firstIndex(where: { $0.id == messageId })
+        else { return }
+        let images = msgs[idx].images
+        let audio = msgs[idx].audio
+        isNearBottom = true
+        appState.truncateMessages(in: sessionId, keepingFirst: idx)
+        chatEngine.runTurn(sessionId: sessionId, userText: trimmed,
+                           images: images, audio: audio,
+                           config: buildTurnConfig(),
                            approval: { await requestToolApproval($0) })
     }
 
@@ -2302,8 +2368,18 @@ struct MessageBubble: View {
     /// a task run's transcript is a record, so it has no delete affordance
     /// rather than one that silently does nothing.
     var onDelete: (() -> Void)?
+    /// Edit this (user) message's text and resend it, dropping everything
+    /// that followed. nil for assistant messages and read-only surfaces —
+    /// same reasoning as `onDelete`.
+    var onEdit: ((String) -> Void)?
+    /// Regenerate this reply. Only ever set on the LAST assistant message —
+    /// the caller decides that, so the bubble itself doesn't need to know its
+    /// position in the transcript.
+    var onRegenerate: (() -> Void)?
     /// Explicit so the accordion HEADER can drive it, not just the chevron.
     @State private var thinkingExpanded = false
+    @State private var isEditing = false
+    @State private var editDraft = ""
 
     var body: some View {
         // A failure notice is not model output: it renders as its own card
@@ -2397,7 +2473,9 @@ struct MessageBubble: View {
                 // tables — and boxing it wastes the column's width and fights
                 // every block that wants the full measure. A tool-call summary
                 // keeps its card so it still reads as machinery, not prose.
-                if !message.content.isEmpty || message.isStreaming {
+                if isEditing, onEdit != nil {
+                    editingContent
+                } else if !message.content.isEmpty || message.isStreaming {
                     VStack(alignment: .leading, spacing: 4) {
                         if message.isAgentSummary {
                             Label("Tool Call", systemImage: "wrench.and.screwdriver")
@@ -2415,6 +2493,20 @@ struct MessageBubble: View {
                             GeneratingIndicator()
                         }
                     }
+                    // `.highPriorityGesture`, not `.onTapGesture` — the `Text`
+                    // above has `.textSelection(.enabled)`, which installs its
+                    // OWN double-click-to-select-word handling. A plain
+                    // `.onTapGesture(count: 2)` sits behind that in the
+                    // gesture hierarchy and never sees the second click, so
+                    // double-click silently did nothing. `highPriorityGesture`
+                    // makes this the one that wins.
+                    .highPriorityGesture(
+                        TapGesture(count: 2).onEnded {
+                            if onEdit != nil {
+                                startEditing()
+                            }
+                        }
+                    )
                     .padding(.horizontal, isBare ? 0 : ChatMetrics.bubblePaddingH)
                     .padding(.vertical, isBare ? 0 : ChatMetrics.bubblePaddingV)
                     .background(bubbleBackground)
@@ -2437,10 +2529,62 @@ struct MessageBubble: View {
         }
         .contextMenu {
             Button("Copy Message") { copyMessage() }
+            if onEdit != nil {
+                Button("Edit Message") { startEditing() }
+            }
+            if onRegenerate != nil {
+                Button("Regenerate") { onRegenerate?() }
+            }
             if onDelete != nil {
                 Button("Delete Message", role: .destructive) { onDelete?() }
             }
         }
+    }
+
+    /// Replaces the static bubble while editing: a growing multi-line field
+    /// pre-filled with the message's current text, Cancel / Save beneath it.
+    /// Save hands the new text to `onEdit`, which drops this message and
+    /// everything after it and resubmits — same shape as a fresh send.
+    private var editingContent: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            TextEditor(text: $editDraft)
+                .font(.body)
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 36, maxHeight: 220)
+                .padding(6)
+                .background(Color(nsColor: .textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            HStack(spacing: 8) {
+                Button("Cancel") { cancelEdit() }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    // .cancelAction binds this to Esc — standard macOS
+                    // convention, and simpler than an onExitCommand that
+                    // depends on the TextEditor actually holding focus.
+                    .keyboardShortcut(.cancelAction)
+                Button("Save") { commitEdit() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(editDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .font(.caption)
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+
+    private func startEditing() {
+        editDraft = message.content
+        isEditing = true
+    }
+
+    private func cancelEdit() {
+        isEditing = false
+        editDraft = ""
+    }
+
+    private func commitEdit() {
+        let text = editDraft
+        isEditing = false
+        onEdit?(text)
     }
 
     // MARK: - Bubble vs bare
@@ -2490,6 +2634,10 @@ struct MessageBubble: View {
 
             HStack(spacing: 2) {
                 footerButton("doc.on.doc", help: "Copy this reply") { copyMessage() }
+                if let onRegenerate {
+                    footerButton("arrow.clockwise", help: "Regenerate this reply (⌘R)",
+                                 action: onRegenerate)
+                }
                 if let onDelete {
                     footerButton("trash", help: "Delete this message from the conversation",
                                  action: onDelete)

--- a/app/Sources/MLXServe/Views/ChatView.swift
+++ b/app/Sources/MLXServe/Views/ChatView.swift
@@ -476,12 +476,35 @@ struct ChatSidebar: View {
     @EnvironmentObject var appState: AppState
     @Environment(\.openWindow) private var openWindow
     @State private var hoveredSessionId: UUID?
+    /// Bulk-delete mode: checkboxes replace the hover-only delete glyph and
+    /// row taps toggle membership in `selectedForDeletion` instead of opening
+    /// the chat. A separate mode (rather than repurposing the List's own
+    /// `UUID?` selection, which drives `activeChatId` app-wide) so entering it
+    /// can never change what chat is open underneath.
+    @State private var isSelecting = false
+    @State private var selectedForDeletion: Set<UUID> = []
+    @State private var showBulkDeleteConfirm = false
 
     var body: some View {
         List(selection: $appState.activeChatId) {
             ForEach(appState.visibleChatSessions) { session in
                 let isSelected = session.id == appState.activeChatId
                 HStack(spacing: 0) {
+                    if isSelecting {
+                        Button {
+                            toggleSelection(session.id)
+                        } label: {
+                            Image(systemName: selectedForDeletion.contains(session.id)
+                                  ? "checkmark.circle.fill" : "circle")
+                                .font(.system(size: 15))
+                                .symbolRenderingMode(.hierarchical)
+                                .foregroundStyle(selectedForDeletion.contains(session.id)
+                                                  ? Color.accentColor
+                                                  : (isSelected ? .white.opacity(0.8) : .secondary))
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.trailing, 8)
+                    }
                     VStack(alignment: .leading, spacing: 2) {
                         HStack(spacing: 4) {
                             if session.isExternalBridge {
@@ -521,7 +544,7 @@ struct ChatSidebar: View {
                         }
                     }
                     Spacer(minLength: 4)
-                    if hoveredSessionId == session.id {
+                    if !isSelecting, hoveredSessionId == session.id {
                         Button {
                             appState.deleteSession(session.id)
                         } label: {
@@ -534,13 +557,30 @@ struct ChatSidebar: View {
                         .help("Delete chat")
                     }
                 }
+                .contentShape(Rectangle())
                 .tag(session.id)
+                .onTapGesture {
+                    if isSelecting { 
+                        toggleSelection(session.id) 
+                    } else if NSEvent.modifierFlags.contains(.shift) {
+                        isSelecting = true
+                        selectedForDeletion = selectionRange(to: session.id)
+                    } else {
+                        // gotta do this manually now since the tap gesture 
+                        // intercepts the default list selection
+                        appState.activeChatId = session.id
+                    }
+                }
                 .onHover { isHovered in
                     hoveredSessionId = isHovered ? session.id : nil
                 }
                 .listRowBackground(
                     Group {
-                        if isSelected {
+                        if isSelecting && selectedForDeletion.contains(session.id) {
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color.accentColor.opacity(0.25))
+                                .padding(.horizontal, 6)
+                        } else if isSelected {
                             RoundedRectangle(cornerRadius: 8)
                                 .fill(Color.accentColor)
                                 .padding(.horizontal, 6)
@@ -553,6 +593,10 @@ struct ChatSidebar: View {
                 .contextMenu {
                     Button("Delete", role: .destructive) {
                         appState.deleteSession(session.id)
+                    }
+                    Button("Select Multiple…") {
+                        isSelecting = true
+                        selectedForDeletion = [session.id]
                     }
                 }
             }
@@ -570,25 +614,118 @@ struct ChatSidebar: View {
         // control it configures. The sidebar is the conversation list, and a
         // second route to the same two windows only competed with it.
         .safeAreaInset(edge: .bottom) {
-            HStack(spacing: 8) {
-                Button {
-                    _ = appState.newChatSession()
-                } label: {
-                    Label("New Chat", systemImage: "plus")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .contentShape(Rectangle())
+            if isSelecting {
+                bulkDeleteBar
+            } else {
+                HStack(spacing: 8) {
+                    Button {
+                        _ = appState.newChatSession()
+                    } label: {
+                        Label("New Chat", systemImage: "plus")
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .contentShape(Rectangle())
+                    }
+                    // `.plain` + our own frame and background, NOT `.bordered` —
+                    // see `ChatMetrics.sidebarButtonHeight`. It is the only way the
+                    // two controls are the same height by construction rather than
+                    // by whatever a style style decides their labels are worth.
+                    .buttonStyle(.plain)
+                    .sidebarActionButton()
+                    newAgentChatMenu
                 }
-                // `.plain` + our own frame and background, NOT `.bordered` —
-                // see `ChatMetrics.sidebarButtonHeight`. It is the only way the
-                // two controls are the same height by construction rather than
-                // by whatever a style style decides their labels are worth.
-                .buttonStyle(.plain)
-                .sidebarActionButton()
-                newAgentChatMenu
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
         }
+        .confirmationDialog(
+            selectedForDeletion.count == 1
+                ? "Delete this chat?"
+                : "Delete \(selectedForDeletion.count) chats?",
+            isPresented: $showBulkDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Delete \(selectedForDeletion.count == 1 ? "Chat" : "\(selectedForDeletion.count) Chats")",
+                   role: .destructive) {
+                appState.deleteSessions(selectedForDeletion)
+                selectedForDeletion.removeAll()
+                isSelecting = false
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This can't be undone.")
+        }
+    }
+
+    /// Replaces the New Chat bar while `isSelecting` is on: Cancel exits the
+    /// mode, Select All toggles between all-selected and none, and Delete
+    /// fires the confirmation before actually removing anything (a bulk
+    /// action deserves the extra guard a single delete's context menu skips).
+    private var bulkDeleteBar: some View {
+        HStack(spacing: 8) {
+            Button("Cancel") {
+                isSelecting = false
+                selectedForDeletion.removeAll()
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            // .cancelAction binds this to Esc, same as the edit bubble's
+            // Cancel button — only live while this bar is on screen, i.e.
+            // only while `isSelecting` is true.
+            .keyboardShortcut(.cancelAction)
+
+            Spacer()
+
+            Button(selectedForDeletion.count == appState.visibleChatSessions.count
+                   ? "Deselect All" : "Select All") {
+                if selectedForDeletion.count == appState.visibleChatSessions.count {
+                    selectedForDeletion.removeAll()
+                } else {
+                    selectedForDeletion = Set(appState.visibleChatSessions.map(\.id))
+                }
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+
+            Button {
+                showBulkDeleteConfirm = true
+            } label: {
+                Label("Delete\(selectedForDeletion.isEmpty ? "" : " (\(selectedForDeletion.count))")",
+                      systemImage: "trash")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.red)
+            .disabled(selectedForDeletion.isEmpty)
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    private func toggleSelection(_ id: UUID) {
+        if selectedForDeletion.contains(id) {
+            selectedForDeletion.remove(id)
+        } else {
+            selectedForDeletion.insert(id)
+        }
+    }
+
+    /// Shift-click's range: everything between the chat that's currently
+    /// open and the row that was shift-clicked, inclusive, in the sidebar's
+    /// own order — not just the two endpoints. Anchored on `activeChatId`
+    /// (the open chat) rather than wherever a previous shift-click landed,
+    /// since that's the reference point the person can actually see. Falls
+    /// back to just the clicked row if there's no open chat to anchor on
+    /// (e.g. nothing selected yet) or either end can't be located.
+    private func selectionRange(to targetId: UUID) -> Set<UUID> {
+        let sessions = appState.visibleChatSessions
+        guard let anchorId = appState.activeChatId,
+              let anchorIndex = sessions.firstIndex(where: { $0.id == anchorId }),
+              let targetIndex = sessions.firstIndex(where: { $0.id == targetId })
+        else {
+            return [targetId]
+        }
+        let range = anchorIndex <= targetIndex ? anchorIndex...targetIndex : targetIndex...anchorIndex
+        return Set(sessions[range].map(\.id))
     }
 
     /// Start a chat AS an agent.
@@ -1175,6 +1312,10 @@ struct ChatDetailView: View {
     }
 
     private var emptyState: some View {
+        // Was a single LEADING Spacer, so the greeting hugged the bottom of
+        // whatever box the outer layout gave this view — i.e. sat just above
+        // the composer with a tall gap above it. A trailing Spacer balances
+        // it so the text centers in that box instead of pinning to its floor.
         VStack(spacing: 10) {
             Spacer()
             Text("How can I help you today?")
@@ -1188,8 +1329,9 @@ struct ChatDetailView: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
             }
+            Spacer()
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     var body: some View {

--- a/app/Sources/MLXServe/Views/ImageGenView.swift
+++ b/app/Sources/MLXServe/Views/ImageGenView.swift
@@ -58,10 +58,21 @@ struct ImageGenView: View {
     @State private var hydrating: Bool = false
     /// Hydrate exactly once per window lifetime (the first `.onAppear`).
     @State private var didHydrate: Bool = false
+    /// True while a drag carrying a file is hovering the window — drives the
+    /// dashed-border drop overlay, same idiom as the chat composer's drop zone.
+    @State private var isDropTargeted: Bool = false
 
     var body: some View {
         readyView
         .frame(minWidth: 880, minHeight: 640)
+        // Drop an image anywhere in the window — not just onto the "Choose
+        // image…" button. Routed intelligently in placeDroppedImage: first
+        // drop becomes the source, later drops become references (or replace
+        // the source outright in single-image variation mode).
+        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
+            handleImageDrop(providers)
+        }
+        .overlay { dropOverlay }
         .onAppear {
             if !didHydrate {
                 hydrating = true
@@ -116,6 +127,19 @@ struct ImageGenView: View {
             }
         } message: {
             Text(ramWarningMessage)
+        }
+    }
+
+    /// Dashed highlight shown while a drag is over the window, so the drop
+    /// target reads as live rather than the drop silently doing nothing.
+    @ViewBuilder
+    private var dropOverlay: some View {
+        if isDropTargeted {
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(Color.accentColor, style: StrokeStyle(lineWidth: 3, dash: [8]))
+                .background(Color.accentColor.opacity(0.06))
+                .allowsHitTesting(false)
+                .padding(6)
         }
     }
 
@@ -534,6 +558,52 @@ struct ImageGenView: View {
         if AppActivation.runModal(panel) == .OK, let url = panel.url, refImageURLs.count < 3 {
             refImageURLs.append(url)
         }
+    }
+
+    /// Entry point for `.onDrop`: pulls a file URL out of each provider and,
+    /// once resolved, hands it to `placeDroppedImage` on the main actor (item
+    /// providers resolve asynchronously, off the UI thread). Returns whether
+    /// the drop was even worth accepting — SwiftUI uses this to animate the
+    /// drop away or bounce it back.
+    private func handleImageDrop(_ providers: [NSItemProvider]) -> Bool {
+        let candidates = providers.filter { $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) }
+        guard !candidates.isEmpty else { return false }
+        for provider in candidates {
+            provider.loadObject(ofClass: URL.self) { url, _ in
+                guard let url, Self.isImageFile(url) else { return }
+                DispatchQueue.main.async { placeDroppedImage(url) }
+            }
+        }
+        return true
+    }
+
+    /// A dropped file counts as an image by extension, matching the panel's
+    /// `allowedContentTypes` (png/jpeg/heic) plus the couple of common
+    /// formats NSImage also opens fine (webp, tiff, gif, bmp).
+    private static func isImageFile(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        return ["png", "jpg", "jpeg", "heic", "heif", "webp", "tiff", "tif", "gif", "bmp"].contains(ext)
+    }
+
+    /// Where a dropped image lands, in priority order:
+    /// 1. No source yet → it becomes the source (same as "Choose image…").
+    /// 2. Source set, edit mode, room left in the 3-reference cap → it joins
+    ///    `refImageURLs` (same as "Add reference image…").
+    /// 3. Source set, plain variation mode (single image slot, no references
+    ///    exist in that mode) → it replaces the source.
+    /// 4. Source set, edit mode, references already full → dropped, no-op;
+    ///    the user would need to remove one first, same as the picker button
+    ///    disappearing at 3.
+    private func placeDroppedImage(_ url: URL) {
+        if initImageURL == nil {
+            initImageURL = url
+            return
+        }
+        if effectiveEditMode && model.supportsReferenceEdit {
+            if refImageURLs.count < 3 { refImageURLs.append(url) }
+            return
+        }
+        initImageURL = url
     }
 
     private func chooseLora() {

--- a/app/Sources/MLXServe/Views/VideoGenView.swift
+++ b/app/Sources/MLXServe/Views/VideoGenView.swift
@@ -58,10 +58,19 @@ struct VideoGenView: View {
     /// Hydration guard — see ImageGenView for the full rationale.
     @State private var hydrating: Bool = false
     @State private var didHydrate: Bool = false
+    /// True while a drag carrying a file hovers the window — drives the
+    /// dashed-border drop overlay (see ImageGenView, same idiom).
+    @State private var isDropTargeted: Bool = false
 
     var body: some View {
         readyView
         .frame(minWidth: 880, minHeight: 660)
+        // Drop an image anywhere in the window to set it as the first frame —
+        // not just onto the "Choose image..." button.
+        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
+            handleImageDrop(providers)
+        }
+        .overlay { dropOverlay }
         .onAppear {
             if !didHydrate {
                 hydrating = true
@@ -144,6 +153,18 @@ struct VideoGenView: View {
         }
     }
 
+    /// Dashed highlight shown while a drag is over the window.
+    @ViewBuilder
+    private var dropOverlay: some View {
+        if isDropTargeted {
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(Color.accentColor, style: StrokeStyle(lineWidth: 3, dash: [8]))
+                .background(Color.accentColor.opacity(0.06))
+                .allowsHitTesting(false)
+                .padding(6)
+        }
+    }
+
     // MARK: - Sections
 
     private var promptSection: some View {
@@ -154,6 +175,19 @@ struct VideoGenView: View {
                 Menu("Examples") {
                     ForEach(Self.examplePrompts, id: \.title) { ex in
                         Button(ex.title) { prompt = ex.body }
+                    }
+                    // User-dropped prompts from ~/.mlx-serve/examples/video/
+                    // — read fresh on every menu open, so no restart needed
+                    // to pick up a newly-added file.
+                    let custom = CustomPromptExamples.load(for: "video")
+                        if !custom.isEmpty {
+                            ForEach(custom, id: \.name) { group in
+                                Section(group.name) {
+                                    ForEach(group.examples, id: \.title) { ex in
+                                        Button(ex.title) { prompt = ex.body }
+                                }
+                            }
+                        }
                     }
                 }
                 .menuStyle(.borderlessButton)
@@ -718,6 +752,27 @@ struct VideoGenView: View {
         if AppActivation.runModal(panel) == .OK, let url = panel.url {
             firstFrameImageURL = url
         }
+    }
+
+    /// Entry point for `.onDrop`: only one image slot exists on this pane
+    /// (the first frame), so unlike ImageGen's source/reference routing this
+    /// is just "the dropped image becomes — or replaces — the first frame."
+    /// Item providers resolve asynchronously off the UI thread, so the
+    /// actual assignment happens back on the main actor.
+    private func handleImageDrop(_ providers: [NSItemProvider]) -> Bool {
+        let candidates = providers.filter { $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) }
+        guard let provider = candidates.first else { return false }
+        provider.loadObject(ofClass: URL.self) { url, _ in
+            guard let url, Self.isImageFile(url) else { return }
+            DispatchQueue.main.async { firstFrameImageURL = url }
+        }
+        return true
+    }
+
+    /// Same extension allow-list as ImageGenView's drop handling.
+    private static func isImageFile(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+        return ["png", "jpg", "jpeg", "heic", "heif", "webp", "tiff", "tif", "gif", "bmp"].contains(ext)
     }
 
     private func numberField(_ label: String, value: Binding<Int>, step: Int) -> some View {


### PR DESCRIPTION
- Edit your own messages with double click in chat view
- Regenerate responses using arrow icon or cmd ⌘+R shortcut
- Shift click to select multiple chats and open menu for chat selection and deletion (or open menu by right clicking a chat)
- adjust inset of text cursor in chat view to prevent clipping
- center chat view greeting message
- drag and drop reference images in image and video generation views
- cmd ⌘+N for new chat