### PR TITLE
fix: loop-stop banner shown twice in plain chat

### DIFF
--- a/app/Sources/MLXServe/Services/APIClient.swift
+++ b/app/Sources/MLXServe/Services/APIClient.swift
@@ -333,6 +333,34 @@ class APIClient {
     /// any other OpenAI-compatible backend) sends no such field and reads as
     /// `.maxTokens`, which is exactly the behaviour this replaced.
     ///
+    /// One cut, one event — no matter how many times the stream states it.
+    ///
+    /// The server states the ending TWICE on any stream that asked for usage:
+    /// the final chunk carries `finish_reason` + `finish_details`, and the
+    /// `stream_options.include_usage` chunk (which the app always requests)
+    /// repeats both beside the usage object — `src/server.zig`, the two
+    /// `sendSSEChunk` calls that close `handleStreamingGeneration`. That is
+    /// fine on the wire, where restating an ending is idempotent, and wrong
+    /// for a consumer that APPENDS on the event: plain chat put two identical
+    /// "the model started repeating itself" banners under one reply (live
+    /// 2026-08-08, dolphin3.0-llama3.2-3B asked to repeat a word 1000 times).
+    ///
+    /// Latching here rather than at each consumer keeps the rule where the
+    /// duplication is: a restated ending carries no new information, and no
+    /// backend — ours or another OpenAI-compatible one — can stack a banner by
+    /// saying it again. One gate per stream (see `performStream`).
+    struct TruncationGate {
+        private var fired = false
+
+        /// Pass the chunk's cause through the first time it appears; `nil`
+        /// afterwards, and `nil` for every chunk that carries no cut at all.
+        mutating func admit(_ cause: TruncationNotice.Cause?) -> TruncationNotice.Cause? {
+            guard let cause, !fired else { return nil }
+            fired = true
+            return cause
+        }
+    }
+
     /// Static and dictionary-shaped so it is testable without a live stream.
     static func truncationCause(fromChoice choice: [String: Any]?) -> TruncationNotice.Cause? {
         guard let choice, let fr = choice["finish_reason"] as? String, fr == "length" else { return nil }
@@ -568,6 +596,9 @@ class APIClient {
         // recovery when the server streams <tool_call> blocks as plain content
         // (e.g. some Qwen MoE outputs an older binary failed to parse).
         var contentAccumulator = ""
+        // One per stream: the final chunk and the usage chunk both carry the
+        // same finish_reason, and a cut is announced once.
+        var truncationGate = TruncationGate()
 
         for try await line in bytes.lines {
             guard line.hasPrefix("data: ") else { continue }
@@ -666,7 +697,8 @@ class APIClient {
 
             // Check finish_reason. "length" is both the max_tokens cap and the
             // server's own loop cut; `finish_details` is what tells them apart.
-            if let cause = Self.truncationCause(fromChoice: choices.first) {
+            // Gated: the usage chunk restates the same ending (see TruncationGate).
+            if let cause = truncationGate.admit(Self.truncationCause(fromChoice: choices.first)) {
                 continuation.yield(.truncated(cause))
             }
             // "length" + accumulated calls = a TRUNCATED tool call (max_tokens or

--- a/app/Sources/MLXServe/Services/ChatTurnEngine.swift
+++ b/app/Sources/MLXServe/Services/ChatTurnEngine.swift
@@ -517,6 +517,7 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
                 modelId: server.chatModelId
             )
             var coalescer = StreamCoalescer()
+            var truncationCause: TruncationNotice.Cause? = nil
             beginLiveTokenCount(for: sessionId)
             for try await event in stream {
                 try Task.checkCancellation()
@@ -532,16 +533,22 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
                 case .toolCalls:
                     break
                 case .truncated(let cause):
-                    // Plain chat is a single, always-terminal response — show the
-                    // notice immediately (no agent loop to stack it). Flush any
-                    // buffered text first so the notice lands after it, in order.
-                    applyStreamBatch(coalescer.drain(), to: sessionId)
-                    appState.updateLastMessage(in: sessionId, content: TruncationNotice.text(cause: cause, maxTokens: turnMaxTokens(config)))
+                    // Just record it — the notice is appended ONCE below, after
+                    // the stream ends. `updateLastMessage(content:)` appends, so
+                    // an append per event is an append per restatement of the
+                    // same ending (the agent path has recorded-then-shown for
+                    // this reason; plain chat had not).
+                    truncationCause = cause
                 case .done:
                     break
                 }
             }
             applyStreamBatch(coalescer.drain(), to: sessionId)   // flush the trailing batch
+            // Plain chat is a single, always-terminal response: one cut, one
+            // notice, landing after the reply it explains.
+            if let cause = truncationCause {
+                appState.updateLastMessage(in: sessionId, content: TruncationNotice.text(cause: cause, maxTokens: turnMaxTokens(config)))
+            }
         } catch is CancellationError {
             // Stopped by user (`stop(sessionId:)`) or superseded by a new
             // submission — either way that path already cleared the streaming

--- a/app/Tests/MLXCoreTests/TruncationNoticeTests.swift
+++ b/app/Tests/MLXCoreTests/TruncationNoticeTests.swift
@@ -94,4 +94,41 @@ final class TruncationNoticeTests: XCTestCase {
         XCTAssertNil(APIClient.truncationCause(fromChoice: nil))
         XCTAssertNil(APIClient.truncationCause(fromChoice: [:]))
     }
+
+    // MARK: - One cut, one event (live 2026-08-08)
+
+    func testACutIsAnnouncedOnceEvenThoughTheServerStatesItTwice() {
+        // The server states the ending TWICE on a stream that asked for usage:
+        // the final chunk carries `finish_reason` + `finish_details`, and the
+        // `stream_options.include_usage` chunk repeats both beside the usage
+        // object (src/server.zig, the two sendSSEChunk calls at the end of
+        // handleStreamingGeneration). Yielding per chunk put two identical
+        // loop banners in a plain chat.
+        var gate = APIClient.TruncationGate()
+        let choice: [String: Any] = [
+            "finish_reason": "length",
+            "finish_details": ["type": "repetition_loop"],
+        ]
+        XCTAssertEqual(gate.admit(APIClient.truncationCause(fromChoice: choice)), .repetitionLoop)
+        XCTAssertNil(gate.admit(APIClient.truncationCause(fromChoice: choice)),
+                     "the same ending restated carries no new information")
+    }
+
+    func testTheGateIsSilentUntilThereIsACut() {
+        // Every content chunk passes through it with finish_reason null.
+        var gate = APIClient.TruncationGate()
+        XCTAssertNil(gate.admit(nil))
+        XCTAssertNil(gate.admit(nil))
+        XCTAssertEqual(gate.admit(.maxTokens), .maxTokens)
+        XCTAssertNil(gate.admit(.maxTokens))
+    }
+
+    func testEachStreamGetsItsOwnGate() {
+        // One gate per stream, so the next round in an agent turn can report
+        // its own cut.
+        var first = APIClient.TruncationGate()
+        XCTAssertEqual(first.admit(.maxTokens), .maxTokens)
+        var second = APIClient.TruncationGate()
+        XCTAssertEqual(second.admit(.maxTokens), .maxTokens)
+    }
 }


### PR DESCRIPTION
The server states an ending twice on any stream that asked for usage: the final chunk carries finish_reason + finish_details, and the stream_options.include_usage chunk repeats both beside the usage object (server.zig, the two sendSSEChunk calls
closinghandleStreamingGeneration). The app always requests include_usage, APIClient yielded .truncated per chunk, and updateLastMessage(content:) appends -- so plain chat put two identical "the model started repeating itself" banners under one reply. The agent loop was unaffected: it records the cause and shows it once at the turn's exit.

APIClient.TruncationGate latches the cut per stream, so a restated ending is dropped no matter which backend restates it; streamPlainResponse now records the cause and appends after the stream, mirroring the agent path, so the append site is structurally single rather than merely fed one event. Wire format unchanged -- repeating finish_reason deviates from OpenAI (choices: [] there) but is harmless to correct clients, and changing it would move behaviour other consumers read.

Before:
<img width="656" height="188" alt="image" src="https://github.com/user-attachments/assets/726d9148-efbc-41de-a6bd-cb64e14af483" />
After:
<img width="670" height="185" alt="image" src="https://github.com/user-attachments/assets/02fb42a6-b942-47e0-88b0-e8d4b4d4cc33" />

