### PR TITLE
fix: check for cancellation each denoise step (image models)

### DIFF
--- a/src/flux.zig
+++ b/src/flux.zig
@@ -2131,6 +2131,7 @@ pub fn generateFromCondWithOpts(dit: *Dit, vae: *Vae, enc_owned: mlx.mlx_array, 
     const r = try reshape(noise_bf, &[_]c_int{ 1, 128, @intCast(nlat) }, s); defer _ = mlx.mlx_array_free(r);
     var latents = try transpose(r, &[_]c_int{ 0, 2, 1 }, s); // [1,nlat,128]
     { var c = mlx.mlx_array_new(); try mlx.check(mlx.mlx_contiguous(&c, latents, false, s)); _ = mlx.mlx_array_free(latents); latents = c; }
+    errdefer _ = mlx.mlx_array_free(latents);
 
     const img_ids = try buildLatentIds(a, lh, lw); defer a.free(img_ids);
     const txt_ids = try buildTextIds(a, @intCast(prompt_len)); defer a.free(txt_ids);
@@ -2202,6 +2203,7 @@ pub fn generateFromCondWithOpts(dit: *Dit, vae: *Vae, enc_owned: mlx.mlx_array, 
 
     const run_steps = steps - start_step;
     for (start_step..steps) |t| {
+        if (progress) |p| if (p.cancelled()) return error.Cancelled;
         const nz = blk: {
             if (ref_tokens.ctx != null) {
                 const input = try concat(&[_]mlx.mlx_array{ latents, ref_tokens }, 1, s);

--- a/src/flux.zig
+++ b/src/flux.zig
@@ -2131,7 +2131,9 @@ pub fn generateFromCondWithOpts(dit: *Dit, vae: *Vae, enc_owned: mlx.mlx_array, 
     const r = try reshape(noise_bf, &[_]c_int{ 1, 128, @intCast(nlat) }, s); defer _ = mlx.mlx_array_free(r);
     var latents = try transpose(r, &[_]c_int{ 0, 2, 1 }, s); // [1,nlat,128]
     { var c = mlx.mlx_array_new(); try mlx.check(mlx.mlx_contiguous(&c, latents, false, s)); _ = mlx.mlx_array_free(latents); latents = c; }
-    errdefer _ = mlx.mlx_array_free(latents);
+    errdefer if (latents.ctx != null) {
+        _ = mlx.mlx_array_free(latents);
+    };
 
     const img_ids = try buildLatentIds(a, lh, lw); defer a.free(img_ids);
     const txt_ids = try buildTextIds(a, @intCast(prompt_len)); defer a.free(txt_ids);
@@ -2196,9 +2198,10 @@ pub fn generateFromCondWithOpts(dit: *Dit, vae: *Vae, enc_owned: mlx.mlx_array, 
         const ns = try mulA(latents, sa, s);
         defer _ = mlx.mlx_array_free(ns);
         const mixed = try addA(zs, ns, s);
+        defer _ = mlx.mlx_array_free(mixed);
+        const nl = try astype(mixed, .bfloat16, s);
         _ = mlx.mlx_array_free(latents);
-        latents = try astype(mixed, .bfloat16, s);
-        _ = mlx.mlx_array_free(mixed);
+        latents = nl;
     }
 
     const run_steps = steps - start_step;
@@ -2228,6 +2231,7 @@ pub fn generateFromCondWithOpts(dit: *Dit, vae: *Vae, enc_owned: mlx.mlx_array, 
     // 4. unpack → [1,128,lh,lw], decode
     const lr = try reshape(latents, &[_]c_int{ 1, @intCast(lh), @intCast(lw), 128 }, s); defer _ = mlx.mlx_array_free(lr);
     _ = mlx.mlx_array_free(latents);
+    latents = .{ .ctx = null };
     const packed_lat = try transpose(lr, &[_]c_int{ 0, 3, 1, 2 }, s); defer _ = mlx.mlx_array_free(packed_lat);
     const decoded = try vae.decode(packed_lat); defer _ = mlx.mlx_array_free(decoded);
     // denormalize: clip(x/2+0.5, 0, 1)

--- a/src/gen.zig
+++ b/src/gen.zig
@@ -1953,6 +1953,12 @@ pub fn handleImage(io: std.Io, allocator: std.mem.Allocator, conn: *Conn, body: 
         .cond_weights = cond_weights,
     };
     const img = engine.generateImage(allocator, prompt, width, height, seed, steps, gen_opts, prog) catch |err| {
+        // Client hung up mid-generation — there is nobody to answer, and
+        // saying "generation failed" would be a lie about a job we stopped.
+        if (err == error.Cancelled) {
+            log.info("[image] generation cancelled — client disconnected\n", .{});
+            return;
+        }
         log.err("[image] generation failed: {}\n", .{err});
         if (want_stream) {
             sse.sendError(conn, "generation failed");

--- a/src/krea.zig
+++ b/src/krea.zig
@@ -2332,6 +2332,7 @@ pub const Engine = struct {
 
         const run_steps = steps - start_step;
         for (start_step..steps) |i| {
+            if (progress) |p| if (p.cancelled()) return error.Cancelled;
             const tc: f32 = @floatCast(ts[i]);
             const tp: f32 = @floatCast(ts[i + 1]);
             const v = try self.dit.forwardPrebuilt(img, ctx, tc, rope.cos, rope.sin, full_mask, txt_mask, s);

--- a/src/mage_flow.zig
+++ b/src/mage_flow.zig
@@ -880,6 +880,7 @@ pub const Engine = struct {
         // 4. Euler denoise. text mask is all-valid ⇒ null (no additive mask).
         // Update in f32, store back in the latent (bf16) dtype — `_mage_flow_euler_step`.
         for (0..n_steps) |i| {
+            if (progress) |p| if (p.cancelled()) return error.Cancelled;
             const v = try self.dit.forward(img, txt, sigmas[i], 1, lat_h, lat_w, null);
             defer _ = mlx.mlx_array_free(v);
             const img_f = try astype(img, .float32, s);
@@ -1051,7 +1052,9 @@ fn denoiseEditLoop(dit: *const Dit, txt: mlx.mlx_array, noise: mlx.mlx_array, re
     const HW = lat_h * lat_w;
     var target = mlx.mlx_array_new();
     try mlx.check(mlx.mlx_array_set(&target, noise));
+    errdefer _ = mlx.mlx_array_free(target);
     for (0..sigmas.len - 1) |i| {
+        if (progress) |p| if (p.cancelled()) return error.Cancelled;
         const model_input = try concat(&.{ target, ref_latents }, 1, s); // [1, n_images*HW, 128]
         defer _ = mlx.mlx_array_free(model_input);
         const v_full = try dit.forward(model_input, txt, sigmas[i], n_images, lat_h, lat_w, null);

--- a/tests/test_image_cancel.sh
+++ b/tests/test_image_cancel.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Client-disconnect cancellation for IMAGE generation (PR #155).
+#
+# A cancelled image request (client hung up mid-denoise) must abort at the
+# next step — flux/krea/mage_flow poll progress.cancelled() like every other
+# media backend — and gen.zig logs it as a cancellation, not a failure.
+# Red on trees without the checks: the server burns through every remaining
+# step + VAE decode + PNG encode for a peer that is gone (the log shows
+# "[image] -> N PNG bytes" with nobody connected) while other requests queue
+# behind the ghost.
+#
+# Usage: FLUX_MODEL=<dir> ./tests/test_image_cancel.sh [port]
+set -uo pipefail
+PORT="${1:-11299}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/mlx-serve"
+[ -x "$BIN" ] || { echo "FAIL: build first (zig build -Doptimize=ReleaseFast)"; exit 1; }
+
+FLUX="${FLUX_MODEL:-$(ls -d ~/.mlx-serve/models/Runpod/FLUX.2-klein-4B-mflux-4bit 2>/dev/null | head -1)}"
+[ -n "$FLUX" ] || { echo "SKIP: no FLUX model (set FLUX_MODEL)"; exit 0; }
+FLUX_ID="$(basename "$FLUX")"
+
+LOG=/tmp/test_image_cancel_server.log
+SSE=/tmp/test_image_cancel_sse.txt
+BASE="http://127.0.0.1:$PORT"
+
+"$BIN" --serve --model-dir "$(dirname "$FLUX")" --port "$PORT" >"$LOG" 2>&1 &
+SRV=$!
+CURL_PID=""
+trap 'kill $CURL_PID $SRV 2>/dev/null' EXIT
+for i in $(seq 1 60); do
+  curl -sf "$BASE/health" >/dev/null 2>&1 && break
+  kill -0 $SRV 2>/dev/null || { echo "FAIL: server did not start"; tail -5 "$LOG"; exit 1; }
+  sleep 1
+done
+
+curl -s -m 300 "$BASE/v1/load-model" -X POST -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$FLUX\"}" >/dev/null
+
+# Streaming request with enough steps that the disconnect lands mid-loop.
+: >"$SSE"
+curl -sN -m 600 -X POST "$BASE/v1/images/generations" -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$FLUX_ID\",\"prompt\":\"a lighthouse at dusk\",\"size\":\"1024x1024\",\"steps\":24,\"stream\":true}" \
+  >"$SSE" &
+CURL_PID=$!
+
+# Wait until the denoise loop is demonstrably running (>=2 progress events),
+# then vanish. First request includes model warmup, so be patient.
+IN_LOOP=0
+for i in $(seq 1 180); do
+  if [ "$(grep -c '"type":"progress"' "$SSE" 2>/dev/null)" -ge 2 ]; then IN_LOOP=1; break; fi
+  kill -0 $CURL_PID 2>/dev/null || break
+  sleep 1
+done
+[ "$IN_LOOP" = "1" ] || { echo "FAIL: never saw progress events"; tail -c 300 "$SSE"; tail -5 "$LOG"; exit 1; }
+kill $CURL_PID 2>/dev/null
+wait $CURL_PID 2>/dev/null
+CURL_PID=""
+echo "client disconnected mid-denoise"
+
+# The server must notice and CANCEL. Completing the ghost job instead
+# ("[image] -> N PNG bytes") is the bug.
+VERDICT=""
+for i in $(seq 1 240); do
+  if grep -q '\[image\] generation cancelled' "$LOG"; then VERDICT=cancelled; break; fi
+  if grep -q '\[image\] -> ' "$LOG"; then VERDICT=completed; break; fi
+  sleep 1
+done
+case "$VERDICT" in
+  cancelled) echo "PASS: disconnect mid-denoise -> generation cancelled" ;;
+  completed) echo "FAIL: generation ran to completion for a disconnected client"; exit 1 ;;
+  *)         echo "FAIL: neither cancelled nor completed after 240s"; tail -5 "$LOG"; exit 1 ;;
+esac
+grep -q '\[image\] generation failed' "$LOG" && { echo "FAIL: cancel misreported as a failure"; exit 1; }
+
+# Server healthy, inference thread free: a small follow-up gen succeeds.
+code=$(curl -s -m 300 -X POST "$BASE/v1/images/generations" -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$FLUX_ID\",\"prompt\":\"a green circle\",\"size\":\"512x512\",\"steps\":2}" \
+  -o /tmp/test_image_cancel_after.json -w "%{http_code}")
+[ "$code" = "200" ] || { echo "FAIL: follow-up gen http $code"; exit 1; }
+python3 - /tmp/test_image_cancel_after.json <<'PY'
+import sys, json, base64
+b = base64.b64decode(json.load(open(sys.argv[1]))["data"][0]["b64_json"])
+assert b[:8] == bytes([0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A]), "not a PNG"
+print(f"PASS: follow-up generation after cancel -> {len(b)} byte PNG")
+PY
+echo "ALL PASS"


### PR DESCRIPTION
A cancelled image-generation request (client disconnect) ran to full completion on the inference thread — flux.zig/krea.zig/mage_flow.zig emitted progress every step but never polled progress.cancelled(), unlike every other media backend (video/audio/mesh). Added the check before each denoise step, piggybacking on the eval that already runs there, and gave image gen its own error.Cancelled branch in gen.zig matching the video/mesh "client disconnected" log.