### PR TITLE
Add 544x960 H3 resolution preset

### DIFF
--- a/app/Sources/MLXServe/Services/MediaGen.swift
+++ b/app/Sources/MLXServe/Services/MediaGen.swift
@@ -728,6 +728,7 @@ struct VideoModelPreset: Identifiable, Hashable {
         .init(width: 768,  height: 768,  label: "768 × 768 (square) — 1.2x slower"),
         .init(width: 1024, height: 768,  label: "1024 × 768 (4:3 landscape) — 1.8x slower"),
         .init(width: 768,  height: 1024, label: "768 × 1024 (3:4 portrait) — 1.8x slower"),
+        .init(width: 544,  height: 960,  label: "544 × 960 (9:16 portrait) — fastest, best for long clips"),
         .init(width: 768,  height: 1344, label: "768 × 1344 (9:16 portrait) — 2.9x slower"),
         .init(width: 1536, height: 672,  label: "1536 × 672 (21:9 cinematic) — 2.9x slower"),
     ]


### PR DESCRIPTION
## Summary

Adds a `544 × 960` 9:16 portrait option to the MiniMax H3 resolution menu.

## Why

This is the portrait counterpart to the existing `960 × 544` fast canvas. It provides a substantially lower-cost portrait option than `768 × 1024` while remaining divisible by 32, as required by the H3 server.

## Validation

- Generated successfully through `POST /v1/video/generations` at `544 × 960`.
- `swift build -c release -Xswiftc -swift-version -Xswiftc 5` passes.
- `swift test`
- Running built app to generate a `544 x 960` video.

<img width="499" height="324" alt="Screenshot 2026-08-14 at 9 54 56 AM" src="https://github.com/user-attachments/assets/56453ee6-6826-4d5b-8459-3227d4936a56" />
