### PR TITLE
fix: LC_RPATH is resolved against the launching cwd, so the binary only starts from the repo root

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -486,23 +486,6 @@ fn buildRootHandle(b: *std.Build) std.Io.Dir {
     return b.root.root_dir.handle;
 }
 
-/// Absolute path to `sub_path` under the build root, for baking into an
-/// LC_RPATH. `b.path(sub_path)` looks like it would do this, but when `zig
-/// build` is invoked with cwd == build root (the normal `zig build
-/// -Doptimize=ReleaseFast` from CONTRIBUTING.md), `b.build_root.path` is
-/// null ("means cwd") and `Directory.join` returns the bare relative
-/// string with nothing prefixed. That relative string is exactly what
-/// ends up in the linked binary's LC_RPATH — fine for the linker
-/// (build-time cwd is the build root), wrong for the binary, whose
-/// LC_RPATH is resolved against cwd at process launch, which can be
-/// anywhere. Resolve to an absolute path once here so the rpath keeps
-/// working regardless of where the binary is later run from.
-fn absBuildPath(b: *std.Build, sub_path: []const u8) []const u8 {
-    return buildRootHandle(b).realPathFileAlloc(b.graph.io, sub_path, b.allocator) catch |err| {
-        std.debug.panic("failed to resolve '{s}' under the build root: {t}", .{ sub_path, err });
-    };
-}
-
 /// The llama.cpp tag staged by scripts/fetch-llama.sh (it writes LLAMA_TAG to
 /// `lib/llama/.version`). Read at configure time so a plain `zig build` reports
 /// the real tag without app/build.sh having to pass `--llama-tag`. Returns null
@@ -530,7 +513,27 @@ fn addLlamaLib(b: *std.Build, module: *std.Build.Module) void {
     // would otherwise hijack this link (pulling in /opt/homebrew's version + its
     // separate libggml). We want exactly the pinned dylib staged in lib/llama/lib.
     module.linkSystemLibrary("llama", .{ .use_pkg_config = .no });
-    module.addRPath(.{ .cwd_relative = absBuildPath(b, "lib/llama/lib") });
+    // @loader_path resolves against the BINARY's own location at launch,
+    // not the launching process's cwd. A bare relative string here (e.g.
+    // "lib/llama/lib") gets baked verbatim into LC_RPATH when `zig build`
+    // runs with cwd == build root (b.build_root.path is null in that case,
+    // so b.path() can't make it absolute) and dyld then resolves that
+    // relative string against argv[0]'s cwd, breaking any launch from
+    // outside the repo root. An absolute path avoids that but bakes in a
+    // machine-specific location, so the build isn't relocatable. This is
+    // relative to the binary itself, so it stays correct from any launch
+    // cwd and survives copying the whole zig-out + lib tree elsewhere.
+    //
+    // This module backs two different binaries at two different depths
+    // under the build root, so one entry can't serve both: the installed
+    // exe lands at zig-out/bin/mlx-serve (@loader_path = zig-out/bin/, 2
+    // levels up to root), while `zig build test` runs straight out of
+    // .zig-cache/o/<hash>/test (@loader_path = that dir, 3 levels up to
+    // root). dyld tries every LC_RPATH entry in order and silently skips
+    // ones that don't resolve, so listing both depths here is safe — each
+    // binary finds its own and ignores the other.
+    module.addRPath(.{ .cwd_relative = "@loader_path/../../lib/llama/lib" });
+    module.addRPath(.{ .cwd_relative = "@loader_path/../../../lib/llama/lib" });
 
     // Our clean C shim over llama.h (src/llama_ffi.zig mirrors lib/llama_shim/llama_shim.h).
     // C11 for pthread_once-based one-time backend init.
@@ -555,7 +558,13 @@ fn addMlxLib(b: *std.Build, module: *std.Build.Module) void {
     // link — we want exactly the staged NAX-enabled pair (same class as the
     // llama.pc hijack above).
     module.linkSystemLibrary("mlxc", .{ .use_pkg_config = .no });
-    module.addRPath(.{ .cwd_relative = absBuildPath(b, "lib/mlx/lib") });
+    // See addLlamaLib above: @loader_path is relative to the binary itself,
+    // so this stays correct regardless of the launching process's cwd and
+    // stays relocatable across machines. Two entries for the same reason —
+    // the installed exe and the `zig build test` binary sit at different
+    // depths under the build root.
+    module.addRPath(.{ .cwd_relative = "@loader_path/../../lib/mlx/lib" });
+    module.addRPath(.{ .cwd_relative = "@loader_path/../../../lib/mlx/lib" });
 }
 
 /// Configure-time check that scripts/build-mlx.sh has staged the pinned

--- a/build.zig
+++ b/build.zig
@@ -486,6 +486,23 @@ fn buildRootHandle(b: *std.Build) std.Io.Dir {
     return b.root.root_dir.handle;
 }
 
+/// Absolute path to `sub_path` under the build root, for baking into an
+/// LC_RPATH. `b.path(sub_path)` looks like it would do this, but when `zig
+/// build` is invoked with cwd == build root (the normal `zig build
+/// -Doptimize=ReleaseFast` from CONTRIBUTING.md), `b.build_root.path` is
+/// null ("means cwd") and `Directory.join` returns the bare relative
+/// string with nothing prefixed. That relative string is exactly what
+/// ends up in the linked binary's LC_RPATH — fine for the linker
+/// (build-time cwd is the build root), wrong for the binary, whose
+/// LC_RPATH is resolved against cwd at process launch, which can be
+/// anywhere. Resolve to an absolute path once here so the rpath keeps
+/// working regardless of where the binary is later run from.
+fn absBuildPath(b: *std.Build, sub_path: []const u8) []const u8 {
+    return buildRootHandle(b).realPathFileAlloc(b.graph.io, sub_path, b.allocator) catch |err| {
+        std.debug.panic("failed to resolve '{s}' under the build root: {t}", .{ sub_path, err });
+    };
+}
+
 /// The llama.cpp tag staged by scripts/fetch-llama.sh (it writes LLAMA_TAG to
 /// `lib/llama/.version`). Read at configure time so a plain `zig build` reports
 /// the real tag without app/build.sh having to pass `--llama-tag`. Returns null
@@ -513,7 +530,7 @@ fn addLlamaLib(b: *std.Build, module: *std.Build.Module) void {
     // would otherwise hijack this link (pulling in /opt/homebrew's version + its
     // separate libggml). We want exactly the pinned dylib staged in lib/llama/lib.
     module.linkSystemLibrary("llama", .{ .use_pkg_config = .no });
-    module.addRPath(b.path("lib/llama/lib"));
+    module.addRPath(.{ .cwd_relative = absBuildPath(b, "lib/llama/lib") });
 
     // Our clean C shim over llama.h (src/llama_ffi.zig mirrors lib/llama_shim/llama_shim.h).
     // C11 for pthread_once-based one-time backend init.
@@ -538,7 +555,7 @@ fn addMlxLib(b: *std.Build, module: *std.Build.Module) void {
     // link — we want exactly the staged NAX-enabled pair (same class as the
     // llama.pc hijack above).
     module.linkSystemLibrary("mlxc", .{ .use_pkg_config = .no });
-    module.addRPath(b.path("lib/mlx/lib"));
+    module.addRPath(.{ .cwd_relative = absBuildPath(b, "lib/mlx/lib") });
 }
 
 /// Configure-time check that scripts/build-mlx.sh has staged the pinned


### PR DESCRIPTION
Fixes #192.

`zig-out/bin/mlx-serve` only ran when the current working directory was the repo root. From anywhere else:

```
dyld[2831]: Library not loaded: @rpath/libllama.dylib
  Referenced from: <AB4CF513-6982-3C8F-8E8F-29C39382488C> /path/to/mlx-serve/zig-out/bin/mlx-serve
  Reason: tried: 'lib/llama/lib/libllama.dylib' (no such file), ...
```

## Cause

`otool -l zig-out/bin/mlx-serve | grep -A2 LC_RPATH` showed both rpaths as relative strings (`lib/llama/lib`, `lib/mlx/lib`). `LC_RPATH` is resolved by dyld against the process's cwd at launch, not against the build directory, so a relative rpath only works from one specific cwd.

`addLlamaLib`/`addMlxLib` in `build.zig` set these via `module.addRPath(b.path("lib/llama/lib"))` / `module.addRPath(b.path("lib/mlx/lib"))`. When `zig build` runs with cwd already at the build root (the normal `zig build -Doptimize=ReleaseFast` from CONTRIBUTING.md), `b.build_root.path` is `null` ("means cwd"), so `Directory.join` returns the bare relative string with nothing prefixed — exactly what ends up baked into the binary.

This doesn't touch the packaged release: `release.yml` / `app/build.sh` already rewrite the `LC_LOAD_DYLIB` references directly via `install_name_tool -change ... @executable_path/...`, independent of these `LC_RPATH` entries.

## Fix

Resolve `lib/llama/lib` and `lib/mlx/lib` to absolute paths at configure time before handing them to `addRPath`, using the build root's existing open directory handle (`buildRootHandle(b).realPathFileAlloc(...)`) — the same pattern `readLlamaTag` already uses a few lines up to read `lib/llama/.version`.

## Testing

- `zig build -Doptimize=ReleaseFast`, then:
  - `otool -l zig-out/bin/mlx-serve | grep -A2 LC_RPATH` now shows absolute paths (`/…/lib/llama/lib`, `/…/lib/mlx/lib`)
  - `./zig-out/bin/mlx-serve --help` from the repo root: starts (unchanged)
  - `/absolute/path/to/zig-out/bin/mlx-serve --help` from `/tmp`: now starts too (previously died with the dyld error above)
- `zig build test`: green

No changes to `src/transformer.zig` or anything unrelated — this PR is scoped to the rpath fix only.