### PR TITLE
Save video generation settings and prompt to text file on generation

### DIFF
--- a/app/Sources/MLXServe/Services/VideoGenService.swift
+++ b/app/Sources/MLXServe/Services/VideoGenService.swift
@@ -199,6 +199,10 @@ final class VideoGenService: ObservableObject {
                                       measuredSeconds: ProcessInfo.processInfo.systemUptime - startedAt)
                 setPhase(.running(step: steps, total: steps, message: "Encoding mp4…"), for: gen)
                 let outFps = frames.fps > 0 ? frames.fps : fps
+                let settings = Self.settingsText(
+                    request, modelId: modelId,
+                    outputWidth: frames.width, outputHeight: frames.height,
+                    outputFrames: frames.frames, outputFps: outFps)
                 try await Task.detached(priority: .userInitiated) {
                     try VideoGenService.writeMP4(
                         rgb: frames.rgb, frames: frames.frames,
@@ -206,6 +210,9 @@ final class VideoGenService: ObservableObject {
                         fps: outFps, to: URL(fileURLWithPath: outputPath),
                         audioPCM: frames.audioPCM, audioSampleRate: frames.audioSampleRate,
                         audioChannels: frames.audioChannels)
+                    // The mp4 is the primary artifact. Match audio/music generation:
+                    // a sidecar failure must not discard a successfully encoded clip.
+                    try? VideoGenService.writeSettingsSidecar(settings, forVideo: outputPath)
                 }.value
                 setPhase(.completed(path: outputPath), for: gen)
                 insertRecent(outputPath)
@@ -276,6 +283,10 @@ final class VideoGenService: ObservableObject {
             }
             report(steps, steps, "Encoding mp4")
             let outFps = frames.fps > 0 ? frames.fps : request.fps
+            let settings = Self.settingsText(
+                request, modelId: modelId,
+                outputWidth: frames.width, outputHeight: frames.height,
+                outputFrames: frames.frames, outputFps: outFps)
             try await Task.detached(priority: .userInitiated) {
                 try VideoGenService.writeMP4(
                     rgb: frames.rgb, frames: frames.frames,
@@ -283,6 +294,7 @@ final class VideoGenService: ObservableObject {
                     fps: outFps, to: URL(fileURLWithPath: outputPath),
                     audioPCM: frames.audioPCM, audioSampleRate: frames.audioSampleRate,
                     audioChannels: frames.audioChannels)
+                try? VideoGenService.writeSettingsSidecar(settings, forVideo: outputPath)
             }.value
             await releaseIfNeeded()
             return outputPath
@@ -434,6 +446,121 @@ final class VideoGenService: ObservableObject {
             if request.refImageSize != .match { body["ref_image_size"] = request.refImageSize.rawValue }
         }
         return body
+    }
+
+    // MARK: - Settings sidecar
+
+    /// Human-readable `<clip>.txt` companion for a generated video. This is
+    /// deliberately built from paths/settings, never from the wire body: the
+    /// latter contains multi-megabyte base64 images, PCM audio, and video frames.
+    /// Optional fields are capability-gated exactly like `requestBody`, so a
+    /// stale control value left behind by a preset switch is not documented as
+    /// something the selected backend actually used.
+    nonisolated static func settingsText(_ request: VideoGenRequest, modelId: String,
+                                         outputWidth: Int? = nil, outputHeight: Int? = nil,
+                                         outputFrames: Int? = nil, outputFps: Int? = nil) -> String {
+        var lines: [String] = [
+            "model: \(modelId)",
+            "preset: \(request.model.name)",
+            "seed: \(request.seed)",
+            "width: \(request.width)",
+            "height: \(request.height)",
+            "frames: \(request.numFrames)",
+            "fps: \(request.fps)",
+            "steps: \(request.steps)",
+        ]
+
+        if let outputWidth, let outputHeight,
+           outputWidth != request.width || outputHeight != request.height {
+            lines.append("output_width: \(outputWidth)")
+            lines.append("output_height: \(outputHeight)")
+        }
+        if let outputFrames, outputFrames != request.numFrames {
+            lines.append("output_frames: \(outputFrames)")
+        }
+        if let outputFps, outputFps != request.fps {
+            lines.append("output_fps: \(outputFps)")
+        }
+
+        let hasAudio = request.model.supportsAudioInput &&
+            request.audioPath?.isEmpty == false
+        let upgradedForAudio = hasAudio && request.mode == .oneStage
+        if request.model.supportsPipelineModes {
+            let pipeline: String
+            if upgradedForAudio {
+                pipeline = "two_stage"
+            } else {
+                switch request.mode {
+                case .oneStage:   pipeline = "one_stage"
+                case .twoStage:   pipeline = "two_stage"
+                case .twoStageHQ: pipeline = "two_stage_hq"
+                }
+            }
+            lines.append("pipeline: \(pipeline)")
+        }
+        // A one-stage audio request intentionally drops its one-stage guidance
+        // values and lets the server use two-stage defaults.
+        if request.model.supportsCFG, !upgradedForAudio {
+            lines.append("cfg_scale: \(String(format: "%.2f", request.cfgScale))")
+            lines.append("stg_scale: \(String(format: "%.2f", request.stgScale))")
+        }
+        if request.model.supportsFastRecipe {
+            lines.append("fast_recipe: \(!request.bestQuality && !request.turbo)")
+        }
+        if request.model.supportsDiffusionDecoder {
+            lines.append("decoder: \(request.diffusionDecoder ? "diffusion" : "convolution")")
+        }
+        if request.model.supportsTurbo {
+            lines.append("turbo: \(request.turbo)")
+        }
+        if request.model.supportsChainedWindows {
+            lines.append("chain_windows: \(max(request.chainWindows, 1))")
+        }
+
+        func basename(_ path: String) -> String {
+            (path as NSString).lastPathComponent
+        }
+        if let path = request.firstFrameImagePath, !path.isEmpty {
+            lines.append("first_frame: \(basename(path))")
+        }
+        if hasAudio, let path = request.audioPath {
+            lines.append("input_audio: \(basename(path))")
+        }
+
+        if request.model.supportsLoRA {
+            for (index, lora) in request.loras.filter({ !$0.path.isEmpty }).enumerated() {
+                lines.append("lora_\(index + 1)_file: \(basename(lora.path))")
+                lines.append("lora_\(index + 1)_scale: \(String(format: "%.2f", lora.scale))")
+            }
+        }
+        if request.model.supportsReferences {
+            for (index, path) in request.refImagePaths.filter({ !$0.isEmpty }).enumerated() {
+                lines.append("reference_image_\(index + 1): \(basename(path))")
+            }
+            for (index, path) in request.refVideoPaths.filter({ !$0.isEmpty }).enumerated() {
+                lines.append("reference_video_\(index + 1): \(basename(path))")
+            }
+            for (index, path) in request.refAudioPaths.filter({ !$0.isEmpty }).enumerated() {
+                lines.append("reference_audio_\(index + 1): \(basename(path))")
+            }
+            lines.append("reference_image_size: \(request.refImageSize.rawValue)")
+        }
+
+        var out = lines.joined(separator: "\n")
+        out += "\n\n# Prompt\n" + request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return out + "\n"
+    }
+
+    /// `<clip>.mp4` → `<clip>.txt` companion path.
+    nonisolated static func sidecarPath(forVideo videoPath: String) -> String {
+        (videoPath as NSString).deletingPathExtension + ".txt"
+    }
+
+    /// Kept separate from mp4 encoding so tests can pin actual filesystem
+    /// behavior without synthesizing video frames through AVFoundation.
+    nonisolated static func writeSettingsSidecar(_ text: String, forVideo videoPath: String) throws {
+        try text.write(to: URL(fileURLWithPath: sidecarPath(forVideo: videoPath)),
+                       atomically: true, encoding: .utf8)
     }
 
     /// Longest clip shipped to the server. LTX's frame ladder tops out around

--- a/app/Tests/MLXCoreTests/VideoSettingsSidecarTests.swift
+++ b/app/Tests/MLXCoreTests/VideoSettingsSidecarTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import MLXCore
+
+/// The `<clip>.txt` prompt/settings sidecar written beside each generated video.
+final class VideoSettingsSidecarTests: XCTestCase {
+    func testSidecarDocumentsPromptRequestAndActualOutput() {
+        var req = VideoGenRequest(
+            model: .ltx25Q8,
+            prompt: "  A lighthouse in a winter storm.  \n",
+            seed: 123,
+            width: 704,
+            height: 480,
+            numFrames: 97,
+            fps: 24,
+            mode: .twoStage,
+            steps: 30,
+            cfgScale: 3.0)
+        req.stgScale = 1.0
+        req.diffusionDecoder = true
+        req.firstFrameImagePath = "/private/reference/start.png"
+        req.audioPath = "/private/reference/dialogue.m4a"
+        req.loras = [LoraAdapter(path: "/private/loras/cinematic.safetensors", scale: 0.75)]
+
+        let text = VideoGenService.settingsText(
+            req, modelId: "remote/ltx-model",
+            outputWidth: 960, outputHeight: 544,
+            outputFrames: 105, outputFps: 25)
+
+        XCTAssertTrue(text.contains("model: remote/ltx-model"))
+        XCTAssertTrue(text.contains("preset: \(req.model.name)"))
+        XCTAssertTrue(text.contains("seed: 123"))
+        XCTAssertTrue(text.contains("width: 704"))
+        XCTAssertTrue(text.contains("height: 480"))
+        XCTAssertTrue(text.contains("frames: 97"))
+        XCTAssertTrue(text.contains("fps: 24"))
+        XCTAssertTrue(text.contains("steps: 30"))
+        XCTAssertTrue(text.contains("output_width: 960"))
+        XCTAssertTrue(text.contains("output_height: 544"))
+        XCTAssertTrue(text.contains("output_frames: 105"))
+        XCTAssertTrue(text.contains("output_fps: 25"))
+        XCTAssertTrue(text.contains("pipeline: two_stage"))
+        XCTAssertTrue(text.contains("cfg_scale: 3.00"))
+        XCTAssertTrue(text.contains("stg_scale: 1.00"))
+        XCTAssertTrue(text.contains("decoder: diffusion"))
+        XCTAssertTrue(text.contains("first_frame: start.png"))
+        XCTAssertTrue(text.contains("input_audio: dialogue.m4a"))
+        XCTAssertTrue(text.contains("lora_1_file: cinematic.safetensors"))
+        XCTAssertTrue(text.contains("lora_1_scale: 0.75"))
+        XCTAssertTrue(text.contains("# Prompt\nA lighthouse in a winter storm.\n"))
+        XCTAssertFalse(text.contains("/private/reference"), "store portable basenames, not private paths")
+        XCTAssertFalse(text.contains("/private/loras"), "store portable basenames, not private paths")
+    }
+
+    func testMatchingOutputDoesNotAddRedundantOutputFields() {
+        let req = VideoGenRequest(model: .ltx23Q4, prompt: "p", width: 704, height: 480,
+                                  numFrames: 97, fps: 24, mode: .oneStage,
+                                  steps: 8, cfgScale: 1.0)
+        let text = VideoGenService.settingsText(
+            req, modelId: "m", outputWidth: 704, outputHeight: 480,
+            outputFrames: 97, outputFps: 24)
+        XCTAssertFalse(text.contains("output_width:"))
+        XCTAssertFalse(text.contains("output_height:"))
+        XCTAssertFalse(text.contains("output_frames:"))
+        XCTAssertFalse(text.contains("output_fps:"))
+    }
+
+    func testAudioUpgradeRecordsEffectivePipelineAndOmitsDroppedGuidance() {
+        var req = VideoGenRequest(model: .ltx23Q4, prompt: "p", width: 704, height: 480,
+                                  numFrames: 97, fps: 24, mode: .oneStage,
+                                  steps: 8, cfgScale: 1.0)
+        req.stgScale = 0.5
+        req.audioPath = "/clips/voice.wav"
+        let text = VideoGenService.settingsText(req, modelId: "m")
+        XCTAssertTrue(text.contains("pipeline: two_stage"))
+        XCTAssertTrue(text.contains("input_audio: voice.wav"))
+        XCTAssertFalse(text.contains("cfg_scale:"), "one-stage guidance is not sent after the audio upgrade")
+        XCTAssertFalse(text.contains("stg_scale:"), "one-stage guidance is not sent after the audio upgrade")
+    }
+
+    func testMultipleReferencesRemainOrderedAndUseBasenames() {
+        var req = VideoGenRequest(model: .minimaxH3Ref2VA, prompt: "p", width: 544, height: 960,
+                                  numFrames: 90, fps: 24, mode: .oneStage,
+                                  steps: 30, cfgScale: 1.0)
+        req.refImagePaths = ["/refs/character.png", "/refs/style.jpg"]
+        req.refVideoPaths = ["/refs/walk.mp4", "/refs/camera.mov"]
+        req.refAudioPaths = ["/refs/voice.wav", "/refs/music.m4a"]
+        req.refImageSize = .max
+        let text = VideoGenService.settingsText(req, modelId: "h3-ref")
+
+        XCTAssertTrue(text.contains("reference_image_1: character.png"))
+        XCTAssertTrue(text.contains("reference_image_2: style.jpg"))
+        XCTAssertTrue(text.contains("reference_video_1: walk.mp4"))
+        XCTAssertTrue(text.contains("reference_video_2: camera.mov"))
+        XCTAssertTrue(text.contains("reference_audio_1: voice.wav"))
+        XCTAssertTrue(text.contains("reference_audio_2: music.m4a"))
+        XCTAssertTrue(text.contains("reference_image_size: max"))
+        XCTAssertLessThan(text.range(of: "character.png")!.lowerBound,
+                          text.range(of: "style.jpg")!.lowerBound)
+        XCTAssertFalse(text.contains("/refs/"))
+    }
+
+    func testUnsupportedStaleSettingsAreNotDocumentedAsUsed() {
+        var req = VideoGenRequest(model: .minimaxH3, prompt: "p", width: 960, height: 544,
+                                  numFrames: 90, fps: 24, mode: .twoStageHQ,
+                                  steps: 30, cfgScale: 7.0)
+        req.stgScale = 2.0
+        req.audioPath = "/clips/not-sent.wav"
+        req.diffusionDecoder = true
+        req.refImagePaths = ["/refs/not-sent.png"]
+        req.refVideoPaths = ["/refs/not-sent.mp4"]
+        req.refAudioPaths = ["/refs/not-sent.m4a"]
+        req.refImageSize = .max
+        let text = VideoGenService.settingsText(req, modelId: "h3")
+
+        XCTAssertFalse(text.contains("pipeline:"))
+        XCTAssertFalse(text.contains("cfg_scale:"))
+        XCTAssertFalse(text.contains("stg_scale:"))
+        XCTAssertFalse(text.contains("input_audio:"))
+        XCTAssertFalse(text.contains("decoder:"))
+        XCTAssertFalse(text.contains("reference_image_"))
+        XCTAssertFalse(text.contains("reference_video_"))
+        XCTAssertFalse(text.contains("reference_audio_"))
+        XCTAssertTrue(text.contains("fast_recipe: true"))
+        XCTAssertTrue(text.contains("turbo: false"))
+        XCTAssertTrue(text.contains("chain_windows: 1"))
+    }
+
+    func testTurboRecordsFastRecipeAsDisabled() {
+        var req = VideoGenRequest(model: .minimaxH3, prompt: "p", width: 960, height: 544,
+                                  numFrames: 90, fps: 24, mode: .oneStage,
+                                  steps: 4, cfgScale: 1.0)
+        req.turbo = true
+        let text = VideoGenService.settingsText(req, modelId: "h3")
+        XCTAssertTrue(text.contains("turbo: true"))
+        XCTAssertTrue(text.contains("fast_recipe: false"))
+    }
+
+    func testSidecarPathAndAtomicWrite() throws {
+        XCTAssertEqual(VideoGenService.sidecarPath(forVideo: "/a/my.clip.v2.mp4"),
+                       "/a/my.clip.v2.txt")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("video-sidecar-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: directory) }
+        let videoPath = directory.appendingPathComponent("clip.mp4").path
+
+        try VideoGenService.writeSettingsSidecar("settings\n", forVideo: videoPath)
+        let written = try String(contentsOfFile: directory.appendingPathComponent("clip.txt").path,
+                                 encoding: .utf8)
+        XCTAssertEqual(written, "settings\n")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a human-readable .txt sidecar beside each generated video MP4.

- Records the prompt, model, seed, requested settings, and returned output properties.
- Records effective video options, LoRAs, and reference media using portable basenames only.
- Writes sidecars for both Video window and agent-driven generations.
- Keeps a successfully encoded MP4 even if writing its sidecar fails.

## Why

Generated videos currently have no adjacent record of the prompt or settings that produced them. This makes them difficult to reproduce or compare later.

## Validation

- swift test --filter VideoSettingsSidecarTests (7 tests)
- swift test --filter MediaGenServiceTests (70 tests)
- swift test (2,935 passed, 24 skipped)
- swift build -c release