### PR TITLE
Separate starting the server from loading a model (#214)

### DIFF
--- a/app/Sources/MLXServe/AppState.swift
+++ b/app/Sources/MLXServe/AppState.swift
@@ -191,6 +191,30 @@ class AppState: ObservableObject {
     @Published var autoStartServer: Bool {
         didSet { UserDefaults.standard.set(autoStartServer, forKey: "autoStartServer") }
     }
+    /// Should the launch gate pass `--model` (an EAGER, BLOCKING load) instead
+    /// of starting headless? Separate from `autoStartServer` on purpose:
+    /// "run the server" and "resident a checkpoint" are different decisions,
+    /// and folding them into one checkbox made "Auto-start on launch" read tens
+    /// of gigabytes off disk at login with nothing in the UI saying so
+    /// (issue #214). Default OFF, including for existing users — that IS the
+    /// fix. The server still comes up, and the first chat turn hot-loads the
+    /// selected model via `ServerManager.ensureDefaultChatModel`.
+    @Published var loadModelAtStart: Bool {
+        didSet { UserDefaults.standard.set(loadModelAtStart, forKey: "loadModelAtStart") }
+    }
+    /// WHICH model `loadModelAtStart` loads: `StartupModelChoice.lastUsedTag`
+    /// (the default — "Last model used", resolved at start) or a model's
+    /// absolute path.
+    ///
+    /// Deliberately NOT `selectedModelPath`. That property is the model
+    /// answering chats right now, so its `didSet` hot-switches or restarts a
+    /// running server — editing a *startup* preference must not swap the model
+    /// under a conversation in progress, and it has no way to spell "whichever
+    /// one I used last" besides. `selectedModelPath` and its stored key are
+    /// left exactly as they were.
+    @Published var startupModelPath: String {
+        didSet { UserDefaults.standard.set(startupModelPath, forKey: "startupModelPath") }
+    }
     /// All server-launch flags + per-request defaults, mirrored to UserDefaults.
     /// Auto-saves on every mutation. Prefer this over the legacy single-key
     /// `maxTokens`/`contextSize` defaults — those forward into here.
@@ -426,12 +450,18 @@ class AppState: ObservableObject {
         // Defaults to ON when the key is absent — `UserDefaults.bool` would
         // read a never-set key as false, which is why a fresh install used to
         // download a model and then sit there with the server stopped. The
-        // launch gate below is `autoStartServer && !selectedModelPath.isEmpty`,
-        // so this stays a no-op until a model exists; the first download's
-        // completion hook is what actually starts it. No migration: existing
-        // users who never touched the toggle get it turned on, which is the
-        // intent.
+        // launch gate below now starts the server HEADLESS on its own, so this
+        // no longer waits for a model to exist; what it starts is a server, not
+        // a load. No migration: existing users who never touched the toggle get
+        // it turned on, which is the intent.
         self.autoStartServer = UserDefaults.standard.object(forKey: "autoStartServer") as? Bool ?? true
+        // Both default OFF / "Last model used" via the absent-key reads, and
+        // deliberately WITHOUT a migration from the old behaviour: an upgrading
+        // user whose "Auto-start on launch" used to eagerly load 26 GB must stop
+        // doing that on the next launch. That is the whole point of the change.
+        self.loadModelAtStart = UserDefaults.standard.bool(forKey: "loadModelAtStart")
+        self.startupModelPath = UserDefaults.standard.string(forKey: "startupModelPath")
+            ?? StartupModelChoice.lastUsedTag
         self.selectedModelPath = UserDefaults.standard.string(forKey: "selectedModelPath") ?? ""
         // Load ServerOptions, then migrate legacy single-key defaults
         // (`maxTokens`, `contextSize`) into it on first run if the dedicated
@@ -529,9 +559,24 @@ class AppState: ObservableObject {
             }
         }
 
-        // Auto-start server if enabled and a model is available
-        if autoStartServer, !selectedModelPath.isEmpty {
-            server.start(modelPath: selectedModelPath, options: serverOptions)
+        // Auto-start. "Start the server" and "load a model" are two decisions
+        // (`StartupModelChoice.launch`): auto-start on its own brings the server
+        // up HEADLESS, and only Settings ▸ Server ▸ "Load a model at start" —
+        // default OFF — makes launch pay for a checkpoint. `refreshModels()`
+        // above is what makes the installed-library check below meaningful.
+        switch StartupModelChoice.launch(
+            autoStart: autoStartServer,
+            loadModelAtStart: loadModelAtStart,
+            choice: startupModelPath,
+            lastUsed: StartupModelChoice.lastUsed(),
+            installedPaths: localModels.filter(\.isChatPickable).map(\.path)
+        ) {
+        case .doNothing:
+            break
+        case .headless:
+            server.startHeadless(modelsDir: ServerManager.modelsRoot, options: serverOptions)
+        case .load(let path):
+            server.start(modelPath: path, options: serverOptions)
         }
         // LAN sharing/discovery lives in the server process — with either
         // enabled the server should be up (headless when nothing was

--- a/app/Sources/MLXServe/AppState.swift
+++ b/app/Sources/MLXServe/AppState.swift
@@ -202,18 +202,37 @@ class AppState: ObservableObject {
     @Published var loadModelAtStart: Bool {
         didSet { UserDefaults.standard.set(loadModelAtStart, forKey: "loadModelAtStart") }
     }
-    /// WHICH model `loadModelAtStart` loads: `StartupModelChoice.lastUsedTag`
-    /// (the default — "Last model used", resolved at start) or a model's
-    /// absolute path.
+    /// WHICH model `loadModelAtStart` loads — follow the last one used, or
+    /// always `startupModelPinnedPath`. Stored as its own key rather than as a
+    /// magic value inside a path field, so no reader has to know a secret
+    /// string to tell a rule from a filename.
+    @Published var startupModelMode: StartupModelChoice.Mode {
+        didSet {
+            UserDefaults.standard.set(startupModelMode.rawValue, forKey: "startupModelMode")
+            // Switching to "Always this model" having never pinned one would
+            // leave the dropdown matching no row and rendering blank — the
+            // dead-control class. Seed it with the answer the other mode was
+            // already giving, so the control opens on what is about to happen.
+            guard startupModelMode == .pinned, startupModelPinnedPath.isEmpty else { return }
+            let pickable = localModels.filter(\.isChatPickable)
+            startupModelPinnedPath = StartupModelChoice.resolved(
+                mode: .lastUsed,
+                pinnedPath: nil,
+                lastUsed: StartupModelChoice.lastUsed(),
+                installedPaths: pickable.map(\.path)
+            ) ?? pickable.first?.path ?? ""
+        }
+    }
+    /// The model pinned by `startupModelMode == .pinned`. Empty means nothing
+    /// has been pinned yet — an absent optional, never a sentinel.
     ///
     /// Deliberately NOT `selectedModelPath`. That property is the model
     /// answering chats right now, so its `didSet` hot-switches or restarts a
     /// running server — editing a *startup* preference must not swap the model
-    /// under a conversation in progress, and it has no way to spell "whichever
-    /// one I used last" besides. `selectedModelPath` and its stored key are
-    /// left exactly as they were.
-    @Published var startupModelPath: String {
-        didSet { UserDefaults.standard.set(startupModelPath, forKey: "startupModelPath") }
+    /// out from under a conversation in progress. `selectedModelPath` and its
+    /// stored key are left exactly as they were.
+    @Published var startupModelPinnedPath: String {
+        didSet { UserDefaults.standard.set(startupModelPinnedPath, forKey: "startupModelPinnedPath") }
     }
     /// All server-launch flags + per-request defaults, mirrored to UserDefaults.
     /// Auto-saves on every mutation. Prefer this over the legacy single-key
@@ -460,8 +479,9 @@ class AppState: ObservableObject {
         // user whose "Auto-start on launch" used to eagerly load 26 GB must stop
         // doing that on the next launch. That is the whole point of the change.
         self.loadModelAtStart = UserDefaults.standard.bool(forKey: "loadModelAtStart")
-        self.startupModelPath = UserDefaults.standard.string(forKey: "startupModelPath")
-            ?? StartupModelChoice.lastUsedTag
+        self.startupModelMode = UserDefaults.standard.string(forKey: "startupModelMode")
+            .flatMap(StartupModelChoice.Mode.init(rawValue:)) ?? .default
+        self.startupModelPinnedPath = UserDefaults.standard.string(forKey: "startupModelPinnedPath") ?? ""
         self.selectedModelPath = UserDefaults.standard.string(forKey: "selectedModelPath") ?? ""
         // Load ServerOptions, then migrate legacy single-key defaults
         // (`maxTokens`, `contextSize`) into it on first run if the dedicated
@@ -567,7 +587,8 @@ class AppState: ObservableObject {
         switch StartupModelChoice.launch(
             autoStart: autoStartServer,
             loadModelAtStart: loadModelAtStart,
-            choice: startupModelPath,
+            mode: startupModelMode,
+            pinnedPath: startupModelPinnedPath,
             lastUsed: StartupModelChoice.lastUsed(),
             installedPaths: localModels.filter(\.isChatPickable).map(\.path)
         ) {

--- a/app/Sources/MLXServe/Models/StartupModelChoice.swift
+++ b/app/Sources/MLXServe/Models/StartupModelChoice.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// What launch does with the server, and where "the last model used" comes
+/// from.
+///
+/// Startup is TWO decisions, not one: whether the server comes up, and whether
+/// a checkpoint goes resident before anybody has asked for one. They used to be
+/// the same checkbox — "Auto-start on launch" passed `--model`, which the server
+/// treats as an EAGER, BLOCKING load — so ticking a box labelled *start* read
+/// tens of gigabytes off disk at login, with nothing in the UI saying so
+/// (issue #214). The server has always been able to start without a model
+/// (`runHeadlessServe` → `no_initial_load = true`); only the app never asked it
+/// to.
+///
+/// Pure and static on purpose: the gate is one branch in `AppState.init` that
+/// nobody can watch run, and its previous shape shipped a multi-gigabyte load
+/// behind a checkbox that promised a server.
+enum StartupModelChoice {
+
+    /// The startup dropdown's first entry: load whatever loaded LAST, resolved
+    /// at start time rather than at the moment the setting was saved. The model
+    /// you want next is usually the one you just used, and pinning a path when
+    /// the setting was written would freeze that answer forever.
+    ///
+    /// Empty, so it is also the default for a key that was never set — a fresh
+    /// install has no last model, and "load the last one" then correctly
+    /// resolves to loading nothing.
+    static let lastUsedTag = ""
+
+    // MARK: - Last model used
+
+    private static let lastUsedKey = "lastLoadedModelPath"
+
+    /// Record a chat model the server FINISHED loading.
+    ///
+    /// Called only from confirmed loads — a load that was *requested* and then
+    /// failed is not a model that was used, and writing it here would replay
+    /// the same failure on the next launch. Absolute paths only: a registry id
+    /// is a directory basename (for a Hugging Face snapshot, a commit hash) and
+    /// a LAN id names another Mac's model, so neither is something we can hand
+    /// back to `--model`.
+    static func recordLoaded(path: String, defaults: UserDefaults = .standard) {
+        guard path.hasPrefix("/") else { return }
+        defaults.set(path, forKey: lastUsedKey)
+    }
+
+    /// The last confirmed load, or nil when there has never been one.
+    static func lastUsed(defaults: UserDefaults = .standard) -> String? {
+        let stored = defaults.string(forKey: lastUsedKey) ?? ""
+        return stored.isEmpty ? nil : stored
+    }
+
+    // MARK: - The launch gate
+
+    /// What `AppState.init` should do with the server.
+    enum Launch: Equatable {
+        /// Auto-start is off — the user starts the server themselves.
+        case doNothing
+        /// Server up, no model resident. Models load on demand (`/v1/load-model`,
+        /// or the first chat turn via `ServerManager.ensureDefaultChatModel`).
+        case headless
+        /// Server up with `--model <path>` — the eager load, now only ever
+        /// reached because the user explicitly asked for it.
+        case load(path: String)
+    }
+
+    /// `choice` is the saved dropdown pick: `lastUsedTag` for "Last model used",
+    /// otherwise a model's absolute path. `installedPaths` is the chat-pickable
+    /// library (`LocalModel.isChatPickable`).
+    ///
+    /// A pick that is no longer on disk — uninstalled between launches, or a
+    /// last-used model that has since been deleted — starts the server HEADLESS.
+    /// It must not send `--model <gone>` into an instant FileNotFound, and it
+    /// must not quietly promote some other model in its place: a startup that
+    /// loads a model the user never chose is worse than one that loads none.
+    static func launch(autoStart: Bool,
+                       loadModelAtStart: Bool,
+                       choice: String,
+                       lastUsed: String?,
+                       installedPaths: [String]) -> Launch {
+        guard autoStart else { return .doNothing }
+        guard loadModelAtStart else { return .headless }
+        let wanted = choice == lastUsedTag ? lastUsed : choice
+        guard let wanted, installedPaths.contains(wanted) else { return .headless }
+        return .load(path: wanted)
+    }
+}

--- a/app/Sources/MLXServe/Models/StartupModelChoice.swift
+++ b/app/Sources/MLXServe/Models/StartupModelChoice.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// What launch does with the server, and where "the last model used" comes
-/// from.
+/// What launch does with the server, and which model — if any — it loads.
 ///
 /// Startup is TWO decisions, not one: whether the server comes up, and whether
 /// a checkpoint goes resident before anybody has asked for one. They used to be
@@ -17,15 +16,30 @@ import Foundation
 /// behind a checkbox that promised a server.
 enum StartupModelChoice {
 
-    /// The startup dropdown's first entry: load whatever loaded LAST, resolved
-    /// at start time rather than at the moment the setting was saved. The model
-    /// you want next is usually the one you just used, and pinning a path when
-    /// the setting was written would freeze that answer forever.
-    ///
-    /// Empty, so it is also the default for a key that was never set — a fresh
-    /// install has no last model, and "load the last one" then correctly
-    /// resolves to loading nothing.
-    static let lastUsedTag = ""
+    /// WHICH model start loads. A mode, stored separately from any path — the
+    /// rule is not one of the models, so it must not be spelled as a magic path
+    /// value in a field that otherwise holds real ones. A sentinel in a path
+    /// field is the same defect in different clothes: every reader has to know
+    /// the secret, and one that doesn't treats it as a filename.
+    enum Mode: String, CaseIterable, Identifiable, Hashable {
+        /// Follow whatever was loaded last, resolved at START time rather than
+        /// pinned when the setting was saved. The model you want next is
+        /// usually the one you just used.
+        case lastUsed
+        /// Always this one, whatever has been used since.
+        case pinned
+
+        var id: String { rawValue }
+
+        var label: String {
+            switch self {
+            case .lastUsed: return "Last model used"
+            case .pinned:   return "Always this model"
+            }
+        }
+
+        static let `default`: Mode = .lastUsed
+    }
 
     // MARK: - Last model used
 
@@ -50,6 +64,33 @@ enum StartupModelChoice {
         return stored.isEmpty ? nil : stored
     }
 
+    // MARK: - Resolving the choice
+
+    /// The model a start would load right now, or nil for "none — headless".
+    ///
+    /// The ONE resolution: the launch gate and the Settings readout both ask
+    /// this question, so the secondary text under the control cannot promise a
+    /// model the gate would decline to load.
+    ///
+    /// `installedPaths` is the chat-pickable library (`LocalModel.isChatPickable`).
+    /// A model that is no longer on disk — uninstalled between launches, or a
+    /// last-used one since deleted — resolves to nil. It must not become
+    /// `--model <gone>`, an instant FileNotFound, and it must not quietly
+    /// promote some other model in its place: a startup that loads a model the
+    /// user never chose is worse than one that loads none.
+    static func resolved(mode: Mode,
+                         pinnedPath: String?,
+                         lastUsed: String?,
+                         installedPaths: [String]) -> String? {
+        let wanted: String?
+        switch mode {
+        case .lastUsed: wanted = lastUsed
+        case .pinned:   wanted = pinnedPath
+        }
+        guard let wanted, !wanted.isEmpty, installedPaths.contains(wanted) else { return nil }
+        return wanted
+    }
+
     // MARK: - The launch gate
 
     /// What `AppState.init` should do with the server.
@@ -64,24 +105,18 @@ enum StartupModelChoice {
         case load(path: String)
     }
 
-    /// `choice` is the saved dropdown pick: `lastUsedTag` for "Last model used",
-    /// otherwise a model's absolute path. `installedPaths` is the chat-pickable
-    /// library (`LocalModel.isChatPickable`).
-    ///
-    /// A pick that is no longer on disk — uninstalled between launches, or a
-    /// last-used model that has since been deleted — starts the server HEADLESS.
-    /// It must not send `--model <gone>` into an instant FileNotFound, and it
-    /// must not quietly promote some other model in its place: a startup that
-    /// loads a model the user never chose is worse than one that loads none.
     static func launch(autoStart: Bool,
                        loadModelAtStart: Bool,
-                       choice: String,
+                       mode: Mode,
+                       pinnedPath: String?,
                        lastUsed: String?,
                        installedPaths: [String]) -> Launch {
         guard autoStart else { return .doNothing }
         guard loadModelAtStart else { return .headless }
-        let wanted = choice == lastUsedTag ? lastUsed : choice
-        guard let wanted, installedPaths.contains(wanted) else { return .headless }
-        return .load(path: wanted)
+        guard let path = resolved(mode: mode,
+                                  pinnedPath: pinnedPath,
+                                  lastUsed: lastUsed,
+                                  installedPaths: installedPaths) else { return .headless }
+        return .load(path: path)
     }
 }

--- a/app/Sources/MLXServe/Services/ServerManager.swift
+++ b/app/Sources/MLXServe/Services/ServerManager.swift
@@ -143,6 +143,12 @@ class ServerManager: ObservableObject {
                                            selectedModelPath: selectedModelPath) else { return }
         if (try? await loadModel(id: selectedModelPath)) != nil {
             chatDefaultEnsured = true
+            // The first-turn hot-load onto a headless server — this is the
+            // common way a model becomes resident now that auto-start no longer
+            // loads one, so without it "Last model used" would stay empty for
+            // anyone who never touches the tray picker. Recorded here rather
+            // than inside `loadModel` because this call passes no `setDefault`.
+            StartupModelChoice.recordLoaded(path: selectedModelPath)
         }
     }
 
@@ -550,6 +556,11 @@ class ServerManager: ObservableObject {
     private func transitionToRunning() {
         guard status != .running else { return }
         status = .running
+        // An eager `--model` launch that reached `.running` really did finish
+        // loading — a start that dies mid-load never gets here. Headless
+        // launches leave `currentModelPath` empty and `recordLoaded` ignores
+        // them (absolute paths only), so nothing needs a second guard.
+        StartupModelChoice.recordLoaded(path: currentModelPath)
         Task { await self.refreshModels() }
         // If the user has the menu open at the exact moment the server comes
         // up, start the live /props ticker now so the GPU-memory bar fills in
@@ -630,7 +641,15 @@ class ServerManager: ObservableObject {
         // A switch moves what the process is serving without restarting it;
         // keep `currentModelPath` honest for the readers that gate on it
         // (TaskScheduler's pinned-model check, TestServer's status).
-        if setDefault, id.hasPrefix("/") { currentModelPath = id }
+        if setDefault, id.hasPrefix("/") {
+            currentModelPath = id
+            // A completed chat-model switch — `api.loadModel` returned, so the
+            // checkpoint is resident. Only the `setDefault` branch records:
+            // `loadModel` is also the media path (`prepareGenModel` hot-loads
+            // FLUX / LTX / Kokoro by directory), and a video model is not the
+            // "last model used" a chat startup should reach for.
+            StartupModelChoice.recordLoaded(path: id)
+        }
         await refreshModels()
         return info
     }

--- a/app/Sources/MLXServe/Views/SettingsView.swift
+++ b/app/Sources/MLXServe/Views/SettingsView.swift
@@ -914,11 +914,29 @@ private struct ServerSectionContent: View {
         return "\(label) · \(model.engine.shortLabel)"
     }
 
+    /// What "Last model used" resolves to RIGHT NOW, worded for the quiet line
+    /// under the disabled dropdown. Asks `StartupModelChoice.resolved` — the
+    /// same question the launch gate asks — so this line cannot promise a model
+    /// that start would decline to load.
+    private var lastUsedResolution: String {
+        guard let path = StartupModelChoice.resolved(mode: .lastUsed,
+                                                     pinnedPath: nil,
+                                                     lastUsed: StartupModelChoice.lastUsed(),
+                                                     installedPaths: pickable.map(\.path)) else {
+            return "Nothing loaded yet — the server will start with no model."
+        }
+        let dupNames = LocalModel.duplicateNames(in: pickable)
+        guard let model = pickable.first(where: { $0.path == path }) else {
+            return "Nothing loaded yet — the server will start with no model."
+        }
+        return "Currently: \(startupModelLabel(model, dupNames: dupNames))"
+    }
+
     var body: some View {
-        // Startup. Deliberately the first two rows of the Server section: "Do
-        // you want the server?" is `autoStartServer` in the tray, and "do you
-        // want a model resident with it?" is here. They were one checkbox, and
-        // the merged one loaded whatever was selected — see `StartupModelChoice`.
+        // Startup, at the top of the Server section. "Do you want the server?"
+        // is `autoStartServer` in the tray; "do you want a model resident with
+        // it, and which one?" is these three rows. It was all one checkbox, and
+        // that checkbox loaded whatever was selected — see `StartupModelChoice`.
         SettingsRow(
             title: "Load a model at start",
             explainer: "Off by default. Auto-start brings the server up with no model resident; it loads one on demand at your first message, so login stays fast. Turn this on to pay for the load up front instead — a large checkpoint can take a while and holds the memory from the moment you log in."
@@ -927,32 +945,62 @@ private struct ServerSectionContent: View {
                 .labelsHidden()
                 .toggleStyle(.switch)
         }
+        // WHICH model is a property of the selector, not one of its items: the
+        // dropdown below lists models and only models, so a rule ("follow the
+        // last one") can't sit in it pretending to be one.
         SettingsRow(
-            title: "Model to load at start",
-            explainer: "\"Last model used\" follows whatever you were last chatting with, decided when the app starts rather than when you set this. If that model has since been removed — or you have not loaded one yet — the server simply starts with nothing resident."
+            title: "Which model",
+            explainer: "\"Last model used\" follows whatever you were last chatting with, decided when the app starts rather than when you set this — so it keeps up as you switch models. \"Always this model\" pins one regardless."
         ) {
-            Picker("", selection: $appState.startupModelPath) {
-                // First, and the default: the model you want next is usually
-                // the one you just used.
-                Text("Last model used").tag(StartupModelChoice.lastUsedTag)
-                let dupNames = LocalModel.duplicateNames(in: pickable)
-                ForEach(pickable) { model in
-                    Text(startupModelLabel(model, dupNames: dupNames)).tag(model.path)
-                }
-                // A pick that has since been uninstalled matches no row, and a
-                // Picker whose selection matches no row renders BLANK — the
-                // dead-control class. Carry it as its own row so the setting
-                // still says what it holds and what launch will do about it.
-                if !appState.startupModelPath.isEmpty,
-                   !pickable.contains(where: { $0.path == appState.startupModelPath }) {
-                    Text("\((appState.startupModelPath as NSString).lastPathComponent) — no longer installed")
-                        .tag(appState.startupModelPath)
+            Picker("", selection: $appState.startupModelMode) {
+                ForEach(StartupModelChoice.Mode.allCases) { mode in
+                    Text(mode.label).tag(mode)
                 }
             }
             .labelsHidden()
-            .pickerStyle(.menu)
-            .frame(minWidth: 180)
+            .pickerStyle(.segmented)
             .disabled(!appState.loadModelAtStart)
+        }
+        SettingsRow(
+            title: "Model",
+            explainer: "If the pinned model is removed later — or nothing has been loaded yet — the server simply starts with nothing resident, rather than substituting a model you did not choose."
+        ) {
+            VStack(alignment: .trailing, spacing: 4) {
+                Picker("", selection: $appState.startupModelPinnedPath) {
+                    let dupNames = LocalModel.duplicateNames(in: pickable)
+                    ForEach(pickable) { model in
+                        Text(startupModelLabel(model, dupNames: dupNames)).tag(model.path)
+                    }
+                    // A pin that has since been uninstalled matches no row, and
+                    // a Picker whose selection matches no row renders BLANK —
+                    // the dead-control class. This row is still a MODEL (one
+                    // that used to be here), not a rule, so it belongs in the
+                    // list. It says what the setting holds and what start will
+                    // do about it.
+                    if !appState.startupModelPinnedPath.isEmpty,
+                       !pickable.contains(where: { $0.path == appState.startupModelPinnedPath }) {
+                        Text("\((appState.startupModelPinnedPath as NSString).lastPathComponent) — no longer installed")
+                            .tag(appState.startupModelPinnedPath)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(minWidth: 180)
+                // Disabled under "Last model used": the dropdown is not what
+                // decides then, and an enabled control that changes nothing is
+                // worse than one that is visibly not in play.
+                .disabled(!appState.loadModelAtStart || appState.startupModelMode == .lastUsed)
+
+                // Which model that rule resolves to today, so the answer is
+                // visible rather than something you find out at the next login.
+                if appState.startupModelMode == .lastUsed {
+                    Text(lastUsedResolution)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.trailing)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         }
         if let m = meta["host"] {
             SettingsRow(

--- a/app/Sources/MLXServe/Views/SettingsView.swift
+++ b/app/Sources/MLXServe/Views/SettingsView.swift
@@ -895,7 +895,65 @@ private struct ServerSectionContent: View {
         ServerLaunchDirty(current: appState.serverOptions, last: server.liveLaunchedOptions)
     }
 
+    /// Chat models only — the same `isChatPickable` filter every other model
+    /// picker in the app uses (tray, composer pill, ⌘L palette). A Mac with only
+    /// media/drafter downloads has a NON-EMPTY `localModels` and nothing
+    /// offerable, which is why no surface may filter on its own.
+    private var pickable: [LocalModel] {
+        appState.localModels.filter(\.isChatPickable)
+    }
+
+    /// Same rule as the tray picker: `displayLabel`, not `name` (a GGUF repo
+    /// ships several quants, each its own row, and siblings share a name), plus
+    /// an engine suffix where two labels would otherwise be identical — macOS
+    /// `.menu` Pickers key the checkmark by item TITLE, so duplicates both
+    /// render selected.
+    private func startupModelLabel(_ model: LocalModel, dupNames: Set<String>) -> String {
+        let label = model.displayLabel
+        guard dupNames.contains(label) else { return label }
+        return "\(label) · \(model.engine.shortLabel)"
+    }
+
     var body: some View {
+        // Startup. Deliberately the first two rows of the Server section: "Do
+        // you want the server?" is `autoStartServer` in the tray, and "do you
+        // want a model resident with it?" is here. They were one checkbox, and
+        // the merged one loaded whatever was selected — see `StartupModelChoice`.
+        SettingsRow(
+            title: "Load a model at start",
+            explainer: "Off by default. Auto-start brings the server up with no model resident; it loads one on demand at your first message, so login stays fast. Turn this on to pay for the load up front instead — a large checkpoint can take a while and holds the memory from the moment you log in."
+        ) {
+            Toggle("", isOn: $appState.loadModelAtStart)
+                .labelsHidden()
+                .toggleStyle(.switch)
+        }
+        SettingsRow(
+            title: "Model to load at start",
+            explainer: "\"Last model used\" follows whatever you were last chatting with, decided when the app starts rather than when you set this. If that model has since been removed — or you have not loaded one yet — the server simply starts with nothing resident."
+        ) {
+            Picker("", selection: $appState.startupModelPath) {
+                // First, and the default: the model you want next is usually
+                // the one you just used.
+                Text("Last model used").tag(StartupModelChoice.lastUsedTag)
+                let dupNames = LocalModel.duplicateNames(in: pickable)
+                ForEach(pickable) { model in
+                    Text(startupModelLabel(model, dupNames: dupNames)).tag(model.path)
+                }
+                // A pick that has since been uninstalled matches no row, and a
+                // Picker whose selection matches no row renders BLANK — the
+                // dead-control class. Carry it as its own row so the setting
+                // still says what it holds and what launch will do about it.
+                if !appState.startupModelPath.isEmpty,
+                   !pickable.contains(where: { $0.path == appState.startupModelPath }) {
+                    Text("\((appState.startupModelPath as NSString).lastPathComponent) — no longer installed")
+                        .tag(appState.startupModelPath)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(minWidth: 180)
+            .disabled(!appState.loadModelAtStart)
+        }
         if let m = meta["host"] {
             SettingsRow(
                 title: m.title,

--- a/app/Sources/MLXServe/Views/StatusMenuView.swift
+++ b/app/Sources/MLXServe/Views/StatusMenuView.swift
@@ -400,6 +400,10 @@ struct StatusMenuView: View {
             Toggle("Auto-start on launch", isOn: $appState.autoStartServer)
                 .toggleStyle(.switch)
                 .controlSize(.mini)
+                // Says what this checkbox does NOW: it starts a server, not a
+                // multi-gigabyte load. Whether a model comes with it moved to
+                // its own setting, so the tooltip names where it went.
+                .help("Start the server when the app launches. It comes up with no model resident — models load on demand. To load one at start instead, see Settings ▸ Server.")
             Spacer()
             // Which embedded engine the selected model routes to (MLX
             // safetensors, llama.cpp GGUF, or ds4 GGUF).

--- a/app/Tests/MLXCoreTests/StartupModelChoiceTests.swift
+++ b/app/Tests/MLXCoreTests/StartupModelChoiceTests.swift
@@ -1,7 +1,8 @@
 import XCTest
 @testable import MLXCore
 
-/// The launch gate: what auto-start actually starts.
+/// The launch gate: what auto-start actually starts, and which model — if any —
+/// comes up with it.
 ///
 /// The bug this pins (issue #214): "Auto-start on launch" passed `--model`,
 /// which the server treats as an eager, blocking load, so one checkbox labelled
@@ -24,7 +25,8 @@ final class StartupModelChoiceTests: XCTestCase {
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: false,
                                       loadModelAtStart: true,
-                                      choice: "/models/qwen",
+                                      mode: .pinned,
+                                      pinnedPath: "/models/qwen",
                                       lastUsed: "/models/qwen",
                                       installedPaths: installed),
             .doNothing)
@@ -36,43 +38,93 @@ final class StartupModelChoiceTests: XCTestCase {
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: true,
                                       loadModelAtStart: false,
-                                      choice: "/models/qwen",
+                                      mode: .pinned,
+                                      pinnedPath: "/models/qwen",
                                       lastUsed: "/models/gemma",
                                       installedPaths: installed),
             .headless)
     }
 
-    func testLoadAtStartWithAnExplicitPickLoadsThatModel() {
+    func testPinnedModeLoadsThePinnedModel() {
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: true,
                                       loadModelAtStart: true,
-                                      choice: "/models/gemma",
+                                      mode: .pinned,
+                                      pinnedPath: "/models/gemma",
                                       lastUsed: "/models/qwen",
                                       installedPaths: installed),
             .load(path: "/models/gemma"))
     }
 
-    // MARK: - "Last model used"
+    /// A pin is a pin: what has been used since must not move it.
+    func testPinnedModeIgnoresTheLastUsedModel() {
+        XCTAssertEqual(
+            StartupModelChoice.resolved(mode: .pinned,
+                                        pinnedPath: "/models/gemma",
+                                        lastUsed: "/models/qwen",
+                                        installedPaths: installed),
+            "/models/gemma")
+    }
 
-    /// Resolved at START time, not when the setting was saved — the saved value
-    /// is the sentinel, so a different last-used model gives a different answer
-    /// from the same stored preference.
-    func testLastUsedResolvesAtStartTime() {
+    /// "Always this model" selected before anything was pinned.
+    func testPinnedModeWithNothingPinnedResolvesToNothing() {
+        XCTAssertNil(
+            StartupModelChoice.resolved(mode: .pinned,
+                                        pinnedPath: "",
+                                        lastUsed: "/models/qwen",
+                                        installedPaths: installed))
+    }
+
+    // MARK: - "Last model used" is a MODE, not a magic path
+
+    /// Resolved at START time, so the same stored preference gives a different
+    /// answer as the last-used model moves. Nothing about the stored value
+    /// changes between these two cases.
+    func testLastUsedModeResolvesAtStartTime() {
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: true,
                                       loadModelAtStart: true,
-                                      choice: StartupModelChoice.lastUsedTag,
+                                      mode: .lastUsed,
+                                      pinnedPath: nil,
                                       lastUsed: "/models/qwen",
                                       installedPaths: installed),
             .load(path: "/models/qwen"))
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: true,
                                       loadModelAtStart: true,
-                                      choice: StartupModelChoice.lastUsedTag,
+                                      mode: .lastUsed,
+                                      pinnedPath: nil,
                                       lastUsed: "/models/gemma",
                                       installedPaths: installed),
             .load(path: "/models/gemma"))
     }
+
+    /// The mode wins over a pin that happens to still be stored — the pinned
+    /// path is inert data under `.lastUsed`, not a fallback.
+    func testLastUsedModeIgnoresAStoredPin() {
+        XCTAssertEqual(
+            StartupModelChoice.resolved(mode: .lastUsed,
+                                        pinnedPath: "/models/gemma",
+                                        lastUsed: "/models/qwen",
+                                        installedPaths: installed),
+            "/models/qwen")
+    }
+
+    /// No mode is spelled as a path, so no path can be mistaken for a mode.
+    /// A raw value that collides with an absolute path would put the sentinel
+    /// straight back.
+    func testNoModeIsSpelledAsAPath() {
+        for mode in StartupModelChoice.Mode.allCases {
+            XCTAssertFalse(mode.rawValue.hasPrefix("/"), "\(mode) reads as a path")
+            XCTAssertFalse(mode.rawValue.isEmpty, "\(mode) reads as an absent value")
+        }
+    }
+
+    func testTheDefaultModeIsLastUsed() {
+        XCTAssertEqual(StartupModelChoice.Mode.default, .lastUsed)
+    }
+
+    // MARK: - Nothing to load
 
     /// Fresh install. Not an error, and emphatically not "pick one for them" —
     /// a startup that loads a model the user never chose is worse than one that
@@ -81,7 +133,8 @@ final class StartupModelChoiceTests: XCTestCase {
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: true,
                                       loadModelAtStart: true,
-                                      choice: StartupModelChoice.lastUsedTag,
+                                      mode: .lastUsed,
+                                      pinnedPath: nil,
                                       lastUsed: nil,
                                       installedPaths: installed),
             .headless)
@@ -93,17 +146,19 @@ final class StartupModelChoiceTests: XCTestCase {
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: true,
                                       loadModelAtStart: true,
-                                      choice: StartupModelChoice.lastUsedTag,
+                                      mode: .lastUsed,
+                                      pinnedPath: nil,
                                       lastUsed: "/models/deleted",
                                       installedPaths: installed),
             .headless)
     }
 
-    func testUninstalledExplicitPickStartsHeadless() {
+    func testUninstalledPinStartsHeadless() {
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: true,
                                       loadModelAtStart: true,
-                                      choice: "/models/deleted",
+                                      mode: .pinned,
+                                      pinnedPath: "/models/deleted",
                                       lastUsed: "/models/qwen",
                                       installedPaths: installed),
             .headless)
@@ -114,7 +169,8 @@ final class StartupModelChoiceTests: XCTestCase {
         XCTAssertEqual(
             StartupModelChoice.launch(autoStart: true,
                                       loadModelAtStart: true,
-                                      choice: StartupModelChoice.lastUsedTag,
+                                      mode: .lastUsed,
+                                      pinnedPath: nil,
                                       lastUsed: "/models/qwen",
                                       installedPaths: []),
             .headless)

--- a/app/Tests/MLXCoreTests/StartupModelChoiceTests.swift
+++ b/app/Tests/MLXCoreTests/StartupModelChoiceTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import MLXCore
+
+/// The launch gate: what auto-start actually starts.
+///
+/// The bug this pins (issue #214): "Auto-start on launch" passed `--model`,
+/// which the server treats as an eager, blocking load, so one checkbox labelled
+/// *start* read tens of gigabytes off disk at login. Splitting the two
+/// decisions is only safe if the split itself is checkable — the gate is a
+/// single branch in `AppState.init` that nobody can watch run.
+final class StartupModelChoiceTests: XCTestCase {
+
+    private let installed = ["/models/qwen", "/models/gemma"]
+
+    private func scratchDefaults(_ name: String = #function) -> UserDefaults {
+        let suite = "StartupModelChoiceTests.\(name)"
+        UserDefaults().removePersistentDomain(forName: suite)
+        return UserDefaults(suiteName: suite)!
+    }
+
+    // MARK: - Start the server vs load a model
+
+    func testAutoStartOffStartsNothing() {
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: false,
+                                      loadModelAtStart: true,
+                                      choice: "/models/qwen",
+                                      lastUsed: "/models/qwen",
+                                      installedPaths: installed),
+            .doNothing)
+    }
+
+    /// The whole point of the change: auto-start alone brings the server up
+    /// WITHOUT a model. If this ever goes back to `.load`, login is slow again.
+    func testAutoStartAloneIsHeadless() {
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: true,
+                                      loadModelAtStart: false,
+                                      choice: "/models/qwen",
+                                      lastUsed: "/models/gemma",
+                                      installedPaths: installed),
+            .headless)
+    }
+
+    func testLoadAtStartWithAnExplicitPickLoadsThatModel() {
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: true,
+                                      loadModelAtStart: true,
+                                      choice: "/models/gemma",
+                                      lastUsed: "/models/qwen",
+                                      installedPaths: installed),
+            .load(path: "/models/gemma"))
+    }
+
+    // MARK: - "Last model used"
+
+    /// Resolved at START time, not when the setting was saved — the saved value
+    /// is the sentinel, so a different last-used model gives a different answer
+    /// from the same stored preference.
+    func testLastUsedResolvesAtStartTime() {
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: true,
+                                      loadModelAtStart: true,
+                                      choice: StartupModelChoice.lastUsedTag,
+                                      lastUsed: "/models/qwen",
+                                      installedPaths: installed),
+            .load(path: "/models/qwen"))
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: true,
+                                      loadModelAtStart: true,
+                                      choice: StartupModelChoice.lastUsedTag,
+                                      lastUsed: "/models/gemma",
+                                      installedPaths: installed),
+            .load(path: "/models/gemma"))
+    }
+
+    /// Fresh install. Not an error, and emphatically not "pick one for them" —
+    /// a startup that loads a model the user never chose is worse than one that
+    /// loads none.
+    func testNoLastUsedStartsHeadlessRatherThanPickingSomething() {
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: true,
+                                      loadModelAtStart: true,
+                                      choice: StartupModelChoice.lastUsedTag,
+                                      lastUsed: nil,
+                                      installedPaths: installed),
+            .headless)
+    }
+
+    /// The model was uninstalled between launches. `--model <gone>` is an
+    /// instant FileNotFound, which is the failure this change exists to avoid.
+    func testUninstalledLastUsedStartsHeadless() {
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: true,
+                                      loadModelAtStart: true,
+                                      choice: StartupModelChoice.lastUsedTag,
+                                      lastUsed: "/models/deleted",
+                                      installedPaths: installed),
+            .headless)
+    }
+
+    func testUninstalledExplicitPickStartsHeadless() {
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: true,
+                                      loadModelAtStart: true,
+                                      choice: "/models/deleted",
+                                      lastUsed: "/models/qwen",
+                                      installedPaths: installed),
+            .headless)
+    }
+
+    /// A Mac with nothing chat-pickable at all.
+    func testEmptyLibraryStartsHeadless() {
+        XCTAssertEqual(
+            StartupModelChoice.launch(autoStart: true,
+                                      loadModelAtStart: true,
+                                      choice: StartupModelChoice.lastUsedTag,
+                                      lastUsed: "/models/qwen",
+                                      installedPaths: []),
+            .headless)
+    }
+
+    // MARK: - Recording the last model used
+
+    func testNothingRecordedYetReadsAsNil() {
+        XCTAssertNil(StartupModelChoice.lastUsed(defaults: scratchDefaults()))
+    }
+
+    func testRecordedLoadIsReadBack() {
+        let d = scratchDefaults()
+        StartupModelChoice.recordLoaded(path: "/models/qwen", defaults: d)
+        XCTAssertEqual(StartupModelChoice.lastUsed(defaults: d), "/models/qwen")
+    }
+
+    func testTheMostRecentLoadWins() {
+        let d = scratchDefaults()
+        StartupModelChoice.recordLoaded(path: "/models/qwen", defaults: d)
+        StartupModelChoice.recordLoaded(path: "/models/gemma", defaults: d)
+        XCTAssertEqual(StartupModelChoice.lastUsed(defaults: d), "/models/gemma")
+    }
+
+    /// A registry id is a directory BASENAME (for a Hugging Face snapshot, a
+    /// commit hash) and a LAN id names another Mac's model. Neither can be
+    /// handed to `--model`, so neither may become the last model used.
+    func testNonPathIdsAreNotRecorded() {
+        let d = scratchDefaults()
+        StartupModelChoice.recordLoaded(path: "/models/qwen", defaults: d)
+        StartupModelChoice.recordLoaded(path: "lan:some-peer-model", defaults: d)
+        StartupModelChoice.recordLoaded(path: "a1b2c3d4", defaults: d)
+        StartupModelChoice.recordLoaded(path: "", defaults: d)
+        XCTAssertEqual(StartupModelChoice.lastUsed(defaults: d), "/models/qwen")
+    }
+}


### PR DESCRIPTION
Written by an agent. Not compiled, not tested. The machine this was written on has no Zig toolchain and 2.6 GB of free disk, so nothing was built. Please treat this as a suggestion to verify, not a ready patch. Staying a draft until someone builds it.

The only check that was run is `swiftc -parse` on each edited file, which is **syntax only** — it does not type-check, so it proves nothing about whether this compiles.

Closes #214 (if you agree with the shape).

---

## The problem: one checkbox does two things

`AppState.swift` (the launch gate, before this change):

```swift
// Auto-start server if enabled and a model is available
if autoStartServer, !selectedModelPath.isEmpty {
    server.start(modelPath: selectedModelPath, options: serverOptions)
}
```

`ServerManager.start(modelPath:options:)` always passes `--model`:

```swift
func start(modelPath: String, options: ServerOptions) {
    guard status != .running, status != .starting else { return }
    let resolvedModel = Self.launchModelPath(modelPath)
    currentModelPath = resolvedModel
    var args = ["--model", resolvedModel]
```

And on the server side `--model` is an **eager, blocking** load:

- `main.zig:1258` — sets `no_initial_load = false`
- `server.zig:1205` — `Scheduler.init` runs *before* the listener binds
- `scheduler.zig:1305` — blocks until the checkpoint is loaded

So the single checkbox in `StatusMenuView.swift`:

```swift
Toggle("Auto-start on launch", isOn: $appState.autoStartServer)
```

silently reads the entire selected checkpoint off disk at login. With a 26.7 GB model selected — which is what my own setting points at — that is a very long, very invisible startup.

## The server already supports what we want

Nothing needs to change in Zig. Starting without a model is an existing, supported path:

- `main.zig:1032-1035` — no `--model` routes to `runHeadlessServe`
- `main.zig:1755` — headless sets `no_initial_load = true`
- `scheduler.zig:3451-3453` — *"Headless: no primary model loaded; models load on demand."*

The model then loads at `server.zig:3755` (`/v1/load-model`) or `server.zig:1860` (first request). The app already had both halves too — `ServerManager.startHeadless(modelsDir:options:)`, used today by `ensureServerForLan()` and the media-gen path, and `ServerManager.ensureDefaultChatModel(selectedModelPath:)`, which hot-loads the chat model on the first turn when the running server was launched headless. Auto-start was simply the one caller that never asked for it.

## The change

**Auto-start now starts the server headless.** "Auto-start on launch" stays exactly where it is in the tray, keeps its name, and keeps meaning *start the server* — which is now all it does. It gained a tooltip pointing at where loading went.

**Loading became its own decision**, as three rows at the top of Settings ▸ Server:

| Row | Control |
|---|---|
| **Load a model at start** | Toggle, **default OFF**. |
| **Which model** | Two-state segmented control: *Last model used* / *Always this model*. |
| **Model** | Dropdown of installed chat models. |

"Which model" is a property of the selector, not a member of the list — the dropdown contains **only real models**, never a synthetic row. Under *Last model used* the dropdown is disabled and a quiet caption underneath names the model the rule resolves to today ("Currently: Qwen3-8B", or "Nothing loaded yet — the server will start with no model"), so the answer is visible now rather than discovered at the next login.

### The stored preference is a mode plus an optional pinned path

Not a magic path value. `StartupModelChoice.Mode` (`.lastUsed` / `.pinned`) has its own key, beside `startupModelPinnedPath`, which is empty when nothing has been pinned — an absent optional, not a sentinel. A sentinel inside a path field is the same defect in different clothes: every reader has to know the secret string, and one that doesn't treats it as a filename. There is a test pinning that no mode's raw value can be mistaken for a path.

The gate is now a pure function rather than an `if` in `init`, because it is a branch nobody can watch run and its previous shape shipped a multi-gigabyte load behind a checkbox that promised a server:

```swift
static func resolved(mode: Mode,
                     pinnedPath: String?,
                     lastUsed: String?,
                     installedPaths: [String]) -> String? {
    let wanted: String?
    switch mode {
    case .lastUsed: wanted = lastUsed
    case .pinned:   wanted = pinnedPath
    }
    guard let wanted, !wanted.isEmpty, installedPaths.contains(wanted) else { return nil }
    return wanted
}

static func launch(autoStart: Bool, loadModelAtStart: Bool, mode: Mode,
                   pinnedPath: String?, lastUsed: String?,
                   installedPaths: [String]) -> Launch {
    guard autoStart else { return .doNothing }
    guard loadModelAtStart else { return .headless }
    guard let path = resolved(mode: mode, pinnedPath: pinnedPath,
                              lastUsed: lastUsed,
                              installedPaths: installedPaths) else { return .headless }
    return .load(path: path)
}
```

The Settings caption and the launch gate both call `resolved`, so the readout cannot promise a model the gate would decline to load.

### The load toggle defaults OFF, and there is deliberately no migration

An upgrading user whose "Auto-start on launch" used to eagerly load 26 GB **stops doing that on the next launch**. That is the point of the change, not a side effect of it. `loadModelAtStart` is read with `UserDefaults.standard.bool(forKey:)`, so an absent key is false, and nothing writes a true on their behalf.

They lose nothing: the server still comes up, and their model still loads — on the first message, through the `ensureDefaultChatModel` path that already exists.

### Nothing to load is a normal outcome, not an error

No recorded last model (fresh install), or a model uninstalled since it was chosen: the server starts **headless**. It never falls back to an arbitrary model — a startup that loads a model the user never chose is worse than one that loads none — and never sends `--model <gone>`, an instant FileNotFound. The stored pick is checked against the installed chat-pickable library on every launch, so removal is caught here rather than discovered by the server.

### Where "last used" comes from

**I checked for an existing store first and did not find one.** `grep -i "lastModel|recentModel|lastUsed|lastLoaded|mostRecent"` over `app/Sources/MLXServe/` returns only `SandboxSessionTabs.mostRecentActive` (terminal sessions) and its caller. `MediaRecents` tracks generated media *files*, not models. So this adds the smallest store I could: one `UserDefaults` key behind two static functions in `StartupModelChoice`. If there is a source of truth I missed, say so and I will delete mine and read yours instead.

**It is written only where a load is confirmed, never where one is requested** — a load that failed is not a model that was used, and recording it would replay the failure next launch. Three sites, all in `ServerManager`:

| Site | Why it is a confirmed load |
|---|---|
| `transitionToRunning()` | An eager `--model` launch that reached `.running`. A start that dies mid-load never gets here. Headless leaves `currentModelPath` empty, which `recordLoaded` ignores. |
| `loadModel(...)`, inside the existing `if setDefault, id.hasPrefix("/")` branch | A completed chat-model hot-switch — `api.loadModel` returned. **Only** the `setDefault` branch records: `loadModel` is also the media path (`prepareGenModel` hot-loads FLUX / LTX / Kokoro by directory), and a video model is not a "last model used" that a chat startup should reach for. |
| `ensureDefaultChatModel(...)` on success | The first-turn hot-load onto a headless server. This is now the *common* way a model goes resident, so without it "Last model used" would stay empty for anyone who never touches the tray picker. |

`recordLoaded` takes absolute paths only. A registry id is a directory basename (for a Hugging Face snapshot, a commit hash) and a LAN id names another Mac's model; neither can be handed back to `--model`.

## `selectedModelPath` is untouched

Its key, its value, and its `didSet` are exactly as they were. Nobody's chosen model is lost.

The startup pin is a separate key, not a reuse of `selectedModelPath`, because `selectedModelPath` is the model answering chats *right now* — its `didSet` hot-switches or restarts a running server, and editing a startup preference must not swap the model out from under a conversation in progress.

## How the dropdown is populated

It reuses the existing list source; no new scanner. `AppState.localModels` (populated by `DownloadManager.discoverLocalModels()`), filtered by `LocalModel.isChatPickable` — the same filter the tray picker, the composer pill, the ⌘L palette and `AppState.refreshModels` all use, which excludes drafters, media models, `bert` encoders and the NSFW classifier. Labels use `displayLabel` with `LocalModel.duplicateNames` engine-suffixing, copied from `StatusMenuView.modelPicker`, because sibling GGUF quants share a `name` and a macOS `.menu` Picker keys its checkmark by item title.

A pin that is no longer installed keeps a "— no longer installed" row so the Picker never matches no row and renders blank. That row is still a *model* (one that used to be there), not a rule.

## Files

| File | Change |
|---|---|
| `app/Sources/MLXServe/Models/StartupModelChoice.swift` | **New.** The mode, the pure resolution + launch decision, and the last-used store. |
| `app/Sources/MLXServe/AppState.swift` | `loadModelAtStart`, `startupModelMode`, `startupModelPinnedPath`; launch gate switched to `StartupModelChoice.launch`. |
| `app/Sources/MLXServe/Services/ServerManager.swift` | Three `recordLoaded` calls at confirmed-load sites. |
| `app/Sources/MLXServe/Views/SettingsView.swift` | The three new rows at the top of `ServerSectionContent`. |
| `app/Sources/MLXServe/Views/StatusMenuView.swift` | Tooltip on the existing auto-start toggle. |
| `app/Tests/MLXCoreTests/StartupModelChoiceTests.swift` | **New.** 17 cases over the mode, the gate and the store. |

## What a reviewer should check first

Beyond "does it compile", which I genuinely do not know:

1. **`transitionToRunning()` is called from more than one place** (`forceRunning()` is the `TestServer` path). Recording there assumes reaching `.running` with a non-empty `currentModelPath` means the checkpoint really loaded. I believe that holds because `Scheduler.init` blocks before the listener binds, so health cannot answer until the load finished — but that is the inference most worth a second opinion.
2. **`ensureServerForLan()` is now usually a no-op at launch**, since auto-start has already brought the server up headless. That looks like an improvement (it removes a race) rather than a regression, but it is a behaviour change I did not set out to make.
3. Whether the three rows belong in **Settings ▸ Server** or somewhere else. `.server` was the closest fit; there is no "General".
4. Whether recording only the `setDefault` branch of `loadModel` misses a chat-load path I did not find.
