### PR TITLE
My Models: media checkpoints stop reading as "Unsupported", and get a Use button

### DIFF
--- a/app/Sources/MLXServe/Models/HFModels.swift
+++ b/app/Sources/MLXServe/Models/HFModels.swift
@@ -66,14 +66,96 @@ let supportedModelTypes: Set<String> = [
 /// Mirrors `model_discovery.isMediaModelType` (Zig).
 private let mediaModelTypePrefixes: [String] = ["flux2", "krea", "mage_flow", "hunyuan3d"]
 // Mirrors `gen.media_model_types` on the server. Drift here is not cosmetic:
-// a media model missing from this list is treated as a chat model by the
-// browser and the picker. `kokoro` is deliberately absent — it is voice-mode
-// only and never appears in the media-gen catalog (see AudioModelPreset).
-private let mediaModelTypeExactValues: Set<String> = ["qwen3_tts", "AudioVideo", "acestep", "minimax_h3"]
+// a media model missing from this list fails the ARCHITECTURE gate outright,
+// so the browser draws it a red "Unsupported" — which is what happened to
+// `minimax_music3` on the same screen that offers to download it, and to bare
+// `mageflow` (MageFlow ships no root config.json, so it is classified from
+// model_index.json under that spelling). `kokoro` was excluded on purpose
+// because it is voice-mode-only and absent from every media picker — but
+// "hidden from pickers" and "shown to the user as an unsupported
+// architecture" are different decisions, and it was getting both. Exclusion
+// from pickers is `isChatPickable`'s job, which reads this same list. #228.
+//
+// `MediaModalityParityTests` reads `media_model_types` out of src/gen.zig and
+// asserts this agrees. Zig already pinned its own two copies against each
+// other; nothing pinned Swift, which is why this drifted unnoticed.
+private let mediaModelTypeExactValues: Set<String> = [
+    "qwen3_tts", "AudioVideo", "acestep", "minimax_h3", "minimax_music3", "kokoro", "mageflow",
+]
 
 func isMediaModelType(_ modelType: String) -> Bool {
     if mediaModelTypeExactValues.contains(modelType) { return true }
     return mediaModelTypePrefixes.contains { modelType.hasPrefix($0) }
+}
+
+/// Media architectures a **Discover search row** may offer as a download.
+///
+/// A narrower question than `isMediaModelType`, and the two were conflated.
+/// "Is this a media architecture?" decides the Unsupported badge and the
+/// chat-picker exclusion — Kokoro is one, and pretending otherwise is what put
+/// a red flag on it. "Should a search result offer this repo?" is a CATALOG
+/// decision, and Kokoro is answered by the built-in voice-mode entry rather
+/// than by arbitrary repos found on the hub. Kokoro still appears in the Media
+/// pane's Audio section via `AudioModelPreset.allIncludingVoiceOnly`, so this
+/// hides nothing the user needs; it only keeps the Discover door shut.
+func discoverableMediaModelType(_ modelType: String) -> Bool {
+    modelType != "kokoro" && isMediaModelType(modelType)
+}
+
+/// Which create pane a media checkpoint belongs to.
+///
+/// Mirrors Zig's `gen.modalityFromType` with ONE deliberate difference: Zig
+/// collapses speech and music into `.audio` because they share an engine slot,
+/// but the app has to tell them apart — they are two tabs of one pane, so a
+/// Use button that only knew "audio" would drop a music model on the Voice
+/// tab. `CustomMediaModels.musicFamily` is the existing discriminator; this is
+/// the same split, minus the running-server requirement (a browser row is a
+/// filesystem `LocalModel` with no capabilities).
+enum MediaModality: CaseIterable {
+    case image, voice, music, video, mesh
+
+    init?(modelType: String) {
+        if modelType.hasPrefix("flux2") || modelType.hasPrefix("krea")
+            || modelType.hasPrefix("mage_flow") || modelType == "mageflow" { self = .image; return }
+        if modelType.hasPrefix("hunyuan3d") { self = .mesh; return }
+        switch modelType {
+        case "qwen3_tts", "kokoro": self = .voice
+        case "acestep", "minimax_music3": self = .music
+        case "AudioVideo", "minimax_h3": self = .video
+        default: return nil
+        }
+    }
+
+    /// The top-level create page. Music has no `GenExperiment` case of its own
+    /// — it is a tab inside Audio — so it shares `.audio` with voice.
+    var experiment: GenExperiment {
+        switch self {
+        case .image: return .image
+        case .voice, .music: return .audio
+        case .video: return .video
+        case .mesh: return .model3d
+        }
+    }
+
+    /// Which tab of the Audio pane, or nil where the question does not apply.
+    var audioTab: AudioGenView.Tab? {
+        switch self {
+        case .voice: return .voice
+        case .music: return .music
+        default: return nil
+        }
+    }
+
+    /// What the Use button says it will open.
+    var paneName: String {
+        switch self {
+        case .image: return "Image Generation"
+        case .voice: return "Voice"
+        case .music: return "Music"
+        case .video: return "Video Generation"
+        case .mesh: return "3D"
+        }
+    }
 }
 
 /// The `config` block the HF API returns when asked (`expand[]=config`).
@@ -153,11 +235,11 @@ struct HFModel: Identifiable, Codable {
     /// diffusers repos carry no model_type), else a tag spelling a media
     /// model_type verbatim (mlx-serve packs tag it, e.g. "minimax_h3").
     /// nil = not a media repo we serve; Kokoro deliberately maps nowhere
-    /// (voice-mode-only catalog rule).
+    /// (voice-mode-only catalog rule — see `discoverableMediaModelType`).
     var mediaFamilyModelType: String? {
-        if let t = config?.modelType, isMediaModelType(t) { return t }
+        if let t = config?.modelType, discoverableMediaModelType(t) { return t }
         if let c = config?.diffusersClassName, let t = servedDiffusersClasses[c] { return t }
-        return (tags ?? []).first(where: isMediaModelType)
+        return (tags ?? []).first(where: discoverableMediaModelType)
     }
 
     var isServedMediaRepo: Bool { mediaFamilyModelType != nil }

--- a/app/Sources/MLXServe/Models/ModelBrowserSection.swift
+++ b/app/Sources/MLXServe/Models/ModelBrowserSection.swift
@@ -185,6 +185,21 @@ enum ModelBrowserUse {
         return models.first { normalize($0.path) == wanted && $0.isChatPickable }
     }
 
+    /// The media model at `path` and the pane it belongs to, if any.
+    ///
+    /// The sibling of `pickableModel` for the other half of the catalogue. Both
+    /// return nil for the other's kind, so a row asks both and gets at most one
+    /// answer — a media checkpoint is never chat-pickable and a chat model has
+    /// no modality. Every on-disk row can then offer a Use, instead of Discover
+    /// and the Media pane quietly ending at Delete the way My Models did (#228).
+    static func mediaModel(atPath path: String?, in models: [LocalModel]) -> (model: LocalModel, modality: MediaModality)? {
+        guard let path, !path.isEmpty else { return nil }
+        let wanted = normalize(path)
+        guard let m = models.first(where: { normalize($0.path) == wanted }),
+              let modality = MediaModality(modelType: m.modelType) else { return nil }
+        return (m, modality)
+    }
+
     private static func normalize(_ path: String) -> String {
         var p = (path as NSString).standardizingPath
         while p.count > 1, p.hasSuffix("/") { p.removeLast() }

--- a/app/Sources/MLXServe/Views/ModelBrowserView.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserView.swift
@@ -831,7 +831,7 @@ private struct MediaPane: View {
                     systemImage: "photo",
                     tint: .pink
                 ) {
-                    ForEach(ImageModelPreset.all) { MediaModelRow(preset: $0, physicalMemoryBytes: physicalMemory) }
+                    ForEach(ImageModelPreset.all) { MediaModelRow(preset: $0, modality: .image, physicalMemoryBytes: physicalMemory) }
                 }
                 ModelGroupSection(
                     title: "Audio",
@@ -842,7 +842,7 @@ private struct MediaPane: View {
                     // The browser lists the FULL catalog — Kokoro is voice-mode
                     // only (out of `.all`, which the media panes offer) but is
                     // still a model the user can fetch from here.
-                    ForEach(AudioModelPreset.allIncludingVoiceOnly) { MediaModelRow(preset: $0, physicalMemoryBytes: physicalMemory) }
+                    ForEach(AudioModelPreset.allIncludingVoiceOnly) { MediaModelRow(preset: $0, modality: .voice, physicalMemoryBytes: physicalMemory) }
                 }
                 ModelGroupSection(
                     title: "Video",
@@ -850,7 +850,7 @@ private struct MediaPane: View {
                     systemImage: "film",
                     tint: .indigo
                 ) {
-                    ForEach(VideoModelPreset.all) { MediaModelRow(preset: $0, physicalMemoryBytes: physicalMemory) }
+                    ForEach(VideoModelPreset.all) { MediaModelRow(preset: $0, modality: .video, physicalMemoryBytes: physicalMemory) }
                 }
                 ModelGroupSection(
                     title: "Music",
@@ -858,7 +858,7 @@ private struct MediaPane: View {
                     systemImage: "music.note",
                     tint: .orange
                 ) {
-                    ForEach(MusicModelPreset.all) { MediaModelRow(preset: $0, physicalMemoryBytes: physicalMemory) }
+                    ForEach(MusicModelPreset.all) { MediaModelRow(preset: $0, modality: .music, physicalMemoryBytes: physicalMemory) }
                 }
             }
             .padding(16)
@@ -900,11 +900,18 @@ private struct ModelGroupSection<Content: View>: View {
 
 /// One row for any media preset (image/audio/video/music) — generic over
 /// `MediaModelPreset` so the four modalities share this instead of four
-/// near-duplicate views. Download/progress/retry mirrors `BundleDownloadBar`;
-/// unlike a chat model there's no "Use" (each gen pane keeps its own sticky
-/// model selection), so the terminal state is just on-disk + Delete.
+/// near-duplicate views. Download/progress/retry mirrors `BundleDownloadBar`.
+///
+/// The terminal state used to be on-disk + Delete and nothing else, on the
+/// reasoning that each gen pane keeps its own sticky model selection. But that
+/// left "throw it away" as the only verb the browser offered for a model it
+/// had just finished downloading (#228). `Use` opens the owning pane; the pane
+/// still keeps its own selection, so this is navigation, not a second loader.
+/// The modality is passed in rather than derived — the Media pane already
+/// groups by it, so the call site knows it exactly.
 private struct MediaModelRow<Preset: MediaModelPreset>: View {
     let preset: Preset
+    let modality: MediaModality
     let physicalMemoryBytes: UInt64
     @EnvironmentObject var downloads: DownloadManager
     @EnvironmentObject var appState: AppState
@@ -972,9 +979,7 @@ private struct MediaModelRow<Preset: MediaModelPreset>: View {
     private var actionControl: some View {
         if isReady {
             HStack(spacing: 6) {
-                Text("✓ On disk")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.green)
+                UseMediaModelButton(modality: modality, name: preset.name)
                 Button {
                     confirmDelete = true
                 } label: {
@@ -1063,6 +1068,30 @@ private struct UseModelButton: View {
         .controlSize(.small)
         .disabled(isLoading)
         .help("Load \(name) as the server's model, then open chat")
+    }
+}
+
+/// "Use" for a media checkpoint: open the pane that owns it.
+///
+/// `AppState.showCreate` is documented as the one way into a create page.
+/// Music needs a second step because it has no `GenExperiment` case of its own
+/// — it is a tab inside the Audio pane — and that tab is `@AppStorage`, so
+/// writing it here is what makes the pane come up on Music instead of Voice.
+private struct UseMediaModelButton: View {
+    let modality: MediaModality
+    let name: String
+    @EnvironmentObject var appState: AppState
+    @Environment(\.openWindow) private var openWindow
+    @AppStorage("audioGenTab") private var audioTab: AudioGenView.Tab = .voice
+
+    var body: some View {
+        Button("Use") {
+            if let tab = modality.audioTab { audioTab = tab }
+            appState.showCreate(modality.experiment)
+            AppActivation.openWindow(id: "chat", using: openWindow)
+        }
+        .controlSize(.small)
+        .help("Open \(name) in \(modality.paneName)")
     }
 }
 
@@ -1774,6 +1803,16 @@ private struct LocalModelRow: View {
                     } else {
                         ModelUseBadge(state: useState)
                     }
+                } else if let modality = MediaModality(modelType: model.modelType) {
+                    // A media checkpoint is a real, loadable, servable model —
+                    // it just is not a CHAT model, and until now that meant the
+                    // only verb the browser offered for it was Delete. This
+                    // does NOT go through `useModelAndAwaitReady`: that starts
+                    // the server on the path as its primary chat model, which
+                    // for a diffusion checkpoint means the text loader. It
+                    // opens the pane that owns the model instead, and lets the
+                    // pane load it the way it always has.
+                    UseMediaModelButton(modality: modality, name: model.name)
                 }
                 if let reason = model.externalReadOnlyReason {
                     // Read-only: this model lives outside ~/.mlx-serve (LM Studio,

--- a/app/Sources/MLXServe/Views/ModelBrowserView.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserView.swift
@@ -386,6 +386,12 @@ private struct RecommendedModelTableRow: View {
         return ModelBrowserUse.pickableModel(atPath: path, in: appState.localModels)
     }
 
+    /// The other half of the catalogue — see `ModelBrowserUse.mediaModel`.
+    private var usableMedia: (model: LocalModel, modality: MediaModality)? {
+        let path = pick.ggufFilename != nil ? ggufFilePath : downloads.existingModelDir(for: pick.repoId)
+        return ModelBrowserUse.mediaModel(atPath: path, in: appState.localModels)
+    }
+
     var body: some View {
         HStack(spacing: RecTableMetrics.spacing) {
             // Model — name + tagline; the full blurb is on hover.
@@ -480,6 +486,8 @@ private struct RecommendedModelTableRow: View {
                     } else {
                         ModelUseBadge(state: use)
                     }
+                } else if let media = usableMedia {
+                    UseMediaModelButton(modality: media.modality, name: media.model.name)
                 } else {
                     Text("✓ On disk")
                         .font(.caption.weight(.medium))
@@ -1360,6 +1368,14 @@ private struct ModelBrowserRow: View {
         )
     }
 
+    /// The other half of the catalogue — see `ModelBrowserUse.mediaModel`.
+    private var usableMedia: (model: LocalModel, modality: MediaModality)? {
+        ModelBrowserUse.mediaModel(
+            atPath: downloads.existingModelDir(for: model.id),
+            in: appState.localModels
+        )
+    }
+
     /// A verified community media pack downloads as its FAMILY bundle — the
     /// same allowlists + ready markers the catalog packs use — never the flat
     /// chat-default pull, which would miss subdirs and grab repo junk. nil for
@@ -1428,6 +1444,8 @@ private struct ModelBrowserRow: View {
                         } else {
                             ModelUseBadge(state: use)
                         }
+                    } else if let media = usableMedia {
+                        UseMediaModelButton(modality: media.modality, name: media.model.name)
                     } else {
                         Text("✓ On disk")
                             .font(.caption.weight(.medium))

--- a/app/Tests/MLXCoreTests/MediaModalityTests.swift
+++ b/app/Tests/MLXCoreTests/MediaModalityTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import MLXCore
+
+/// The app keeps its own copy of the server's media-architecture table, and
+/// that copy drifted: `minimax_music3`, `kokoro` and bare `mageflow` were
+/// missing, so a MiniMax Music 3 checkpoint on disk was labelled a red
+/// "Unsupported" on the same screen that offers to download it (#228).
+///
+/// Zig already pins its two copies against each other (`gen.media_model_types`
+/// vs `model_discovery.isMediaModelType`). Nothing pinned Swift, which is
+/// exactly why the drift went unnoticed — so the guard reads the Zig array.
+final class MediaModalityParityTests: XCTestCase {
+
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // MLXCoreTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // app
+            .deletingLastPathComponent()  // repo root
+    }
+
+    /// `media_model_types` out of src/gen.zig, which is the source of truth.
+    private func zigMediaModelTypes() throws -> Set<String> {
+        let text = try String(contentsOf: repoRoot.appendingPathComponent("src/gen.zig"), encoding: .utf8)
+        guard let start = text.range(of: "pub const media_model_types = [_][]const u8{"),
+              let end = text.range(of: "};", range: start.upperBound..<text.endIndex) else {
+            XCTFail("could not find media_model_types in src/gen.zig")
+            return []
+        }
+        let body = text[start.upperBound..<end.lowerBound]
+        return Set(body.split(whereSeparator: { $0 == "," || $0 == "\n" })
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.hasPrefix("\"") }
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: "\"")) })
+    }
+
+    func testEveryMediaArchitectureTheServerKnowsIsKnownToTheApp() throws {
+        let zig = try zigMediaModelTypes()
+        XCTAssertGreaterThanOrEqual(zig.count, 11, "parsed too few types — did the Zig array move?")
+        for type in zig {
+            // Prefix entries in Zig ("flux2", "krea", "mage_flow", "hunyuan3d")
+            // are matched by prefix on both sides, so the bare stem must pass.
+            XCTAssertTrue(isMediaModelType(type),
+                          "\(type) is a media architecture on the server but reads as unsupported in the app")
+        }
+    }
+
+    func testTheThreeThatDriftedAreCoveredByName() {
+        // Named individually so a future prefix-vs-exact refactor cannot make
+        // the loop above pass while these regress.
+        XCTAssertTrue(isMediaModelType("minimax_music3"))
+        XCTAssertTrue(isMediaModelType("kokoro"))
+        XCTAssertTrue(isMediaModelType("mageflow"))
+        XCTAssertTrue(isMediaModelType("mage_flow_turbo"))
+    }
+
+    func testChatArchitecturesStillDoNotReadAsMedia() {
+        for t in ["qwen3", "llama", "gemma3", "bailing_hybrid", "bert", "minimax_text"] {
+            XCTAssertFalse(isMediaModelType(t), "\(t) must not read as media")
+        }
+    }
+
+    func testAMediaModelIsStillNeverChatPickable() {
+        // Widening the media list also widens the chat-picker EXCLUSION
+        // (`isChatPickable` reads it), which is the direction we want: today
+        // minimax_music3 is excluded only by accident, because it fails the
+        // architecture gate entirely. It must stay excluded for the right
+        // reason — `useModelAndAwaitReady` would push a diffusion checkpoint
+        // through the text loader.
+        for t in ["minimax_music3", "kokoro", "acestep", "flux2-klein-4b", "qwen3_tts"] {
+            let m = LocalModel(id: "test:\(t)", name: t, path: "/tmp/\(t)",
+                               sizeFormatted: "1 GB", modelType: t, source: .mlxServe, kind: .base)
+            XCTAssertFalse(m.isChatPickable, "\(t) must not be chat-pickable")
+        }
+    }
+}
+
+/// Which create pane a media checkpoint belongs to. Mirrors Zig's
+/// `gen.modalityFromType`, which the app had no equivalent of — the browser
+/// could tell that a model was media, but not what KIND, so it could not offer
+/// to open it anywhere.
+final class MediaModalityRoutingTests: XCTestCase {
+
+    func testEveryMediaArchitectureRoutesToItsPane() {
+        let cases: [(String, MediaModality)] = [
+            ("flux2-klein-4b", .image), ("krea2_turbo", .image),
+            ("mage_flow", .image), ("mageflow", .image),
+            ("qwen3_tts", .voice), ("kokoro", .voice),
+            ("acestep", .music), ("minimax_music3", .music),
+            ("AudioVideo", .video), ("minimax_h3", .video),
+            ("hunyuan3d_2_1", .mesh), ("hunyuan3d_2_1_paint", .mesh),
+        ]
+        for (type, want) in cases {
+            XCTAssertEqual(MediaModality(modelType: type), want, "\(type)")
+        }
+    }
+
+    func testANonMediaArchitectureHasNoModality() {
+        for t in ["qwen3", "llama", "bert", ""] {
+            XCTAssertNil(MediaModality(modelType: t), "\(t)")
+        }
+    }
+
+    func testMusicAndVoiceSplitEvenThoughTheServerCallsThemBothAudio() {
+        // Zig's modalityFromType collapses these to `.audio` because they share
+        // one engine slot. The APP has to tell them apart: they are two tabs of
+        // one pane, so a Use button that only knew "audio" would drop a music
+        // model on the Voice tab.
+        XCTAssertEqual(MediaModality(modelType: "acestep")?.experiment, .audio)
+        XCTAssertEqual(MediaModality(modelType: "qwen3_tts")?.experiment, .audio)
+        XCTAssertEqual(MediaModality(modelType: "acestep")?.audioTab, .music)
+        XCTAssertEqual(MediaModality(modelType: "qwen3_tts")?.audioTab, .voice)
+        // Non-audio modalities have no tab to pick.
+        XCTAssertNil(MediaModality(modelType: "flux2-klein-4b")?.audioTab)
+        XCTAssertEqual(MediaModality(modelType: "minimax_h3")?.experiment, .video)
+        XCTAssertEqual(MediaModality(modelType: "hunyuan3d_2_1")?.experiment, .model3d)
+    }
+
+    func testEveryModalityNamesThePaneItOpens() {
+        for m in MediaModality.allCases {
+            XCTAssertFalse(m.paneName.isEmpty, "\(m) has no pane name for the Use button")
+        }
+    }
+}
+
+/// The media Use button must never reach the chat load path.
+final class MediaUseButtonSourceTests: XCTestCase {
+
+    func testTheMediaUseButtonNeverStartsTheServerOnTheModel() throws {
+        // `useModelAndAwaitReady` → `server.start(modelPath:)` loads a path as
+        // the server's PRIMARY CHAT model. Pointing that at a diffusion
+        // checkpoint runs it through the text loader — the exact failure
+        // `isChatPickable` exists to prevent, and the tempting one-line "fix"
+        // for this issue. The media button opens a pane instead; the pane
+        // loads the model the way it always has.
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+        let text = try String(
+            contentsOf: root.appendingPathComponent("app/Sources/MLXServe/Views/ModelBrowserView.swift"),
+            encoding: .utf8)
+        guard let start = text.range(of: "private struct UseMediaModelButton"),
+              let end = text.range(of: "\n}", range: start.upperBound..<text.endIndex) else {
+            XCTFail("UseMediaModelButton not found — did it move?")
+            return
+        }
+        let body = String(text[start.lowerBound..<end.upperBound])
+        XCTAssertFalse(body.contains("useModelAndAwaitReady"),
+                       "the media Use button must not load the model as the chat model")
+        XCTAssertFalse(body.contains("server.start"),
+                       "the media Use button must not start the server on the model path")
+        XCTAssertTrue(body.contains("showCreate"),
+                      "the media Use button should route through AppState.showCreate")
+    }
+}

--- a/app/Tests/MLXCoreTests/MediaModalityTests.swift
+++ b/app/Tests/MLXCoreTests/MediaModalityTests.swift
@@ -153,3 +153,62 @@ final class MediaUseButtonSourceTests: XCTestCase {
                       "the media Use button should route through AppState.showCreate")
     }
 }
+
+/// `pickableModel` and `mediaModel` are the two halves of the catalogue, and
+/// every on-disk row asks both. Before this, only My Models was fixed and
+/// Discover / Recommended still ended at Delete.
+final class MediaModelResolutionTests: XCTestCase {
+
+    private func local(_ type: String, path: String) -> LocalModel {
+        LocalModel(id: "test:\(type)", name: type, path: path, sizeFormatted: "1 GB",
+                   modelType: type, source: .mlxServe, kind: .base)
+    }
+
+    func testTheTwoHalvesNeverBothAnswer() {
+        // A media checkpoint is never chat-pickable and a chat model has no
+        // modality, so a row asking both gets at most one answer — no ordering
+        // rule needed between them.
+        let models = [local("minimax_music3", path: "/m/music"), local("qwen3", path: "/m/chat")]
+        XCTAssertNil(ModelBrowserUse.pickableModel(atPath: "/m/music", in: models))
+        XCTAssertEqual(ModelBrowserUse.mediaModel(atPath: "/m/music", in: models)?.modality, .music)
+
+        XCTAssertNotNil(ModelBrowserUse.pickableModel(atPath: "/m/chat", in: models))
+        XCTAssertNil(ModelBrowserUse.mediaModel(atPath: "/m/chat", in: models))
+    }
+
+    func testEachMediaKindResolvesToItsOwnPane() {
+        let models = [local("flux2-klein-4b", path: "/m/img"), local("AudioVideo", path: "/m/vid"),
+                      local("qwen3_tts", path: "/m/voice"), local("acestep", path: "/m/music"),
+                      local("hunyuan3d_2_1", path: "/m/mesh")]
+        XCTAssertEqual(ModelBrowserUse.mediaModel(atPath: "/m/img", in: models)?.modality, .image)
+        XCTAssertEqual(ModelBrowserUse.mediaModel(atPath: "/m/vid", in: models)?.modality, .video)
+        XCTAssertEqual(ModelBrowserUse.mediaModel(atPath: "/m/voice", in: models)?.modality, .voice)
+        XCTAssertEqual(ModelBrowserUse.mediaModel(atPath: "/m/music", in: models)?.modality, .music)
+        XCTAssertEqual(ModelBrowserUse.mediaModel(atPath: "/m/mesh", in: models)?.modality, .mesh)
+    }
+
+    func testPathMatchingIsAsForgivingAsTheChatHalf() {
+        // Same normalization, or the two halves would disagree about which row
+        // a path belongs to.
+        let models = [local("acestep", path: "/m/music")]
+        XCTAssertNotNil(ModelBrowserUse.mediaModel(atPath: "/m/music/", in: models))
+        XCTAssertNotNil(ModelBrowserUse.mediaModel(atPath: "/m/./music", in: models))
+        XCTAssertNil(ModelBrowserUse.mediaModel(atPath: "", in: models))
+        XCTAssertNil(ModelBrowserUse.mediaModel(atPath: nil, in: models))
+    }
+
+    func testEveryOnDiskRowOffersAUse() throws {
+        // Source audit: all three on-disk arms (Recommended, Discover, My
+        // Models) must consult the media half, not just the chat one. The Media
+        // pane passes its modality directly, so it is exempt.
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent()
+            .deletingLastPathComponent().deletingLastPathComponent()
+        let text = try String(
+            contentsOf: root.appendingPathComponent("app/Sources/MLXServe/Views/ModelBrowserView.swift"),
+            encoding: .utf8)
+        let uses = text.components(separatedBy: "UseMediaModelButton(").count - 1
+        XCTAssertGreaterThanOrEqual(uses, 4,
+            "expected the media Use button in Recommended, Discover, My Models and the Media pane")
+    }
+}

--- a/app/Tests/MLXCoreTests/ModelBrowserSectionTests.swift
+++ b/app/Tests/MLXCoreTests/ModelBrowserSectionTests.swift
@@ -143,7 +143,9 @@ final class ModelBrowserSectionTests: XCTestCase {
         XCTAssertNil(ModelBrowserUse.pickableModel(atPath: "/m/draft", in: models))
     }
 
-    func testUseIsUnavailableForAnEncoderOrMediaModel() {
+    /// Media models DO get a Use button now (#228), but it opens their create
+    /// pane — it never goes through the CHAT use path this function guards.
+    func testChatUseIsUnavailableForAnEncoderOrMediaModel() {
         let bert = [local("bge-small", path: "/m/bge", type: "bert")]
         XCTAssertNil(ModelBrowserUse.pickableModel(atPath: "/m/bge", in: bert))
 


### PR DESCRIPTION
Closes #228.

Two independent problems, both making a downloaded and perfectly servable media model look like a mistake in **My Models**.

## The red "Unsupported" badge was a Swift↔Zig drift

The app keeps its own copy of the server's media-architecture table and it had drifted: 8 entries against Zig's 11. Missing were `minimax_music3`, bare `mageflow`, and `kokoro`. `modelType` comes verbatim from config.json, so a MiniMax Music 3 checkpoint matched neither the chat list nor the media list and got flagged red — on the same screen that offers to download it.

Zig already pins its own two copies against each other. **Nothing pinned Swift**, which is why this drifted unnoticed, so the guard now reads `media_model_types` out of `src/gen.zig` and asserts the app agrees. Two existing tests enumerated media archs and both omitted `minimax_music3` — the same blind spot.

Widening the list also widens the chat-picker exclusion (`isChatPickable` reads it), which is the right direction: `minimax_music3` was excluded only by accident before, by failing the architecture gate entirely.

`kokoro` forced two questions apart. *Is this a media architecture?* decides the badge — it is one. *May a Discover row offer this repo?* is a catalog decision that was deliberately no. Conflating them meant fixing the badge silently opened the Discover door, which `CustomMediaRepoTests` caught.

## No media model had a Use button

Independent of the badge, and it hit **every** media arch. The app could download a model, serve it, and generate with it, while the model list offered only to throw it away.

`UseMediaModelButton` opens the pane that owns the model. It deliberately does **not** call `useModelAndAwaitReady` — that starts the server on the path as its primary chat model, i.e. a diffusion checkpoint through the text loader, which is the failure `isChatPickable` exists to prevent and the tempting one-line "fix" here. A source-scan test pins that the button never reaches it.

Routing needed a modality classifier Swift lacked. `MediaModality` mirrors Zig's `modalityFromType` with one deliberate difference: Zig collapses speech and music into `.audio` because they share an engine slot, but the app has to split them — they are two tabs of one pane, so a button that only knew "audio" would drop a music model on the Voice tab.

The Media pane's rows get the same button.

## Testing

`swift test` — 2741 run, 2 failures, both pre-existing `AgentIntegrationTests` cases that hit a live endpoint (identical on clean `main`). 9 new tests, including the Swift↔Zig parity guard and the source scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)