### PR TITLE
fix: load Ling 3.0 tiny under both converter layouts; accept a null q_lora_rank

### DIFF
--- a/src/model.zig
+++ b/src/model.zig
@@ -717,6 +717,17 @@ pub const ModelConfig = struct {
         return self.mla_kv_lora_rank > 0;
     }
 
+    /// Does Q go through a low-rank pair, or straight from the hidden state?
+    ///
+    /// `q_lora_rank: null` is DeepSeek-V3's documented option and what the
+    /// whole Ling 3.0 FLASH line ships (tiny ships 256). Those checkpoints
+    /// carry a plain `attention.q_proj` instead of
+    /// q_a_proj/q_a_layernorm/q_b_proj. 0 is the signal, since a real rank is
+    /// always positive.
+    pub fn mlaHasQLora(self: *const ModelConfig) bool {
+        return self.mla_q_lora_rank > 0;
+    }
+
     /// MLA query/key head dim = the non-positional part plus the rope part.
     /// This — not head_dim — is what the attention scale and the cached K's
     /// last dim are measured in.
@@ -2105,9 +2116,10 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
             if (v == .integer) config.mla_v_head_dim = @intCast(v.integer);
         }
         if (config.mla_v_head_dim == 0) config.mla_v_head_dim = config.head_dim;
-        // q_lora_rank null (a plain q_proj) is a different weight layout.
-        if (config.mla_q_lora_rank == 0 or config.mla_kv_lora_rank == 0) {
-            log.err("bailing_hybrid: q_lora_rank and kv_lora_rank are required\n", .{});
+        // `q_lora_rank: null` is a plain q_proj — a different weight layout,
+        // now served (see `mlaHasQLora`). The KV latent has no such fallback.
+        if (config.mla_kv_lora_rank == 0) {
+            log.err("bailing_hybrid: kv_lora_rank is required\n", .{});
             return error.UnsupportedBailingConfig;
         }
         // The declared qk_head_dim must agree with nope+rope: everything
@@ -5717,4 +5729,64 @@ test "attnCacheLayerCount: a layer_block_types hybrid counts only its ATTENTION 
     bare.head_dim = 128;
     bare.has_hybrid_layers = true;
     try testing.expectEqual(@as(u32, 16), bare.attnCacheLayerCount());
+}
+
+test "bailing_hybrid: a null q_lora_rank is the direct-q_proj arm, not a refusal" {
+    // Ling 3.0 FLASH ships `"q_lora_rank": null` where tiny ships 256, and its
+    // MLA layers carry a plain `attention.q_proj` instead of the
+    // q_a_proj/q_a_layernorm/q_b_proj triple. That is DeepSeek-V3's documented
+    // option, not a broken export — refusing it meant the whole flash line was
+    // unloadable while tiny worked.
+    const json =
+        \\{
+        \\  "model_type": "bailing_hybrid",
+        \\  "hidden_size": 2560, "num_hidden_layers": 42,
+        \\  "num_attention_heads": 32, "num_key_value_heads": 32, "head_dim": 128,
+        \\  "layer_group_size": 6,
+        \\  "q_lora_rank": null, "kv_lora_rank": 512,
+        \\  "qk_nope_head_dim": 128, "qk_rope_head_dim": 64, "v_head_dim": 128,
+        \\  "num_experts": 512, "num_experts_per_tok": 8, "moe_intermediate_size": 768,
+        \\  "vocab_size": 157184, "kda_lower_bound": -5.0
+        \\}
+    ;
+    const cfg = try parseConfigFromJson(testing.allocator, json);
+    try testing.expect(cfg.isMla());
+    // 0 IS the signal: no low-rank Q, project straight from the hidden state.
+    try testing.expectEqual(@as(u32, 0), cfg.mla_q_lora_rank);
+    try testing.expect(!cfg.mlaHasQLora());
+    try testing.expectEqual(@as(u32, 512), cfg.mla_kv_lora_rank);
+    // The attention scale still comes from the FULL query width, unchanged.
+    try testing.expectEqual(@as(u32, 192), cfg.mlaQkHeadDim());
+    try testing.expectEqual(@as(u32, 192), cfg.query_pre_attn_scalar);
+
+    // kv_lora_rank is still genuinely required — the latent has no fallback.
+    const no_kv =
+        \\{
+        \\  "model_type": "bailing_hybrid",
+        \\  "hidden_size": 2560, "num_hidden_layers": 42,
+        \\  "num_attention_heads": 32, "num_key_value_heads": 32, "head_dim": 128,
+        \\  "layer_group_size": 6, "q_lora_rank": null,
+        \\  "qk_nope_head_dim": 128, "qk_rope_head_dim": 64, "v_head_dim": 128,
+        \\  "num_experts": 512, "num_experts_per_tok": 8, "moe_intermediate_size": 768,
+        \\  "vocab_size": 157184
+        \\}
+    ;
+    try testing.expectError(error.UnsupportedBailingConfig, parseConfigFromJson(testing.allocator, no_kv));
+
+    // And tiny's low-rank arm is untouched.
+    const tiny =
+        \\{
+        \\  "model_type": "bailing_hybrid",
+        \\  "hidden_size": 1536, "num_hidden_layers": 24,
+        \\  "num_attention_heads": 16, "num_key_value_heads": 16, "head_dim": 128,
+        \\  "layer_group_size": 4,
+        \\  "q_lora_rank": 256, "kv_lora_rank": 512,
+        \\  "qk_nope_head_dim": 128, "qk_rope_head_dim": 64, "v_head_dim": 128,
+        \\  "num_experts": 128, "num_experts_per_tok": 8, "moe_intermediate_size": 512,
+        \\  "vocab_size": 157184
+        \\}
+    ;
+    const t = try parseConfigFromJson(testing.allocator, tiny);
+    try testing.expect(t.mlaHasQLora());
+    try testing.expectEqual(@as(u32, 256), t.mla_q_lora_rank);
 }

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -13727,12 +13727,28 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
                 qkv_s[n] = getLayerWeightOpt(weights, name_buf, prefix, li, std.fmt.bufPrint(&nb, "{s}.scales", .{base}) catch unreachable) orelse mlx.mlx_array_new();
                 qkv_b[n] = getLayerWeightOpt(weights, name_buf, prefix, li, std.fmt.bufPrint(&nb, "{s}.biases", .{base}) catch unreachable) orelse mlx.mlx_array_new();
                 if (qkv_s[n].ctx != null) any_scales = true;
-                const conv_base = switch (n) {
+                // The depthwise conv is `<x>_conv1d.conv.weight` in the reference
+                // HF checkpoint, where it sits inside a ShortConvolution module.
+                // mlx-lm's converter flattens that module away and emits
+                // `<x>_conv1d.weight` instead — same [C, 1, K] tensor, one name
+                // segment shorter. Both public MLX Ling-3.0 quants ship the flat
+                // form (djrsystemservices/Ling-3.0-tiny-oQ8e,
+                // d1sl1ke/Ling-3.0-flash-oQ4e-mtp), so a nested-only lookup
+                // aborts the load on every one of them. Prefer the nested name
+                // so reference checkpoints bind exactly as before, then fall
+                // back to the flat one.
+                const conv_nested = switch (n) {
                     0 => "attention.q_conv1d.conv.weight",
                     1 => "attention.k_conv1d.conv.weight",
                     else => "attention.v_conv1d.conv.weight",
                 };
-                conv_w[n] = getLayerWeight(weights, name_buf, prefix, li, conv_base);
+                const conv_flat = switch (n) {
+                    0 => "attention.q_conv1d.weight",
+                    1 => "attention.k_conv1d.weight",
+                    else => "attention.v_conv1d.weight",
+                };
+                conv_w[n] = getLayerWeightOpt(weights, name_buf, prefix, li, conv_nested) orelse
+                    getLayerWeight(weights, name_buf, prefix, li, conv_flat);
             }
             // The three projections must be quantized IDENTICALLY to join. A
             // dense q beside a quantized k gives a triple whose scales cover
@@ -14048,20 +14064,31 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
             // Routing itself (sigmoid → +bias → group limit → top-k → renorm →
             // routed_scaling_factor) is hy3's chain with the group limit
             // inserted; `moe_n_group`/`moe_topk_group` pick it in moeMLP2.
+            //
+            // mlx-lm's converter renames both banks: it quantizes the router
+            // and keeps its module level, so the router lands at
+            // `mlp.gate.gate_proj.*`, and it stacks the experts under
+            // `mlp.switch_mlp.*`. Resolve each by probing, exactly as laguna
+            // and hy_v3 already do, so reference and converted checkpoints
+            // both bind.
+            const rt = bailingRouterBase(weights, name_buf, prefix, li);
+            const ex = hy3ExpertContainer(weights, name_buf, prefix, li);
+            var rtbuf: [64]u8 = undefined;
+            var exbuf: [64]u8 = undefined;
             lw.mlp = .{
                 .moe = .{
-                    .router_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.gate.weight"),
-                    .router_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.gate.scales") orelse mlx.mlx_array_new(),
-                    .router_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.gate.biases") orelse mlx.mlx_array_new(),
-                    .switch_gate_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.experts.gate_proj.weight"),
-                    .switch_gate_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.gate_proj.scales") orelse mlx.mlx_array_new(),
-                    .switch_gate_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.gate_proj.biases") orelse mlx.mlx_array_new(),
-                    .switch_up_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.experts.up_proj.weight"),
-                    .switch_up_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.up_proj.scales") orelse mlx.mlx_array_new(),
-                    .switch_up_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.up_proj.biases") orelse mlx.mlx_array_new(),
-                    .switch_down_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.experts.down_proj.weight"),
-                    .switch_down_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.down_proj.scales") orelse mlx.mlx_array_new(),
-                    .switch_down_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.down_proj.biases") orelse mlx.mlx_array_new(),
+                    .router_w = getLayerWeight(weights, name_buf, prefix, li, moeExpertSuffix(&rtbuf, rt, "weight")),
+                    .router_s = getLayerWeightOpt(weights, name_buf, prefix, li, moeExpertSuffix(&rtbuf, rt, "scales")) orelse mlx.mlx_array_new(),
+                    .router_b = getLayerWeightOpt(weights, name_buf, prefix, li, moeExpertSuffix(&rtbuf, rt, "biases")) orelse mlx.mlx_array_new(),
+                    .switch_gate_w = getLayerWeight(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "gate_proj.weight")),
+                    .switch_gate_s = getLayerWeightOpt(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "gate_proj.scales")) orelse mlx.mlx_array_new(),
+                    .switch_gate_b = getLayerWeightOpt(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "gate_proj.biases")) orelse mlx.mlx_array_new(),
+                    .switch_up_w = getLayerWeight(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "up_proj.weight")),
+                    .switch_up_s = getLayerWeightOpt(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "up_proj.scales")) orelse mlx.mlx_array_new(),
+                    .switch_up_b = getLayerWeightOpt(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "up_proj.biases")) orelse mlx.mlx_array_new(),
+                    .switch_down_w = getLayerWeight(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "down_proj.weight")),
+                    .switch_down_s = getLayerWeightOpt(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "down_proj.scales")) orelse mlx.mlx_array_new(),
+                    .switch_down_b = getLayerWeightOpt(weights, name_buf, prefix, li, moeExpertSuffix(&exbuf, ex, "down_proj.biases")) orelse mlx.mlx_array_new(),
                     .shared_gate_w = getLayerWeight(weights, name_buf, prefix, li, "mlp.shared_experts.gate_proj.weight"),
                     .shared_gate_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_experts.gate_proj.scales") orelse mlx.mlx_array_new(),
                     .shared_gate_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.shared_experts.gate_proj.biases") orelse mlx.mlx_array_new(),
@@ -18782,6 +18809,22 @@ fn lagunaRouterBase(weights: *const Weights, buf: *[256]u8, prefix: []const u8, 
     return if (getLayerWeightOpt(weights, buf, prefix, layer, "mlp.gate.weight") == null and
         getLayerWeightOpt(weights, buf, prefix, layer, "mlp.gate.proj.weight") != null)
         "mlp.gate.proj"
+    else
+        "mlp.gate";
+}
+
+/// Resolve the bailing_hybrid MoE router's weight base. The reference Ling-3.0
+/// checkpoint carries a dense `mlp.gate.weight`; mlx-lm's converter quantizes
+/// the router and keeps its module layout, so the same [E, hidden] tensor lands
+/// at `mlp.gate.gate_proj.*` with its own scales and biases
+/// (djrsystemservices/Ling-3.0-tiny-oQ8e, d1sl1ke/Ling-3.0-flash-oQ4e-mtp).
+/// Same shape as lagunaRouterBase: prefer the flat name so reference
+/// checkpoints bind byte-identically, and fall back to it when neither exists
+/// so the MISSING WEIGHT error names the canonical key.
+fn bailingRouterBase(weights: *const Weights, buf: *[256]u8, prefix: []const u8, layer: u32) []const u8 {
+    return if (getLayerWeightOpt(weights, buf, prefix, layer, "mlp.gate.weight") == null and
+        getLayerWeightOpt(weights, buf, prefix, layer, "mlp.gate.gate_proj.weight") != null)
+        "mlp.gate.gate_proj"
     else
         "mlp.gate";
 }

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -3723,6 +3723,12 @@ const FullAttnWeights = struct {
     // latent instead of q/k/v — those three fields stay null-ctx and
     // `mlaAttnWith` runs in place of gatedFullAttnWith. `o_w` holds the
     // checkpoint's `dense` (the output projection) as usual.
+    /// The direct Q projection, used INSTEAD of the q_a/q_b pair when the
+    /// config carries `q_lora_rank: null` (`ModelConfig.mlaHasQLora`). Exactly
+    /// one of `mla_q_direct_w` and `mla_q_a_w` is non-null on an MLA layer.
+    mla_q_direct_w: mlx.mlx_array = .{ .ctx = null },
+    mla_q_direct_s: mlx.mlx_array = .{ .ctx = null },
+    mla_q_direct_b: mlx.mlx_array = .{ .ctx = null },
     mla_q_a_w: mlx.mlx_array = .{ .ctx = null },
     mla_q_a_s: mlx.mlx_array = .{ .ctx = null },
     mla_q_a_b: mlx.mlx_array = .{ .ctx = null },
@@ -11278,12 +11284,21 @@ pub const Transformer = struct {
         const strides3 = [_]c_int{ 1, 1, 1 };
         const strides4 = [_]c_int{ 1, 1, 1, 1 };
 
-        // ── Q: low rank, then split into the non-positional and rope halves.
-        const q_a = try self.qmatmul(x, fa.mla_q_a_w, fa.mla_q_a_s, fa.mla_q_a_b);
-        defer _ = mlx.mlx_array_free(q_a);
-        const q_a_n = try self.rmsNorm(q_a, fa.mla_q_a_norm);
-        defer _ = mlx.mlx_array_free(q_a_n);
-        const q_flat = try self.qmatmul(q_a_n, fa.mla_q_b_w, fa.mla_q_b_s, fa.mla_q_b_b);
+        // ── Q, then split into the non-positional and rope halves.
+        //
+        // Two arms. The low-rank pair (q_a → norm → q_b) is tiny's; a direct
+        // q_proj is flash's, where `q_lora_rank` is null. Both produce the same
+        // [batch, seq, heads * qk_head_dim] flat query, so everything below is
+        // shared — only the projection differs.
+        const q_flat = if (fa.mla_q_direct_w.ctx != null)
+            try self.qmatmul(x, fa.mla_q_direct_w, fa.mla_q_direct_s, fa.mla_q_direct_b)
+        else blk: {
+            const q_a = try self.qmatmul(x, fa.mla_q_a_w, fa.mla_q_a_s, fa.mla_q_a_b);
+            defer _ = mlx.mlx_array_free(q_a);
+            const q_a_n = try self.rmsNorm(q_a, fa.mla_q_a_norm);
+            defer _ = mlx.mlx_array_free(q_a_n);
+            break :blk try self.qmatmul(q_a_n, fa.mla_q_b_w, fa.mla_q_b_s, fa.mla_q_b_b);
+        };
         defer _ = mlx.mlx_array_free(q_flat);
 
         var q_heads = mlx.mlx_array_new();
@@ -13919,13 +13934,19 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
                     .g_w = getLayerWeight(weights, name_buf, prefix, li, "attention.g_proj.weight"),
                     .g_s = getLayerWeightOpt(weights, name_buf, prefix, li, "attention.g_proj.scales") orelse mlx.mlx_array_new(),
                     .g_b = getLayerWeightOpt(weights, name_buf, prefix, li, "attention.g_proj.biases") orelse mlx.mlx_array_new(),
-                    .mla_q_a_w = getLayerWeight(weights, name_buf, prefix, li, "attention.q_a_proj.weight"),
-                    .mla_q_a_s = getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_a_proj.scales") orelse mlx.mlx_array_new(),
-                    .mla_q_a_b = getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_a_proj.biases") orelse mlx.mlx_array_new(),
-                    .mla_q_a_norm = getLayerWeight(weights, name_buf, prefix, li, "attention.q_a_layernorm.weight"),
-                    .mla_q_b_w = getLayerWeight(weights, name_buf, prefix, li, "attention.q_b_proj.weight"),
-                    .mla_q_b_s = getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_b_proj.scales") orelse mlx.mlx_array_new(),
-                    .mla_q_b_b = getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_b_proj.biases") orelse mlx.mlx_array_new(),
+                    // Exactly ONE Q arm per checkpoint: the low-rank pair
+                    // (tiny) or a direct q_proj (flash, `q_lora_rank: null`).
+                    // Asking for the absent one would abort the load.
+                    .mla_q_direct_w = if (config.mlaHasQLora()) mlx.mlx_array_new() else getLayerWeight(weights, name_buf, prefix, li, "attention.q_proj.weight"),
+                    .mla_q_direct_s = if (config.mlaHasQLora()) mlx.mlx_array_new() else (getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_proj.scales") orelse mlx.mlx_array_new()),
+                    .mla_q_direct_b = if (config.mlaHasQLora()) mlx.mlx_array_new() else (getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_proj.biases") orelse mlx.mlx_array_new()),
+                    .mla_q_a_w = if (config.mlaHasQLora()) getLayerWeight(weights, name_buf, prefix, li, "attention.q_a_proj.weight") else mlx.mlx_array_new(),
+                    .mla_q_a_s = if (config.mlaHasQLora()) (getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_a_proj.scales") orelse mlx.mlx_array_new()) else mlx.mlx_array_new(),
+                    .mla_q_a_b = if (config.mlaHasQLora()) (getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_a_proj.biases") orelse mlx.mlx_array_new()) else mlx.mlx_array_new(),
+                    .mla_q_a_norm = if (config.mlaHasQLora()) getLayerWeight(weights, name_buf, prefix, li, "attention.q_a_layernorm.weight") else mlx.mlx_array_new(),
+                    .mla_q_b_w = if (config.mlaHasQLora()) getLayerWeight(weights, name_buf, prefix, li, "attention.q_b_proj.weight") else mlx.mlx_array_new(),
+                    .mla_q_b_s = if (config.mlaHasQLora()) (getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_b_proj.scales") orelse mlx.mlx_array_new()) else mlx.mlx_array_new(),
+                    .mla_q_b_b = if (config.mlaHasQLora()) (getLayerWeightOpt(weights, name_buf, prefix, li, "attention.q_b_proj.biases") orelse mlx.mlx_array_new()) else mlx.mlx_array_new(),
                     .mla_kv_a_w = getLayerWeight(weights, name_buf, prefix, li, "attention.kv_a_proj_with_mqa.weight"),
                     .mla_kv_a_s = getLayerWeightOpt(weights, name_buf, prefix, li, "attention.kv_a_proj_with_mqa.scales") orelse mlx.mlx_array_new(),
                     .mla_kv_a_b = getLayerWeightOpt(weights, name_buf, prefix, li, "attention.kv_a_proj_with_mqa.biases") orelse mlx.mlx_array_new(),
@@ -13939,6 +13960,7 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
                 const fa = &lw.attn.full;
                 try maybeTransposeForBf16(&fa.o_w, fa.o_s, &owned_bf16, allocator, s);
                 try maybeTransposeForBf16(&fa.g_w, fa.g_s, &owned_bf16, allocator, s);
+                try maybeTransposeForBf16(&fa.mla_q_direct_w, fa.mla_q_direct_s, &owned_bf16, allocator, s);
                 try maybeTransposeForBf16(&fa.mla_q_a_w, fa.mla_q_a_s, &owned_bf16, allocator, s);
                 try maybeTransposeForBf16(&fa.mla_q_b_w, fa.mla_q_b_s, &owned_bf16, allocator, s);
                 try maybeTransposeForBf16(&fa.mla_kv_a_w, fa.mla_kv_a_s, &owned_bf16, allocator, s);


### PR DESCRIPTION
Makes the Ling 3.0 **tiny** line load across both converter layouts, and opens the
config gate that was refusing the flash line before its weights were ever read.

Two commits, kept separate so the in-flight naming work stays attributed:

**`8aeb05b` — bind conv + MoE router under both converter layouts** (Fe2-O3's
work, carried unmodified). The reference checkpoint and the MLX conversions
disagree on whether the short-conv weight and the MoE router are flat or nested;
both are now probed.

**`15d7a10` — serve a null `q_lora_rank`.** Flash ships `"q_lora_rank": null`
where tiny ships 256, and its MLA layers carry a plain `attention.q_proj` instead
of the `q_a_proj`/`q_a_layernorm`/`q_b_proj` triple. That is DeepSeek-V3's
documented option, not a broken export, but the parser refused the pair outright
("q_lora_rank and kv_lora_rank are required") — so the whole flash line was
rejected at config parse.

- `ModelConfig.mlaHasQLora()` is the arm selector; 0 is the signal, since a real
  rank is always positive.
- `isMla()` already keyed on `kv_lora_rank`, so the layer discriminator is
  unchanged. `kv_lora_rank` stays genuinely required — the latent has no
  fallback — and the refusal message now says only that.
- The loader asks for exactly **one** Q arm per checkpoint; asking for the absent
  one aborts the load. The forward branches once and produces the same flat
  `[B, T, heads*qk_dim]` either way.
- Fields are named `mla_q_direct_*`, not `mla_q_*` — `mla_q_b` sits one
  underscore from the existing `mla_q_b_w` and would be a silent typo trap.

## Testing

TDD: the config-parse test was written first and fails on `main` with
`UnsupportedBailingConfig`.

- `zig build test -Doptimize=ReleaseFast` — 9/9 steps, 0 fail
- Live regression on `rapid-mlx/Ling-3.0-tiny-MLX-4bit` (Layout A, q_a/q_b arm):
  198 tok/s, 4.328 GB peak, coherent output — the arm this PR did **not** change
  is unaffected.

## Not in scope

This does **not** make any published flash quant load. Every MLX/oQ flash
conversion uses the absorbed MLA layout (`embed_q`/`unembed_out`, no
`kv_b_proj`), which is a different computation and needs its own work. Written up
in #231 with both routes, including the cheaper llama.cpp/GGUF one.
