### PR TITLE
feat: reach the five video settings the pane had no control for

### DIFF
--- a/app/Sources/MLXServe/Models/MediaGenSettings.swift
+++ b/app/Sources/MLXServe/Models/MediaGenSettings.swift
@@ -247,6 +247,12 @@ struct VideoGenSettings: Codable, Equatable {
     var diffusionDecoder: Bool = false
     /// Turbo distillation LoRA (H3 fl2va): 4-step sampling.
     var turbo: Bool = false
+    /// Steps in LTX's two-stage refine pass. 0 = Auto (the server's own "all 3").
+    var stage2Steps: Int = 0
+    /// Audio-guidance strength for audio-to-video. The LTX reference default.
+    var cfgAudioScale: Double = 7.0
+    /// Chained windows (H3 fl2va): 1 = a single ordinary window.
+    var chainWindows: Int = 1
     /// Style LoRAs (Advanced): sticky stack of adapter path + strength pairs.
     /// Empty = none attached.
     var loras: [LoraAdapter] = []

--- a/app/Sources/MLXServe/Services/MediaGen.swift
+++ b/app/Sources/MLXServe/Services/MediaGen.swift
@@ -418,6 +418,13 @@ struct VideoModelPreset: Identifiable, Hashable {
     /// Chained-window long clips (server `chain_windows`): N windows joined by
     /// fl2va keyframe conditioning, so the REF2VA pack cannot serve it.
     var supportsChainedWindows: Bool = false
+    /// Last-frame keyframe conditioning (server `last_frame_image`). The other
+    /// half of fl2va — first-LAST frame to video+audio — where the first frame
+    /// is the geometry anchor (plain stretch) and the last is a follower
+    /// (aspect-preserving center-cover). LTX's handler has no such field at
+    /// all, and a reference has no keyframe row to anchor, so this rides the
+    /// same partition complement as Turbo and chaining.
+    var supportsLastFrame: Bool = false
     /// Denoising-step range the Steps slider offers. LTX's is the default; a
     /// backend whose floor is higher declares it, because a slider that goes
     /// somewhere the model does not work is a dead range, not a fast option.
@@ -817,6 +824,7 @@ struct VideoModelPreset: Identifiable, Hashable {
             // derived here so the two fl2va presets cannot drift apart.
             supportsTurbo: !supportsReferences,
             supportsChainedWindows: !supportsReferences,
+            supportsLastFrame: !supportsReferences,
             // MiniMax publishes no step count at all — no default, no range, no
             // maximum — so this range is OURS. 16 is the lowest tier we have a
             // verdict on, and below ~6 the fast recipe's warmup and tail windows
@@ -1632,6 +1640,10 @@ struct VideoGenRequest {
     /// by every pipeline mode (the server VAE-encodes it and pins it as the
     /// clean first latent frame).
     var firstFrameImagePath: String? = nil
+    /// Optional last-frame image (H3 fl2va): the frame the clip lands on. The
+    /// first frame sets the geometry and this one follows it, so a pair with
+    /// mismatched aspects still produces a clean landing.
+    var lastFrameImagePath: String? = nil
     /// Optional speech/audio clip for audio-to-video: the soundtrack is frozen
     /// as conditioning (voices, lip sync and performance follow it) and the
     /// ORIGINAL clip is muxed into the mp4. Any AVFoundation-readable format;
@@ -1658,6 +1670,14 @@ struct VideoGenRequest {
     /// Chained windows (H3 fl2va): number of `numFrames`-frame windows joined
     /// by keyframe conditioning. 1 = a single ordinary window.
     var chainWindows: Int = 1
+    /// Steps for LTX's two-stage refine pass (`stage2_steps`). 0 = Auto, which
+    /// is the server's own "all 3" — sent only when the user picks a number,
+    /// so the absent field keeps meaning the default everywhere.
+    var stage2Steps: Int = 0
+    /// Audio-guidance strength for audio-to-video (`cfg_audio_scale`). Only
+    /// meaningful with a clip attached: without one there is no audio guider
+    /// to scale.
+    var cfgAudioScale: Double = 7.0
     /// ref2va references (REF2VA pack only). Images the generation follows for
     /// character/style, clips for motion and scene, audio for voice and score.
     /// Paths, resolved to base64 at request time.

--- a/app/Sources/MLXServe/Services/VideoGenService.swift
+++ b/app/Sources/MLXServe/Services/VideoGenService.swift
@@ -88,6 +88,7 @@ final class VideoGenService: ObservableObject {
         let steps = request.steps
         let keep = request.keepResident
         let firstFramePath = request.firstFrameImagePath
+        let lastFramePath = request.lastFrameImagePath
         let audioPath = request.audioPath
 
         task = Task {
@@ -102,6 +103,14 @@ final class VideoGenService: ObservableObject {
                 // as the clean first frame. Mirrors AudioGenService's `ref_audio`.
                 let firstFrameB64: String? = await Task.detached(priority: .userInitiated) {
                     firstFramePath.flatMap { path in
+                        (try? Data(contentsOf: URL(fileURLWithPath: path)))?.base64EncodedString()
+                    }
+                }.value
+                // The last-frame anchor reads the same way. Both keyframes are
+                // ordinary image files; the server owns the per-anchor resize
+                // policy (first stretches, last center-covers).
+                let lastFrameB64: String? = await Task.detached(priority: .userInitiated) {
+                    lastFramePath.flatMap { path in
                         (try? Data(contentsOf: URL(fileURLWithPath: path)))?.base64EncodedString()
                     }
                 }.value
@@ -139,6 +148,7 @@ final class VideoGenService: ObservableObject {
                 if Task.isCancelled { setPhase(.cancelled, for: gen); return }
                 let body = Self.requestBody(model: modelId, prompt: prompt,
                                             request: request, firstFrameB64: firstFrameB64,
+                                            lastFrameB64: lastFrameB64,
                                             audioB64: audioB64, refs: refs)
                 // SSE: the server pushes `progress` events per denoise step, then a
                 // `complete` event with the frames. Drive a determinate bar from them.
@@ -352,6 +362,7 @@ final class VideoGenService: ObservableObject {
     /// tests pin every field here so the UI model can't drift from the wire.
     nonisolated static func requestBody(model: String, prompt: String,
                                         request: VideoGenRequest, firstFrameB64: String?,
+                                        lastFrameB64: String? = nil,
                                         audioB64: String? = nil,
                                         refs: VideoRefPayloads = .init()) -> [String: Any] {
         var pipeline: String
@@ -387,8 +398,27 @@ final class VideoGenService: ObservableObject {
         if request.model.supportsCFG, !dropGuidance {
             body["cfg_scale"] = request.cfgScale
             body["stg_scale"] = request.stgScale
+            // The audio guider only exists on the a2vid path, so the scale
+            // rides the clip rather than the preset: without one it would set
+            // a knob on a guider that never runs. It drops with the rest of
+            // the guidance on an upgraded one-stage request, because the whole
+            // point of that drop is to let the server's reference two-stage
+            // defaults (3.0 video / 7.0 audio) apply as a SET.
+            if hasAudio { body["cfg_audio_scale"] = request.cfgAudioScale }
+        }
+        // Stage-2 refine steps. Two-stage only — one-stage has no refine pass,
+        // so the field would be a no-op the server still parses. 0 is Auto and
+        // stays absent, keeping "absent = the server's default" true.
+        if request.model.supportsPipelineModes, pipeline != "one_stage", request.stage2Steps > 0 {
+            body["stage2_steps"] = request.stage2Steps
         }
         if let firstFrameB64 { body["first_frame_image"] = firstFrameB64 }
+        // The other half of fl2va. Capability-gated like every field above: a
+        // preset switch leaves the picked file in state, and LTX's handler has
+        // no `last_frame_image` to ignore it with.
+        if request.model.supportsLastFrame, let lastFrameB64 {
+            body["last_frame_image"] = lastFrameB64
+        }
         // The fast recipe is the SERVER's default — the app only speaks up to
         // opt OUT, and only on a backend that has the recipe at all.
         if request.model.supportsFastRecipe, request.bestQuality { body["fast"] = false }

--- a/app/Sources/MLXServe/Views/VideoGenView.swift
+++ b/app/Sources/MLXServe/Views/VideoGenView.swift
@@ -36,11 +36,21 @@ struct VideoGenView: View {
     @State private var steps: Int = 12
     @State private var cfgScale: Double = 1.0
     @State private var stgScale: Double = 0.0
+    // 0 = Auto (the server's own "all 3"), so the control has an explicit Auto
+    // position rather than a 0 that reads as "no refine at all".
+    @State private var stage2Steps: Int = 0
+    @State private var cfgAudioScale: Double = 7.0
+    @State private var chainWindows: Int = 1
     @State private var seed: Int = 42
     /// Style LoRAs (Advanced): stacked `.safetensors` adapters ([] = none).
     /// Several can attach at once — their effects sum, so order doesn't matter.
     @State private var loras: [LoraAdapter] = []
     @State private var firstFrameImageURL: URL? = nil
+    // The other half of fl2va. Kept across preset changes like the first
+    // frame; the SERVICE gates the field on `supportsLastFrame`, so a leftover
+    // pick can never reach a backend without the anchor.
+    @State private var lastFrameImageURL: URL? = nil
+    @State private var isLastFrameDropTargeted = false
     // ref2va references, kept across preset changes like firstFrameImageURL —
     // `requestBody` gates the fields on the pack's own capability, so state
     // left behind by a preset switch can never reach an FL2VA request.
@@ -108,6 +118,9 @@ struct VideoGenView: View {
         .onChange(of: steps) { _, _ in guard !hydrating else { return }; persist() }
         .onChange(of: cfgScale) { _, _ in guard !hydrating else { return }; persist() }
         .onChange(of: stgScale) { _, _ in guard !hydrating else { return }; persist() }
+        .onChange(of: stage2Steps) { _, _ in guard !hydrating else { return }; persist() }
+        .onChange(of: cfgAudioScale) { _, _ in guard !hydrating else { return }; persist() }
+        .onChange(of: chainWindows) { _, _ in guard !hydrating else { return }; persist() }
         .onChange(of: seed) { _, _ in guard !hydrating else { return }; persist() }
         .onChange(of: keepResident) { _, _ in guard !hydrating else { return }; persist() }
         .onChange(of: service.phase) { _, phase in
@@ -146,6 +159,7 @@ struct VideoGenView: View {
                     resolutionSection
                     framesSection
                     firstFrameSection
+                    lastFrameSection
                     referencesSection
                     speechSection
                     if showAdvanced { advancedSection } else { advancedToggle }
@@ -449,51 +463,82 @@ struct VideoGenView: View {
     // falls back to text-to-video if the VAE encoder isn't downloaded — so the
     // picker is never disabled.
     private var firstFrameSection: some View {
+        keyframeWell(title: "First frame",
+                     note: model.supportsLastFrame ? "optional — starts here" : "optional — I2V",
+                     url: $firstFrameImageURL,
+                     isTargeted: $isDropTargeted,
+                     help: "Select an image to use as the first frame of the video.")
+    }
+
+    // fl2va's second anchor. Hidden rather than offered-and-ignored on a
+    // backend without it (the `pipeline`-on-H3 rule): LTX's handler has no
+    // `last_frame_image`, and ref2va has no keyframe row to land on.
+    @ViewBuilder
+    private var lastFrameSection: some View {
+        if model.supportsLastFrame {
+            VStack(alignment: .leading, spacing: 6) {
+                keyframeWell(title: "Last frame",
+                             note: "optional — ends here",
+                             url: $lastFrameImageURL,
+                             isTargeted: $isLastFrameDropTargeted,
+                             help: "Select the image the clip should land on. The first frame sets the size; this one is fitted to it.")
+                if lastFrameImageURL != nil && firstFrameImageURL == nil {
+                    Text("With only a last frame the model invents the opening and works toward it. Add a first frame to pin both ends.")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    /// One keyframe slot: thumbnail + clear when filled, drop well when empty.
+    /// Both anchors draw the same shape so they read as a pair.
+    private func keyframeWell(title: String, note: String, url: Binding<URL?>,
+                              isTargeted: Binding<Bool>, help: String) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
-                Text("First frame").font(.subheadline.weight(.semibold))
+                Text(title).font(.subheadline.weight(.semibold))
                 Spacer()
-                Text("optional — I2V")
+                Text(note)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-            if let url = firstFrameImageURL {
+            if let picked = url.wrappedValue {
                 HStack(spacing: 8) {
-                    if let img = NSImage(contentsOf: url) {
+                    if let img = NSImage(contentsOf: picked) {
                         Image(nsImage: img)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .frame(width: 64, height: 48)
                             .clipShape(RoundedRectangle(cornerRadius: 4))
                     }
-                    Text(url.lastPathComponent)
+                    Text(picked.lastPathComponent)
                         .font(.caption)
                         .lineLimit(1)
                         .truncationMode(.middle)
                     Spacer()
                     Button {
-                        firstFrameImageURL = nil
+                        url.wrappedValue = nil
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                     }
                     .buttonStyle(.borderless)
                     .foregroundStyle(.secondary)
-                    .help("Clear first frame")
+                    .help("Clear \(title.lowercased())")
                 }
             } else {
                 // The same well the Image and 3D panes' empty states draw —
                 // one shape for "a picture goes here" across the four panes.
                 MediaDropWell(title: "Choose image...",
                               systemImage: "photo.on.rectangle.angled",
-                              isTargeted: isDropTargeted) { chooseFirstFrameImage() }
-                    .help("Select an image to use as the first frame of the video.")
+                              isTargeted: isTargeted.wrappedValue) { chooseKeyframeImage(into: url) }
+                    .help(help)
             }
         }
         // One image slot, so a drop REPLACES whatever is there — same as
         // picking again. Drops land on this section rather than the whole
         // window; see `MediaDropTarget`.
-        .mediaDrop(.image, isTargeted: $isDropTargeted) { urls in
-            if let url = urls.first { firstFrameImageURL = url }
+        .mediaDrop(.image, isTargeted: isTargeted) { urls in
+            if let dropped = urls.first { url.wrappedValue = dropped }
         }
     }
 
@@ -868,6 +913,52 @@ struct VideoGenView: View {
                           help: "Classifier-free guidance strength. LTX-2 default: 3.0; 1.0 = off (fastest).")
                 Text("Guidance strength — how closely the video follows your prompt. 1.0 = off: fastest and most natural-looking. Higher sticks to the prompt more strictly but is slower and can look over-saturated. LTX default is 3.0.")
                     .font(.caption2).foregroundStyle(.secondary)
+
+                // STG was sent on every LTX request from the day the wire was
+                // fixed, with nothing to set it — so it sat at whatever was in
+                // storage. A field on the wire with no control is worse than an
+                // absent one: the request looks right.
+                sliderRow("STG scale", value: $stgScale, range: 0...4, step: 0.5,
+                          help: "Spatio-temporal guidance. 0 = off (the default). Steadies motion and structure at the cost of speed.")
+                Text("Steadies motion and shape by re-running part of the model with its attention perturbed. 0 = off, which is the default. Around 1.0 helps wobbly motion; higher costs time and can flatten detail.")
+                    .font(.caption2).foregroundStyle(.secondary)
+
+                // Audio guidance belongs to the a2vid guider, so it only shows
+                // with a clip attached — otherwise it is a knob on something
+                // that never runs.
+                if model.supportsAudioInput, audioURL != nil {
+                    sliderRow("Audio guidance", value: $cfgAudioScale, range: 1...12, step: 0.5,
+                              help: "How closely the picture follows the attached soundtrack. LTX default: 7.0.")
+                    Text("How hard the video is pushed to match your clip — lip sync, timing, performance. 7.0 is the LTX default. Lower drifts from the audio; higher locks to it and can look stiff.")
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+
+            // Two-stage refine. One-stage has no second pass, so the control is
+            // hidden rather than shown doing nothing.
+            if model.supportsPipelineModes, mode != .oneStage {
+                Picker("Refine steps", selection: $stage2Steps) {
+                    Text("Auto").tag(0)
+                    ForEach(1...6, id: \.self) { Text("\($0)").tag($0) }
+                }
+                .pickerStyle(.menu)
+                .font(.caption)
+                .help("Steps in the second, full-resolution pass. Auto uses the reference schedule (3).")
+                Text("The second pass sharpens the upscaled frames. Auto is the reference schedule. More steps clean up detail and cost time; fewer are faster and softer.")
+                    .font(.caption2).foregroundStyle(.secondary)
+            }
+
+            // Chained windows. Already wired end to end — this is the control
+            // that never existed, which is why long clips were unreachable.
+            if model.supportsChainedWindows {
+                Stepper(value: $chainWindows, in: 1...8) {
+                    Text("Chained windows: \(chainWindows)").font(.caption)
+                }
+                .help("Join several generations end to end, each starting from the last frame of the one before.")
+                Text(chainWindows > 1
+                     ? "\(chainWindows) windows joined end to end — about \(numFrames * chainWindows) frames, and roughly \(chainWindows)x the time of a single window."
+                     : "Joins several generations end to end for a longer clip. Each window costs another full generation.")
+                    .font(.caption2).foregroundStyle(.secondary)
             }
 
             HStack {
@@ -1064,14 +1155,14 @@ struct VideoGenView: View {
         }
     }
 
-    private func chooseFirstFrameImage() {
+    private func chooseKeyframeImage(into slot: Binding<URL?>) {
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.image, .png, .jpeg, .heic]
         panel.canChooseFiles = true
         panel.canChooseDirectories = false
         panel.allowsMultipleSelection = false
         if AppActivation.runModal(panel) == .OK, let url = panel.url {
-            firstFrameImageURL = url
+            slot.wrappedValue = url
         }
     }
 
@@ -1246,6 +1337,11 @@ struct VideoGenView: View {
         steps = min(effectiveStepsRange.upperBound, max(effectiveStepsRange.lowerBound, s.steps))
         cfgScale = min(10, max(1, s.cfgScale))
         stgScale = s.stgScale
+        // Clamped like the sliders above: a value saved before a range moved
+        // would otherwise sit off-scale, and 0 stays Auto.
+        stage2Steps = min(6, max(0, s.stage2Steps))
+        cfgAudioScale = min(12, max(1, s.cfgAudioScale))
+        chainWindows = model.supportsChainedWindows ? min(8, max(1, s.chainWindows)) : 1
         seed = s.seed
         keepResident = s.keepResident
         bestQuality = s.bestQuality
@@ -1268,6 +1364,9 @@ struct VideoGenView: View {
         s.steps = steps
         s.cfgScale = cfgScale
         s.stgScale = stgScale
+        s.stage2Steps = stage2Steps
+        s.cfgAudioScale = cfgAudioScale
+        s.chainWindows = chainWindows
         s.seed = seed
         s.keepResident = keepResident
         s.bestQuality = bestQuality
@@ -1315,6 +1414,9 @@ struct VideoGenView: View {
         steps = min(model.stepsRange.upperBound, max(model.stepsRange.lowerBound, s.steps))
         cfgScale = s.cfgScale
         stgScale = s.stgScale
+        // A tier does not describe chaining, but a preset switch can land on a
+        // partition without it — collapse rather than carry a dead value.
+        if !model.supportsChainedWindows { chainWindows = 1 }
         numFrames = s.numFrames
         clampFramesToRAM()
         // Keep firstFrameImageURL across preset changes so users can swap
@@ -1357,6 +1459,7 @@ struct VideoGenView: View {
             cfgScale: cfgScale,
             stgScale: stgScale,
             firstFrameImagePath: firstFrameImageURL?.path,
+            lastFrameImagePath: lastFrameImageURL?.path,
             // Belt-and-braces with the requestBody gate: a clip must never
             // reach the transcode (whose failure is a hard error) on a
             // backend that generates its own soundtrack.
@@ -1371,6 +1474,11 @@ struct VideoGenView: View {
             // Belt-and-braces with the requestBody gate (turbo state survives
             // preset switches, like the reference files below).
             turbo: turboEngaged,
+            // Gated here too: the stepper's value survives a preset switch,
+            // and only the fl2va partition has a keyframe row to chain.
+            chainWindows: model.supportsChainedWindows ? chainWindows : 1,
+            stage2Steps: stage2Steps,
+            cfgAudioScale: cfgAudioScale,
             // Belt-and-braces with the requestBody gate, same as `audioPath`
             // above: reference files must never reach the reader (whose
             // failure is a hard error) on a pack that cannot use them.

--- a/app/Tests/MLXCoreTests/VideoGenUnreachableSettingsTests.swift
+++ b/app/Tests/MLXCoreTests/VideoGenUnreachableSettingsTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+@testable import MLXCore
+
+/// Five server settings the video pane could not reach (#243). Each is a
+/// finished server feature whose control was missing, so the failure mode is
+/// silent: the request simply never carries the field and the server applies
+/// its default. Two of them (`stg_scale`, `chain_windows`) were already IN the
+/// request and already sent — they just had no control, which is the same bug
+/// wearing a different hat, so those two are pinned by a source scan.
+final class VideoGenUnreachableSettingsTests: XCTestCase {
+
+    private func videoGenViewSource() throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // MLXCoreTests
+            .deletingLastPathComponent() // Tests
+            .deletingLastPathComponent() // app root
+            .appendingPathComponent("Sources/MLXServe/Views/VideoGenView.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private func req(_ model: VideoModelPreset, mode: VideoPipelineMode = .oneStage) -> VideoGenRequest {
+        VideoGenRequest(model: model, prompt: "p", width: 384, height: 256,
+                        numFrames: 124, fps: 24, mode: mode, steps: 16, cfgScale: 1.0)
+    }
+
+    // MARK: - H3 last frame
+
+    func testLastFrameImageReachesTheRequestOnFl2vaOnly() {
+        // fl2va is first-LAST frame to video+audio. The server pins the last
+        // keyframe as a center-COVER anchor; without the field we ship half
+        // the partition the pack is named for. ref2va has no keyframe row to
+        // anchor, and LTX's handler has no `last_frame_image` at all, so both
+        // must stay absent even when the state is populated (a preset switch
+        // leaves the picked file behind — the `pipeline`-on-H3 class).
+        XCTAssertTrue(VideoModelPreset.minimaxH3.supportsLastFrame)
+        XCTAssertTrue(VideoModelPreset.minimaxH3Q4.supportsLastFrame)
+        XCTAssertFalse(VideoModelPreset.minimaxH3Ref2VA.supportsLastFrame)
+        XCTAssertFalse(VideoModelPreset.ltx25Q8.supportsLastFrame)
+        XCTAssertFalse(VideoModelPreset.ltx23Q4.supportsLastFrame)
+
+        for model in [VideoModelPreset.minimaxH3, .minimaxH3Ref2VA, .ltx25Q8] {
+            let body = VideoGenService.requestBody(model: "m", prompt: "p", request: req(model),
+                                                   firstFrameB64: nil, lastFrameB64: "TA==")
+            if model.supportsLastFrame {
+                XCTAssertEqual(body["last_frame_image"] as? String, "TA==",
+                               "\(model.id) declares last-frame support but drops the field")
+            } else {
+                XCTAssertNil(body["last_frame_image"],
+                             "\(model.id) has no last-frame anchor — the field must not be sent")
+            }
+        }
+        // Absent when no image is attached, like first_frame_image.
+        let bare = VideoGenService.requestBody(model: "m", prompt: "p", request: req(.minimaxH3),
+                                               firstFrameB64: nil, lastFrameB64: nil)
+        XCTAssertNil(bare["last_frame_image"])
+    }
+
+    func testLastFrameHasAControlBesideFirstFrame() throws {
+        let source = try videoGenViewSource()
+        XCTAssertTrue(source.contains("lastFrameImageURL"),
+                      "The video pane needs a last-frame well; the server anchor is unreachable without one")
+        XCTAssertTrue(source.contains("lastFrameImagePath: "),
+                      "The picked last frame must reach VideoGenRequest, or the well is decorative")
+    }
+
+    // MARK: - H3 chained windows
+
+    func testChainedWindowsHasAControl() throws {
+        // Already in the request and already sent by the service — it was the
+        // CONTROL that never existed, so `chainWindows` sat at 1 forever.
+        let source = try videoGenViewSource()
+        XCTAssertTrue(source.contains("chainWindows"),
+                      "chain_windows is wired end to end but no view sets it — long clips are unreachable")
+    }
+
+    func testChainedWindowsStaysGatedOnThePartition() {
+        var fl2va = req(.minimaxH3)
+        fl2va.chainWindows = 3
+        XCTAssertEqual(VideoGenService.requestBody(model: "m", prompt: "p", request: fl2va,
+                                                   firstFrameB64: nil)["chain_windows"] as? Int, 3)
+        var ref = req(.minimaxH3Ref2VA)
+        ref.chainWindows = 3
+        XCTAssertNil(VideoGenService.requestBody(model: "m", prompt: "p", request: ref,
+                                                 firstFrameB64: nil)["chain_windows"])
+    }
+
+    // MARK: - LTX spatio-temporal guidance
+
+    func testStgScaleHasASlider() throws {
+        // Declared, persisted and SENT with no way to set it — the worst shape
+        // of this bug, because the wire looks correct.
+        let source = try videoGenViewSource()
+        XCTAssertTrue(source.contains("\"STG scale\""),
+                      "stg_scale is sent on every LTX request but has no slider — it is pinned at whatever is in storage")
+    }
+
+    // MARK: - LTX stage-2 refine steps
+
+    func testStage2StepsIsSentOnlyWhenSetAndOnlyTwoStage() {
+        // 0 means "all 3" server-side, so 0 is Auto and stays absent — the
+        // server's default is the absent-field behavior everywhere else in
+        // this body. One-stage has no refine pass to size.
+        var auto = req(.ltx25Q8, mode: .twoStage)
+        auto.stage2Steps = 0
+        XCTAssertNil(VideoGenService.requestBody(model: "m", prompt: "p", request: auto,
+                                                 firstFrameB64: nil)["stage2_steps"])
+        var set = req(.ltx25Q8, mode: .twoStage)
+        set.stage2Steps = 2
+        XCTAssertEqual(VideoGenService.requestBody(model: "m", prompt: "p", request: set,
+                                                   firstFrameB64: nil)["stage2_steps"] as? Int, 2)
+        var oneStage = req(.ltx25Q8, mode: .oneStage)
+        oneStage.stage2Steps = 2
+        XCTAssertNil(VideoGenService.requestBody(model: "m", prompt: "p", request: oneStage,
+                                                 firstFrameB64: nil)["stage2_steps"],
+                     "one-stage has no refine pass — the field would be a no-op the server still parses")
+        // H3 has no pipeline modes at all.
+        var h3 = req(.minimaxH3)
+        h3.stage2Steps = 2
+        XCTAssertNil(VideoGenService.requestBody(model: "m", prompt: "p", request: h3,
+                                                 firstFrameB64: nil)["stage2_steps"])
+    }
+
+    func testStage2StepsHasAControl() throws {
+        let source = try videoGenViewSource()
+        XCTAssertTrue(source.contains("stage2Steps"),
+                      "The two-stage refine pass has no step control")
+    }
+
+    // MARK: - LTX audio guidance
+
+    func testAudioGuidanceIsSentOnlyWithAnAttachedClip() {
+        // cfg_audio_scale scales the AUDIO guider, which only exists on the
+        // a2vid path. Sending it without a clip would set a knob on a guider
+        // that never runs.
+        var withAudio = req(.ltx25Q8, mode: .twoStage)
+        withAudio.cfgAudioScale = 5.0
+        XCTAssertEqual(VideoGenService.requestBody(model: "m", prompt: "p", request: withAudio,
+                                                   firstFrameB64: nil,
+                                                   audioB64: "UklGRg==")["cfg_audio_scale"] as? Double, 5.0)
+        XCTAssertNil(VideoGenService.requestBody(model: "m", prompt: "p", request: withAudio,
+                                                 firstFrameB64: nil)["cfg_audio_scale"],
+                     "no clip means no audio guider to scale")
+        // A one-stage preset with a clip is upgraded to two_stage and DROPS its
+        // guidance so the server's reference defaults apply — the audio scale
+        // is guidance and must drop with the rest.
+        var upgraded = req(.ltx25Q8, mode: .oneStage)
+        upgraded.cfgAudioScale = 5.0
+        let ubody = VideoGenService.requestBody(model: "m", prompt: "p", request: upgraded,
+                                                firstFrameB64: nil, audioB64: "UklGRg==")
+        XCTAssertEqual(ubody["pipeline"] as? String, "two_stage")
+        XCTAssertNil(ubody["cfg_audio_scale"])
+        XCTAssertNil(ubody["cfg_scale"])
+    }
+
+    func testAudioGuidanceHasAControl() throws {
+        let source = try videoGenViewSource()
+        XCTAssertTrue(source.contains("cfgAudioScale"),
+                      "Audio-to-video always runs the default audio guidance — the scale has no control")
+    }
+}


### PR DESCRIPTION
Closes #243.

Five finished server features the app could not ask for. The failure was silent in every case — the field never left, and the server applied its default.

| setting | backend | was |
|---|---|---|
| `last_frame_image` | H3 fl2va | no control, no request field |
| `chain_windows` | H3 fl2va | wired end to end, **no control** — pinned at 1 |
| `stg_scale` | LTX | declared, persisted **and sent**, no slider |
| `stage2_steps` | LTX two-stage | never sent |
| `cfg_audio_scale` | LTX a2vid | never sent |

**Last frame** is the headline: fl2va means first-**last** frame to video+audio, and we shipped half of it. The server owns both resize policies (first stretches to set the geometry, last center-covers to follow it), so the app just sends two images. `firstFrameSection` is generalised into `keyframeWell` — one shape, one chooser, one drop target for both anchors.

**STG** is the nastiest shape of the bug. It was on the wire the whole time, so the request looked correct while the value was pinned to whatever sat in storage.

**Stage-2 steps** is two-stage only, since one-stage has no refine pass. `0` means "all 3" server-side, so the control has an explicit **Auto** position and 0 stays *absent* — that keeps "absent = the server's default" true across the whole body.

**Audio guidance** rides the attached clip rather than the preset: with no clip there is no audio guider to scale. It drops with the rest of the guidance when a one-stage request is upgraded for audio, because the point of that drop is to let the server's reference two-stage defaults (3.0 video / 7.0 audio) apply as a set.

Every field is capability-gated in `requestBody` **and** again where the request is built — the belt-and-braces rule the `pipeline`-on-H3 bug earned. Control state survives a preset switch, so hiding a control is not the same as not sending its field.

## Testing

TDD. `VideoGenUnreachableSettingsTests` was written first and is red on main for the four missing members (`supportsLastFrame`, `lastFrameB64`, `stage2Steps`, `cfgAudioScale`).

- 9 new tests, all green. Gating pinned per preset in both directions.
- The two settings already on the wire are pinned by a source scan — a control that does not exist cannot be asserted any other way.
- `swift build` clean. `swift test` otherwise unchanged.
- **Pre-existing, untouched:** `AgentIntegrationTests` has 2 failures. They drive a live server over HTTP and none is running. No agent file appears in this diff.

No Zig changes — the server already accepts all five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)