### PR TITLE
feat: native video input for Qwen3-VL-family chat

### DIFF
--- a/app/Sources/MLXServe/Models/ChatModels.swift
+++ b/app/Sources/MLXServe/Models/ChatModels.swift
@@ -213,6 +213,25 @@ struct ChatAudio: Identifiable, Codable, Equatable {
     var durationSeconds: Double { Double(sampleCount) / 16_000.0 }
 }
 
+/// A video attached to a message. `frames` are JPEG bytes sampled evenly
+/// across the whole clip (`VideoPreprocessor.extractFrames`) — Qwen3-VL-family
+/// models are the only ones that read video input, and the server decodes each
+/// frame the same way it decodes a plain `image_url` (no video codec exists
+/// anywhere in mlx-serve, so frame extraction is the client's job).
+struct ChatVideo: Identifiable, Codable, Equatable {
+    let id: UUID
+    let name: String // original filename, for the attachment chip
+    let frames: [Data] // JPEG bytes, one per sampled frame
+
+    init(name: String, frames: [Data]) {
+        self.id = UUID()
+        self.name = name
+        self.frames = frames
+    }
+
+    var frameCount: Int { frames.count }
+}
+
 struct ChatMessage: Identifiable, Codable {
     let id: UUID
     var role: Role
@@ -230,6 +249,7 @@ struct ChatMessage: Identifiable, Codable {
     var toolName: String?     // For tool response messages
     var toolCalls: [SerializedToolCall]? // Tool calls made BY this assistant message
     var images: [ChatImage]?  // Images attached to this message
+    var videos: [ChatVideo]?  // Videos attached to this message
     var audio: [ChatAudio]?   // Audio clips attached to this message
     // Generated media attached BY PATH (see ChatMediaRef) — the tracks and clips
     // the in-chat media tools produce. Absent on every message saved before they
@@ -280,7 +300,7 @@ struct ChatMessage: Identifiable, Codable {
         case id, role, content, reasoningContent, isStreaming, timestamp
         case agentPlan, toolResults, isAgentSummary
         case promptTokens, completionTokens, tokensPerSecond
-        case toolCallId, toolName, toolCalls, images, audio, failedRetry, processHandles
+        case toolCallId, toolName, toolCalls, images, videos, audio, failedRetry, processHandles
         case errorNotice, media, truncationNotice, revisions, activeRevision
     }
 
@@ -302,6 +322,7 @@ struct ChatMessage: Identifiable, Codable {
         toolName = try c.decodeIfPresent(String.self, forKey: .toolName)
         toolCalls = try c.decodeIfPresent([SerializedToolCall].self, forKey: .toolCalls)
         images = try c.decodeIfPresent([ChatImage].self, forKey: .images)
+        videos = try c.decodeIfPresent([ChatVideo].self, forKey: .videos)
         audio = try c.decodeIfPresent([ChatAudio].self, forKey: .audio)
         media = try c.decodeIfPresent([ChatMediaRef].self, forKey: .media)
         failedRetry = try c.decodeIfPresent(Bool.self, forKey: .failedRetry) ?? false
@@ -352,6 +373,11 @@ struct ModelInfo {
     /// was launched with `--no-vision`. The Telegram bridge reads this to
     /// decide whether to forward an incoming photo or refuse it.
     var supportsVision: Bool = false
+    /// True when the model advertises `video` in `input_modalities` (Qwen3-VL-
+    /// family checkpoints that declare `video_token_id` alongside vision).
+    /// Never true without `supportsVision` also being true — video piggybacks
+    /// the same vision tower. Gates the video-attach option in chat.
+    var supportsVideo: Bool = false
     /// True when the model advertises the `embeddings` capability (encoder-
     /// only BERT entries, loaded or stub). DocumentIndex uses this to pick a
     /// GPU embedder for folder indexing.

--- a/app/Sources/MLXServe/Services/APIClient.swift
+++ b/app/Sources/MLXServe/Services/APIClient.swift
@@ -149,6 +149,11 @@ class APIClient {
         // server runs with `--no-vision` (the encoder isn't loaded), so this is
         // the live "can this model see images right now?" signal.
         let supportsVision = caps.contains("vision") || mods.contains("image")
+        // Video rides input_modalities only (no separate "video" capability —
+        // that string is already claimed by media-GENERATION models); it can
+        // never be true without supportsVision, since video piggybacks the
+        // same vision tower server-side.
+        let supportsVideo = supportsVision && mods.contains("video")
         // Encoder-only entries advertise "embeddings" even as unloaded stubs
         // (the server peeks model_type at discovery); architecture is the
         // belt-and-suspenders signal for loaded entries.
@@ -167,6 +172,7 @@ class APIClient {
             isMoE: meta["is_moe"] as? Bool ?? false,
             supportsAudio: supportsAudio,
             supportsVision: supportsVision,
+            supportsVideo: supportsVideo,
             supportsEmbeddings: supportsEmbeddings,
             capabilities: caps,
             drafterLoaded: meta["drafter_loaded"] as? Bool ?? false,

--- a/app/Sources/MLXServe/Services/ChatTurnEngine.swift
+++ b/app/Sources/MLXServe/Services/ChatTurnEngine.swift
@@ -20,9 +20,12 @@ protocol TurnRunning: AnyObject {
     func runTurn(sessionId: UUID,
                  userText: String,
                  images: [ChatImage]?,
+                 videos: [ChatVideo]?,
                  audio: [ChatAudio]?,
                  config: ChatTurnEngine.TurnConfig,
                  approval: @escaping (APIClient.ToolCall) async -> Bool)
+    // (No default for `videos` here — Swift protocol requirements can't carry
+    // default argument values; every call site names it explicitly.)
     /// Cancel every in-flight turn (the legacy app-wide stop).
     func stop()
     /// Cancel one session's in-flight turn, leaving the others running.
@@ -448,11 +451,12 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
     func runTurn(sessionId: UUID,
                  userText: String,
                  images: [ChatImage]?,
+                 videos: [ChatVideo]? = nil,
                  audio: [ChatAudio]?,
                  config: TurnConfig,
                  approval: @escaping (APIClient.ToolCall) async -> Bool) {
         let text = userText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty || images != nil || audio != nil,
+        guard !text.isEmpty || images != nil || videos != nil || audio != nil,
               server.status == .running else { return }
 
         // A new submission to the SAME session supersedes its in-flight turn.
@@ -471,10 +475,10 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
         }
 
         if config.agentMode || config.mcpMode || config.documentIndex != nil {
-            runAgentTurn(sessionId: sessionId, text: text, images: images, audio: audio,
+            runAgentTurn(sessionId: sessionId, text: text, images: images, videos: videos, audio: audio,
                          config: config, token: token, approval: approval)
         } else {
-            runPlainTurn(sessionId: sessionId, text: text, images: images, audio: audio,
+            runPlainTurn(sessionId: sessionId, text: text, images: images, videos: videos, audio: audio,
                          config: config, token: token)
         }
     }
@@ -540,12 +544,13 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
     ///   no placeholder is appended — the trailing assistant message IS the
     ///   placeholder, and the server is told to treat it as a prefill.
     private func runPlainTurn(sessionId: UUID, text: String,
-                              images: [ChatImage]?, audio: [ChatAudio]?,
+                              images: [ChatImage]?, videos: [ChatVideo]? = nil, audio: [ChatAudio]?,
                               config: TurnConfig, token: UUID,
                               continuing: Bool = false) {
         if !continuing {
             var userMsg = ChatMessage(role: .user, content: text)
             userMsg.images = images
+            userMsg.videos = videos
             userMsg.audio = audio
             appState.appendMessage(to: sessionId, message: userMsg)
         }
@@ -554,18 +559,19 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
 
         // Build the request from the session (its source of truth). We append
         // the streaming placeholder AFTER this so it never lands in the
-        // request — same pattern the agent loop uses. Image handling: only
-        // the latest user message's images are sent (older turns' images are
-        // stripped for bandwidth).
+        // request — same pattern the agent loop uses. Image/video handling:
+        // only the latest user message's attachments are sent (older turns'
+        // are stripped for bandwidth).
         let sessionMsgs = session(sessionId)?.messages ?? []
         let lastUserIdx = sessionMsgs.lastIndex { $0.role == .user }
         let useServerPreprocess = wantsServerImagePreprocess
         let history: [[String: Any]] = sessionMsgs.enumerated().map { i, msg in
             if i == lastUserIdx, msg.role == .user {
                 let imgs = msg.images ?? []
+                let vids = msg.videos ?? []
                 let clips = msg.audio ?? []
-                if !imgs.isEmpty || !clips.isEmpty {
-                    return ["role": "user", "content": Self.buildMultimodalContent(text: msg.content, images: imgs, audio: clips, serverPreprocess: useServerPreprocess)]
+                if !imgs.isEmpty || !vids.isEmpty || !clips.isEmpty {
+                    return ["role": "user", "content": Self.buildMultimodalContent(text: msg.content, images: imgs, videos: vids, audio: clips, serverPreprocess: useServerPreprocess)]
                 }
             }
             return Self.plainHistoryDict(msg)
@@ -698,11 +704,12 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
     // MARK: - Agent mode (native tool calling)
 
     private func runAgentTurn(sessionId: UUID, text: String,
-                              images: [ChatImage]?, audio: [ChatAudio]?,
+                              images: [ChatImage]?, videos: [ChatVideo]? = nil, audio: [ChatAudio]?,
                               config: TurnConfig, token: UUID,
                               approval: @escaping (APIClient.ToolCall) async -> Bool) {
         var userMsg = ChatMessage(role: .user, content: text)
         userMsg.images = images
+        userMsg.videos = videos
         userMsg.audio = audio
         appState.appendMessage(to: sessionId, message: userMsg)
 
@@ -1624,15 +1631,17 @@ final class ChatTurnEngine: ObservableObject, TurnRunning {
     }
 
     /// Build OpenAI-style content blocks for a message with images (and,
-    /// optionally, audio). Delegates to the pure, unit-tested `MultimodalContent`
-    /// builder. Two overloads so the `buildAgentHistory` closure (images only)
-    /// and the plain-chat path (images + audio) can both reference it.
+    /// optionally, video/audio). Delegates to the pure, unit-tested
+    /// `MultimodalContent` builder. Two overloads so the `buildAgentHistory`
+    /// closure (images only — the agent tool-loop doesn't send video/audio
+    /// attachments to the model, same as audio today) and the plain-chat path
+    /// (images + video + audio) can both reference it.
     nonisolated static func buildMultimodalContent(text: String, images: [ChatImage], serverPreprocess: Bool = false) -> Any {
-        MultimodalContent.build(text: text, images: images, audio: [], serverPreprocess: serverPreprocess)
+        MultimodalContent.build(text: text, images: images, videos: [], audio: [], serverPreprocess: serverPreprocess)
     }
 
-    nonisolated static func buildMultimodalContent(text: String, images: [ChatImage], audio: [ChatAudio], serverPreprocess: Bool = false) -> Any {
-        MultimodalContent.build(text: text, images: images, audio: audio, serverPreprocess: serverPreprocess)
+    nonisolated static func buildMultimodalContent(text: String, images: [ChatImage], videos: [ChatVideo] = [], audio: [ChatAudio], serverPreprocess: Bool = false) -> Any {
+        MultimodalContent.build(text: text, images: images, videos: videos, audio: audio, serverPreprocess: serverPreprocess)
     }
 
     var wantsServerImagePreprocess: Bool {

--- a/app/Sources/MLXServe/Services/MultimodalContent.swift
+++ b/app/Sources/MLXServe/Services/MultimodalContent.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-/// Builds OpenAI-style multimodal `content` blocks (image_url / input_audio /
-/// text) for a chat message. Pure and dependency-light so it can be unit-tested:
-/// image preprocessing is injected as a closure (the app passes
-/// `ImagePreprocessor.preprocess`), and audio is emitted straight from the
-/// decoded PCM the server expects.
+/// Builds OpenAI-style multimodal `content` blocks (image_url / video_url /
+/// input_audio / text) for a chat message. Pure and dependency-light so it can
+/// be unit-tested: image preprocessing is injected as a closure (the app
+/// passes `ImagePreprocessor.preprocess`), video frames are emitted straight
+/// from `VideoPreprocessor.extractFrames`'s JPEG bytes, and audio is emitted
+/// straight from the decoded PCM the server expects.
 enum MultimodalContent {
     /// Whether the server should do the image preprocessing for this model.
     /// `x-mlx-pixels` is Gemma's square CHW format and ONLY Gemma can read it,
@@ -17,12 +18,16 @@ enum MultimodalContent {
 
     /// Returns a content-blocks array suitable for a `{"role":"user","content":[...]}`
     /// message. Images become `image_url` blocks (preprocessed pixels when the
-    /// preprocessor succeeds, JPEG data-URL otherwise); audio becomes
-    /// `input_audio` blocks carrying base64 float32-LE 16 kHz mono PCM; text is
-    /// appended last when non-empty.
+    /// preprocessor succeeds, JPEG data-URL otherwise); videos become
+    /// `video_url` blocks carrying an ordered array of JPEG-data-URL frames
+    /// (Qwen3-VL-family only — no video codec exists server-side, so frame
+    /// extraction is done here, client-side); audio becomes `input_audio`
+    /// blocks carrying base64 float32-LE 16 kHz mono PCM; text is appended
+    /// last when non-empty.
     static func build(
         text: String,
         images: [ChatImage],
+        videos: [ChatVideo] = [],
         audio: [ChatAudio] = [],
         // When true (Qwen3-VL and other non-Gemma vision models), skip the
         // Gemma-specific square `x-mlx-pixels` preprocessing and send the raw
@@ -45,6 +50,14 @@ enum MultimodalContent {
                 "type": "image_url",
                 "image_url": ["url": img.base64URL] as [String: Any],
             ]
+        }
+
+        for vid in videos {
+            let frameUrls = vid.frames.map { "data:image/jpeg;base64,\($0.base64EncodedString())" }
+            blocks.append([
+                "type": "video_url",
+                "video_url": ["frames": frameUrls] as [String: Any],
+            ])
         }
 
         for clip in audio {

--- a/app/Sources/MLXServe/Services/VideoPreprocessor.swift
+++ b/app/Sources/MLXServe/Services/VideoPreprocessor.swift
@@ -1,0 +1,54 @@
+import Foundation
+import AVFoundation
+import AppKit
+
+/// Extracts JPEG frames from a video file for Qwen3-VL-family video input.
+/// Frames are sampled evenly across the WHOLE clip duration — unlike
+/// MiniMax-H3's reference-video ingestion (`VideoGenService.videoFileToRefPayload`,
+/// first-N-seconds at a fixed 24 fps, snapped to H3's own frame ladder), a chat
+/// attachment is meant to summarize the whole clip, not condition generation on
+/// its opening beats. The server groups every 2 consecutive frames into one
+/// temporal patch (Qwen's `temporal_patch_size`), so the frame COUNT — not the
+/// clip's raw length — is what sizes the prompt-token cost.
+enum VideoPreprocessor {
+    /// Frames requested per attachment. Qwen pays roughly one image's worth of
+    /// merged tokens per PAIR of frames (temporal_patch_size=2), so this costs
+    /// about what 8 images would — a reasonable budget for one attachment.
+    static let maxFrames = 16
+    static let frameMaxEdge: CGFloat = 768
+
+    /// `count` timestamps evenly spaced across `[0, duration]` (inclusive of
+    /// both ends when count > 1). Pure — factored out so the sampling math is
+    /// testable without decoding a real video file.
+    nonisolated static func frameTimes(duration: Double, count: Int) -> [Double] {
+        guard duration > 0, count > 0 else { return [] }
+        guard count > 1 else { return [0] }
+        return (0..<count).map { duration * Double($0) / Double(count - 1) }
+    }
+
+    /// Returns JPEG frame bytes (one per sampled frame, in playback order), or
+    /// nil if the file can't be read or has no readable duration.
+    static func extractFrames(url: URL, maxFrames: Int = maxFrames) -> [Data]? {
+        let asset = AVURLAsset(url: url)
+        let seconds = CMTimeGetSeconds(asset.duration)
+        guard seconds.isFinite, seconds > 0, maxFrames > 0 else { return nil }
+
+        let gen = AVAssetImageGenerator(asset: asset)
+        gen.appliesPreferredTrackTransform = true
+        gen.requestedTimeToleranceBefore = .zero
+        gen.requestedTimeToleranceAfter = .zero
+        gen.maximumSize = CGSize(width: frameMaxEdge, height: frameMaxEdge)
+
+        var frames: [Data] = []
+        frames.reserveCapacity(maxFrames)
+        for t in frameTimes(duration: seconds, count: maxFrames) {
+            let time = CMTime(seconds: t, preferredTimescale: 600)
+            guard let cg = try? gen.copyCGImage(at: time, actualTime: nil) else { return nil }
+            let rep = NSBitmapImageRep(cgImage: cg)
+            guard let jpeg = rep.representation(using: .jpeg, properties: [.compressionFactor: 0.85])
+            else { return nil }
+            frames.append(jpeg)
+        }
+        return frames.isEmpty ? nil : frames
+    }
+}

--- a/app/Sources/MLXServe/Services/VoiceModeController.swift
+++ b/app/Sources/MLXServe/Services/VoiceModeController.swift
@@ -522,7 +522,7 @@ final class VoiceModeController: ObservableObject {
             thinkingEnabled: enableThinking,
             workingDirectory: ctx.workingDirectory)
         let config = ChatTurnEngine.TurnConfig.from(resolved, voiceStyle: true)
-        runner.runTurn(sessionId: ctx.sessionId, userText: text, images: nil, audio: nil,
+        runner.runTurn(sessionId: ctx.sessionId, userText: text, images: nil, videos: nil, audio: nil,
                        config: config, approval: { [weak self] tc in
             await self?.approvalDecision(for: tc) ?? false
         })

--- a/app/Sources/MLXServe/Views/ChatView.swift
+++ b/app/Sources/MLXServe/Views/ChatView.swift
@@ -157,6 +157,7 @@ struct ToolApprovalSheet: View {
 private struct AttachmentPreviewRow: View {
     @Binding var images: [NSImage]
     @Binding var pdfs: [(name: String, text: String)]
+    @Binding var videos: [ChatVideo]
     @Binding var audio: [ChatAudio]
 
     var body: some View {
@@ -168,6 +169,10 @@ private struct AttachmentPreviewRow: View {
                 ForEach(Array(pdfs.enumerated()), id: \.offset) { idx, pdf in
                     fileChip(idx: idx, name: pdf.name, detail: "PDF · \(pdf.text.count) chars",
                              icon: "doc.text.fill", tint: .red) { pdfs.remove(at: idx) }
+                }
+                ForEach(Array(videos.enumerated()), id: \.offset) { idx, vid in
+                    fileChip(idx: idx, name: vid.name, detail: "Video · \(vid.frameCount) frames",
+                             icon: "video.fill", tint: .orange) { videos.remove(at: idx) }
                 }
                 ForEach(Array(audio.enumerated()), id: \.offset) { idx, clip in
                     fileChip(idx: idx, name: clip.name, detail: String(format: "Audio · %.1fs", clip.durationSeconds),
@@ -350,14 +355,15 @@ private struct MicButton: View {
 /// A top-level (non-`@MainActor`) type so the routing is unit-testable without
 /// the rendered view — it mirrors the attach button's dispatch (see ChatPasteTests).
 enum PasteFileKind: String, Equatable {
-    case folder, pdf, audio, image, unhandled
+    case folder, pdf, audio, video, image, unhandled
 
-    static func classify(ext: String, isDirectory: Bool, audioSupported: Bool) -> PasteFileKind {
+    static func classify(ext: String, isDirectory: Bool, audioSupported: Bool, videoSupported: Bool = false) -> PasteFileKind {
         if isDirectory { return .folder }
         let e = ext.lowercased()
         if e == "pdf" { return .pdf }
         if let ut = UTType(filenameExtension: e) {
             if ut.conforms(to: .audio) { return audioSupported ? .audio : .unhandled }
+            if ut.conforms(to: .movie) { return videoSupported ? .video : .unhandled }
             if ut.conforms(to: .image) { return .image }
         }
         return .unhandled
@@ -1543,6 +1549,7 @@ struct ChatDetailView: View {
     @State private var pasteMonitor: Any?
     @State private var pendingImages: [NSImage] = []
     @State private var pendingPDFs: [(name: String, text: String)] = []
+    @State private var pendingVideos: [ChatVideo] = []
     @State private var pendingAudio: [ChatAudio] = []
     @StateObject private var recorder = AudioRecorder()
     // Tool-approval gate state. `pendingApproval` is set right before each
@@ -1722,16 +1729,15 @@ struct ChatDetailView: View {
     /// The agent this tab is talking to (nil = none).
     private var activeAgent: Agent? { appState.agents.agent(id: session?.agentId) }
 
-    /// Images/PDFs/audio for this message, or a folder to ask questions about.
-    /// Its own property (rather than inline in `composerControls`) so it carries
-    /// a hover card like every other glyph in the row.
+    /// Images/videos/PDFs/audio for this message, or a folder to ask questions
+    /// about. Its own property (rather than inline in `composerControls`) so
+    /// it carries a hover card like every other glyph in the row.
     private var attachmentMenu: some View {
         Menu {
             Button {
                 pickAttachment()
             } label: {
-                Label(audioSupported ? "Attach Image, PDF, or Audio…" : "Attach Image or PDF…",
-                      systemImage: "photo.on.rectangle")
+                Label(attachmentMenuLabel, systemImage: "photo.on.rectangle")
             }
             Button {
                 pickDocumentFolder()
@@ -1753,7 +1759,16 @@ struct ChatDetailView: View {
         .buttonStyle(.plain)
         .menuIndicator(.hidden)
         .frame(width: ChatMetrics.composerControlSize, height: ChatMetrics.composerControlSize)
-        .composerTip(.attachments(audioSupported: audioSupported))
+        .composerTip(.attachments(audioSupported: audioSupported, videoSupported: videoSupported))
+    }
+
+    private var attachmentMenuLabel: String {
+        switch (videoSupported, audioSupported) {
+        case (true, true): return "Attach Image, Video, PDF, or Audio…"
+        case (true, false): return "Attach Image, Video, or PDF…"
+        case (false, true): return "Attach Image, PDF, or Audio…"
+        case (false, false): return "Attach Image or PDF…"
+        }
     }
 
     /// Shared look for the composer's icon-only mode controls.
@@ -2225,9 +2240,9 @@ struct ChatDetailView: View {
                 .padding(.horizontal, 14)
                 .padding(.vertical, 12)
               } else {
-                // Pending attachment thumbnails (images + PDFs + audio)
-                if !pendingImages.isEmpty || !pendingPDFs.isEmpty || !pendingAudio.isEmpty {
-                    AttachmentPreviewRow(images: $pendingImages, pdfs: $pendingPDFs, audio: $pendingAudio)
+                // Pending attachment thumbnails (images + PDFs + videos + audio)
+                if !pendingImages.isEmpty || !pendingPDFs.isEmpty || !pendingVideos.isEmpty || !pendingAudio.isEmpty {
+                    AttachmentPreviewRow(images: $pendingImages, pdfs: $pendingPDFs, videos: $pendingVideos, audio: $pendingAudio)
                 }
 
                 // Attached document folder (mini RAG) — indexing progress / ready chip
@@ -2312,7 +2327,7 @@ struct ChatDetailView: View {
                 .frame(width: 0, height: 0)
                 .opacity(0)
         )
-        .onDrop(of: [.image, .pdf, .audio], isTargeted: nil) { providers in
+        .onDrop(of: [.image, .pdf, .audio, .movie], isTargeted: nil) { providers in
             for provider in providers {
                 if provider.hasItemConformingToTypeIdentifier(UTType.pdf.identifier) {
                     provider.loadFileRepresentation(forTypeIdentifier: UTType.pdf.identifier) { url, _ in
@@ -2337,6 +2352,20 @@ struct ChatDetailView: View {
                                 pendingAudio.append(ChatAudio(name: name, pcm: pcm))
                             } else {
                                 showAudioError(name)
+                            }
+                        }
+                    }
+                } else if videoSupported, provider.hasItemConformingToTypeIdentifier(UTType.movie.identifier) {
+                    // Decode inside the closure — the temp URL is only valid here.
+                    provider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { url, _ in
+                        guard let url = url else { return }
+                        let name = url.lastPathComponent
+                        let frames = VideoPreprocessor.extractFrames(url: url)
+                        DispatchQueue.main.async {
+                            if let frames, !frames.isEmpty {
+                                pendingVideos.append(ChatVideo(name: name, frames: frames))
+                            } else {
+                                showVideoError(name)
                             }
                         }
                     }
@@ -2623,7 +2652,7 @@ struct ChatDetailView: View {
         .disabled(server.status != .running
                   || (composerState == .idle
                       && inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                      && pendingImages.isEmpty && pendingPDFs.isEmpty && pendingAudio.isEmpty))
+                      && pendingImages.isEmpty && pendingPDFs.isEmpty && pendingVideos.isEmpty && pendingAudio.isEmpty))
         }
     }
 
@@ -2716,7 +2745,7 @@ struct ChatDetailView: View {
     private func attachFileURL(_ url: URL) -> Bool {
         var isDir: ObjCBool = false
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) else { return false }
-        switch PasteFileKind.classify(ext: url.pathExtension, isDirectory: isDir.boolValue, audioSupported: audioSupported) {
+        switch PasteFileKind.classify(ext: url.pathExtension, isDirectory: isDir.boolValue, audioSupported: audioSupported, videoSupported: videoSupported) {
         case .folder:
             attachDocumentFolder(url)
         case .pdf:
@@ -2727,6 +2756,8 @@ struct ChatDetailView: View {
             }
         case .audio:
             addAudioAttachment(url)
+        case .video:
+            addVideoAttachment(url)
         case .image:
             guard let image = NSImage(contentsOf: url) else { return false }
             pendingImages.append(image)
@@ -2740,8 +2771,11 @@ struct ChatDetailView: View {
 
     private func pickAttachment() {
         let panel = NSOpenPanel()
-        // Only offer audio on models that can use it.
-        panel.allowedContentTypes = audioSupported ? [.image, .pdf, .audio] : [.image, .pdf]
+        // Only offer audio/video on models that can use them.
+        var types: [UTType] = [.image, .pdf]
+        if videoSupported { types.append(.movie) }
+        if audioSupported { types.append(.audio) }
+        panel.allowedContentTypes = types
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
         AppActivation.beginPanel(panel) { response in
@@ -2755,6 +2789,8 @@ struct ChatDetailView: View {
                     }
                 } else if let utType = UTType(filenameExtension: url.pathExtension), utType.conforms(to: .audio) {
                     addAudioAttachment(url)
+                } else if videoSupported, let utType = UTType(filenameExtension: url.pathExtension), utType.conforms(to: .movie) {
+                    addVideoAttachment(url)
                 } else if let image = NSImage(contentsOf: url) {
                     pendingImages.append(image)
                 }
@@ -2786,6 +2822,30 @@ struct ChatDetailView: View {
         alert.runModal()
     }
 
+    /// Extract frames from a video file (off the main thread — AVFoundation
+    /// decode can be slow) and add it as a pending attachment.
+    private func addVideoAttachment(_ url: URL) {
+        let name = url.lastPathComponent
+        DispatchQueue.global(qos: .userInitiated).async {
+            let frames = VideoPreprocessor.extractFrames(url: url)
+            DispatchQueue.main.async {
+                if let frames, !frames.isEmpty {
+                    pendingVideos.append(ChatVideo(name: name, frames: frames))
+                } else {
+                    showVideoError(name)
+                }
+            }
+        }
+    }
+
+    private func showVideoError(_ name: String) {
+        let alert = NSAlert()
+        alert.messageText = "Couldn't read video"
+        alert.informativeText = "\(name) couldn't be decoded."
+        alert.alertStyle = .warning
+        alert.runModal()
+    }
+
     /// Convert pending audio clips to a ChatAudio array, clearing the list.
     private func consumePendingAudio() -> [ChatAudio]? {
         guard !pendingAudio.isEmpty else { return nil }
@@ -2798,6 +2858,19 @@ struct ChatDetailView: View {
     /// the mic button and audio-file attachment so they only appear where audio
     /// actually does something.
     private var audioSupported: Bool { server.chatModelInfo?.supportsAudio ?? false }
+
+    /// Whether the active model understands video (Qwen3-VL-family checkpoints
+    /// declaring `video_token_id`). Gates the video-attach option so it only
+    /// appears where the server can actually read it.
+    private var videoSupported: Bool { server.chatModelInfo?.supportsVideo ?? false }
+
+    /// Convert pending videos to a ChatVideo array, clearing the list.
+    private func consumePendingVideos() -> [ChatVideo]? {
+        guard !pendingVideos.isEmpty else { return nil }
+        let videos = pendingVideos
+        pendingVideos = []
+        return videos
+    }
 
     /// Mic tap handler: start recording (after a permission check), or stop and
     /// turn the captured PCM into a pending audio attachment.
@@ -3129,9 +3202,10 @@ struct ChatDetailView: View {
     private func proceedSend() {
         var text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachedImages = consumePendingImages()
+        let attachedVideos = consumePendingVideos()
         let attachedAudio = consumePendingAudio()
         let pdfText = consumePendingPDFsAsText()
-        guard !text.isEmpty || attachedImages != nil || attachedAudio != nil || !pdfText.isEmpty,
+        guard !text.isEmpty || attachedImages != nil || attachedVideos != nil || attachedAudio != nil || !pdfText.isEmpty,
               composerState != .generatingHere, server.status == .running else { return }
         inputText = ""
         if !pdfText.isEmpty {
@@ -3247,10 +3321,11 @@ struct ChatDetailView: View {
               let idx = msgs.firstIndex(where: { $0.id == messageId })
         else { return }
         let images = msgs[idx].images
+        let videos = msgs[idx].videos
         let audio = msgs[idx].audio
         appState.truncateMessages(in: sessionId, keepingFirst: idx)
         chatEngine.runTurn(sessionId: sessionId, userText: trimmed,
-                           images: images, audio: audio,
+                           images: images, videos: videos, audio: audio,
                            config: buildTurnConfig(),
                            approval: { await requestToolApproval($0) })
         // An edit is started from wherever that message sits, which is by

--- a/app/Sources/MLXServe/Views/ComposerTip.swift
+++ b/app/Sources/MLXServe/Views/ComposerTip.swift
@@ -27,12 +27,15 @@ struct ComposerTip: Equatable {
     // next to New Chat now (a session's agent is fixed once it exists), and a
     // card for a control that no longer renders is a sentence nobody can reach.
 
-    static func attachments(audioSupported: Bool) -> ComposerTip {
-        ComposerTip(
-            title: "Attach",
-            body: audioSupported
-                ? "Image, PDF or audio — or a folder to ask questions about."
-                : "Image or PDF — or a folder to ask questions about.")
+    static func attachments(audioSupported: Bool, videoSupported: Bool = false) -> ComposerTip {
+        let body: String
+        switch (videoSupported, audioSupported) {
+        case (true, true): body = "Image, video, PDF or audio — or a folder to ask questions about."
+        case (true, false): body = "Image, video or PDF — or a folder to ask questions about."
+        case (false, true): body = "Image, PDF or audio — or a folder to ask questions about."
+        case (false, false): body = "Image or PDF — or a folder to ask questions about."
+        }
+        return ComposerTip(title: "Attach", body: body)
     }
 
     static func thinking(isOn: Bool, lockedBy agent: String? = nil) -> ComposerTip {

--- a/app/Tests/MLXCoreTests/ChatPasteTests.swift
+++ b/app/Tests/MLXCoreTests/ChatPasteTests.swift
@@ -11,8 +11,8 @@ import XCTest
 /// import set, and string comparison sidesteps it entirely.
 final class ChatPasteTests: XCTestCase {
 
-    private func kind(_ ext: String, dir: Bool = false, audio: Bool = false) -> String {
-        PasteFileKind.classify(ext: ext, isDirectory: dir, audioSupported: audio).rawValue
+    private func kind(_ ext: String, dir: Bool = false, audio: Bool = false, video: Bool = false) -> String {
+        PasteFileKind.classify(ext: ext, isDirectory: dir, audioSupported: audio, videoSupported: video).rawValue
     }
 
     func testDirectoryIsFolderEvenWithAFileExtension() {
@@ -41,5 +41,18 @@ final class ChatPasteTests: XCTestCase {
     func testUnknownExtensionIsUnhandled() {
         XCTAssertEqual(kind("docx", audio: true), "unhandled")
         XCTAssertEqual(kind("", audio: true), "unhandled")
+    }
+
+    func testVideoIsGatedOnModelSupport() {
+        for ext in ["mov", "mp4", "m4v"] {
+            XCTAssertEqual(kind(ext, video: true), "video", "\(ext) should classify as video when supported")
+            // Model can't read video → don't attach it as video (and it isn't
+            // an image either, so it falls through to unhandled).
+            XCTAssertEqual(kind(ext, video: false), "unhandled", "\(ext) should be unhandled when unsupported")
+        }
+    }
+
+    func testDirectoryBeatsVideoSupportEvenWithAMovieExtension() {
+        XCTAssertEqual(kind("mov", dir: true, video: true), "folder")
     }
 }

--- a/app/Tests/MLXCoreTests/ComposerTipTests.swift
+++ b/app/Tests/MLXCoreTests/ComposerTipTests.swift
@@ -8,6 +8,7 @@ final class ComposerTipTests: XCTestCase {
 
     private var all: [ComposerTip] {
         [.attachments(audioSupported: true), .attachments(audioSupported: false),
+         .attachments(audioSupported: true, videoSupported: true), .attachments(audioSupported: false, videoSupported: true),
          .thinking(isOn: true), .thinking(isOn: false),
          .tools(isOn: true, workspace: "/tmp/w"), .tools(isOn: false, workspace: nil),
          .mcp(isOn: true), .mcp(isOn: false)]
@@ -84,6 +85,15 @@ final class ComposerTipTests: XCTestCase {
     func testAttachmentTipMentionsAudioOnlyWhenTheModelCanHearIt() {
         XCTAssertTrue(ComposerTip.attachments(audioSupported: true).body.lowercased().contains("audio"))
         XCTAssertFalse(ComposerTip.attachments(audioSupported: false).body.lowercased().contains("audio"))
+    }
+
+    /// Same dead-control class as audio, for video (Qwen3-VL-family only).
+    func testAttachmentTipMentionsVideoOnlyWhenTheModelCanSeeIt() {
+        XCTAssertTrue(ComposerTip.attachments(audioSupported: false, videoSupported: true).body.lowercased().contains("video"))
+        XCTAssertFalse(ComposerTip.attachments(audioSupported: false, videoSupported: false).body.lowercased().contains("video"))
+        // Both together — neither offer crowds out the other.
+        let both = ComposerTip.attachments(audioSupported: true, videoSupported: true).body.lowercased()
+        XCTAssertTrue(both.contains("audio") && both.contains("video"))
     }
 
     /// A card that appears the instant the pointer crosses a disc flashes five

--- a/app/Tests/MLXCoreTests/MultimodalContentTests.swift
+++ b/app/Tests/MLXCoreTests/MultimodalContentTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 @testable import MLXCore
 
-/// Unit tests for the pure multimodal content-block builder that feeds the
-/// Gemma 4 12B unified engine (image_url + input_audio + text blocks).
+/// Unit tests for the pure multimodal content-block builder (image_url +
+/// video_url + input_audio + text blocks).
 final class MultimodalContentTests: XCTestCase {
 
     private func blocks(_ any: [[String: Any]]) -> [[String: Any]] { any }
@@ -95,5 +95,36 @@ final class MultimodalContentTests: XCTestCase {
         let clip = ChatAudio(name: "x", pcm: Data(count: 16_000 * 4))
         XCTAssertEqual(clip.sampleCount, 16_000)
         XCTAssertEqual(clip.durationSeconds, 1.0, accuracy: 1e-6)
+    }
+
+    func testVideoEmitsVideoUrlBlockWithOrderedFrameDataUrls() {
+        let frames = [Data([0xFF, 0xD8, 0xFF, 1]), Data([0xFF, 0xD8, 0xFF, 2])]
+        let vid = ChatVideo(name: "clip.mov", frames: frames)
+        let out = MultimodalContent.build(text: "what happens?", images: [], videos: [vid], audio: [])
+        XCTAssertEqual(out.count, 2) // video + text
+        XCTAssertEqual(out[0]["type"] as? String, "video_url")
+        let videoDict = out[0]["video_url"] as? [String: Any]
+        let urls = videoDict?["frames"] as? [String]
+        XCTAssertEqual(urls?.count, 2)
+        XCTAssertEqual(urls?[0], "data:image/jpeg;base64,\(frames[0].base64EncodedString())")
+        XCTAssertEqual(urls?[1], "data:image/jpeg;base64,\(frames[1].base64EncodedString())")
+        XCTAssertEqual(out[1]["type"] as? String, "text")
+    }
+
+    func testImageThenVideoThenAudioThenTextOrdering() {
+        // Mirrors the server's insertion order (image block, then video block,
+        // then audio block) so a reader of the wire body sees the same order
+        // the prompt places the placeholders in.
+        let img = ChatImage(data: Data([1]))
+        let vid = ChatVideo(name: "clip.mov", frames: [Data([2])])
+        let clip = ChatAudio(name: "a.wav", pcm: Data([0, 0, 0, 0]))
+        let out = MultimodalContent.build(text: "q", images: [img], videos: [vid], audio: [clip],
+                                          preprocessImage: { _ in Data([9]) })
+        XCTAssertEqual(out.map { $0["type"] as? String }, ["image_url", "video_url", "input_audio", "text"])
+    }
+
+    func testChatVideoFrameCount() {
+        let vid = ChatVideo(name: "clip.mov", frames: [Data([1]), Data([2]), Data([3])])
+        XCTAssertEqual(vid.frameCount, 3)
     }
 }

--- a/app/Tests/MLXCoreTests/VideoPreprocessorTests.swift
+++ b/app/Tests/MLXCoreTests/VideoPreprocessorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import MLXCore
+
+/// Pins the pure frame-timing math behind chat video attachments. Unlike
+/// MiniMax-H3's reference-video sampling (`VideoGenService.refFrameTimes`,
+/// fixed 24 fps, first-N-seconds only), a chat attachment samples evenly
+/// across the WHOLE clip — a user asking "what happens in this video" wants
+/// the gist of the whole thing, not just its opening beats.
+final class VideoPreprocessorTests: XCTestCase {
+
+    func testFrameTimesSpanTheWholeDurationInclusiveOfBothEnds() {
+        let t = VideoPreprocessor.frameTimes(duration: 10, count: 5)
+        XCTAssertEqual(t.count, 5)
+        XCTAssertEqual(t[0], 0.0, accuracy: 1e-9)
+        XCTAssertEqual(t[4], 10.0, accuracy: 1e-9) // last timestamp reaches the end, not short of it
+        XCTAssertEqual(t[2], 5.0, accuracy: 1e-9) // evenly spaced midpoint
+    }
+
+    func testFrameTimesSingleFrameIsTheStart() {
+        XCTAssertEqual(VideoPreprocessor.frameTimes(duration: 30, count: 1), [0.0])
+    }
+
+    func testFrameTimesEmptyOnInvalidInput() {
+        XCTAssertTrue(VideoPreprocessor.frameTimes(duration: 0, count: 5).isEmpty)
+        XCTAssertTrue(VideoPreprocessor.frameTimes(duration: 10, count: 0).isEmpty)
+        XCTAssertTrue(VideoPreprocessor.frameTimes(duration: -1, count: 5).isEmpty)
+    }
+}

--- a/app/Tests/MLXCoreTests/VoiceModeControllerTests.swift
+++ b/app/Tests/MLXCoreTests/VoiceModeControllerTests.swift
@@ -93,7 +93,7 @@ final class VoiceModeControllerTests: XCTestCase {
         private(set) var calls: [Call] = []
         private(set) var lastApproval: ((APIClient.ToolCall) async -> Bool)?
         private(set) var stopCount = 0
-        func runTurn(sessionId: UUID, userText: String, images: [ChatImage]?, audio: [ChatAudio]?,
+        func runTurn(sessionId: UUID, userText: String, images: [ChatImage]?, videos: [ChatVideo]?, audio: [ChatAudio]?,
                      config: ChatTurnEngine.TurnConfig,
                      approval: @escaping (APIClient.ToolCall) async -> Bool) {
             calls.append(Call(sessionId: sessionId, userText: userText, config: config))

--- a/src/chat.zig
+++ b/src/chat.zig
@@ -68,12 +68,26 @@ pub const AudioData = struct {
     samples: []const u8, // Raw float32-LE bytes (n_samples * 4)
 };
 
+/// Qwen3-VL video: pre-patchified pixel_values for ALL `grid_t` temporal-patch
+/// groups, concatenated (see `qwen_vision.buildPixelValuesVideo` /
+/// `QwenVision.forwardVideo`) — the video-equivalent of `ImageData.pixels`'s
+/// Qwen merge-order layout. `grid_t` is a TEMPORAL PATCH count (raw sampled
+/// frames grouped `tps`-at-a-time), not a raw frame count; `grid_h`/`grid_w`
+/// are the shared per-frame patch grid every frame in the video was resized to.
+pub const VideoData = struct {
+    pixels: []const u8, // merge-order patches [grid_t*(grid_h*grid_w)*feat*4]
+    grid_t: u32,
+    grid_h: u32,
+    grid_w: u32,
+};
+
 pub const Message = struct {
     role: []const u8,
     content: []const u8,
     tool_calls: ?[]const ToolCall = null,
     tool_call_id: ?[]const u8 = null,
     images: ?[]const ImageData = null, // Preprocessed image data for vision
+    videos: ?[]const VideoData = null, // Preprocessed video data for vision
     audio: ?[]const AudioData = null, // Raw PCM for the unified audio embedder
     /// Reasoning the client round-trips on assistant HISTORY messages
     /// (`reasoning_content`/`reasoning` on chat completions, `thinking`

--- a/src/model_discovery.zig
+++ b/src/model_discovery.zig
@@ -998,6 +998,9 @@ pub const StubMeta = struct {
     quant_bits: u32 = 0,
     is_moe: bool = false,
     has_vision: bool = false,
+    /// Qwen3-VL-family video input: a `video_token_id` alongside `has_vision`
+    /// (video piggybacks the vision tower — see src/qwen_vision.zig).
+    has_video: bool = false,
     has_chat: bool = false,
     /// bert, or a bidirectional embedding model (EmbeddingGemma) — the stub
     /// advertises "embeddings" and no chat capabilities.
@@ -1069,6 +1072,7 @@ pub fn parseStubMeta(allocator: std.mem.Allocator, config_json: []const u8, has_
     // Vision: a `vision_config` block on a non-`_text` arch (the `_text` guard
     // skips text-only quantized checkpoints with a vestigial block).
     meta.has_vision = root.get("vision_config") != null and !std.mem.endsWith(u8, mt, "_text");
+    meta.has_video = meta.has_vision and cfgU32(root, text_cfg, "video_token_id") > 0;
     const bidirectional = blk: {
         const cfgBool = struct {
             fn get(r: std.json.ObjectMap, tc: ?std.json.ObjectMap, key: []const u8) bool {

--- a/src/mrope.zig
+++ b/src/mrope.zig
@@ -74,17 +74,20 @@ pub fn interleavedSelector(sel: []u8, mrope_section: [3]u32) void {
 }
 
 /// Faithful single-sequence, full-attention-mask port of `get_rope_index` for
-/// IMAGE inputs. `tokens` is the POST-EXPANSION id sequence (each image's single
-/// `<|image_pad|>` already expanded to its merged-grid token count). `images`
-/// lists the full patch grid per image in document order. Returns 3×seq position
-/// ids (caller owns via `RopeIndex.deinit`) and the decode delta.
-///
-/// Video tokens are not handled (returns error.VideoUnsupported) — the Qwen
-/// vision feature ships image-only in its first cut.
+/// IMAGE and VIDEO inputs. `tokens` is the POST-EXPANSION id sequence (each
+/// image/video's pad run already expanded to its merged-grid token count).
+/// `images`/`videos` list the full patch grid per block in DOCUMENT order
+/// within their own modality — the two lists are walked independently, and
+/// blocks are consumed in the order their markers appear in `tokens` (mirrors
+/// `language.py`'s `ed_image < ed_video` pick-first-marker loop: a video grid's
+/// `t` is its number of TEMPORAL PATCHES, not divided by `merge`; h/w are).
+/// Returns 3×seq position ids (caller owns via `RopeIndex.deinit`) and the
+/// decode delta.
 pub fn getRopeIndex(
     allocator: std.mem.Allocator,
     tokens: []const u32,
     images: []const ImageGrid,
+    videos: []const ImageGrid,
     image_token_id: u32,
     video_token_id: u32,
     vision_start_token_id: u32,
@@ -100,15 +103,18 @@ pub fn getRopeIndex(
     var last_max: i32 = -1;
     var st: usize = 0;
     var image_index: usize = 0;
+    var video_index: usize = 0;
 
-    // image_nums = number of vision_start tokens immediately followed by image_token.
+    // *_nums = number of vision_start tokens immediately followed by that
+    // modality's pad token.
     var image_nums: usize = 0;
+    var video_nums: usize = 0;
     {
         var i: usize = 0;
         while (i + 1 < seq) : (i += 1) {
             if (tokens[i] == vision_start_token_id) {
                 if (tokens[i + 1] == image_token_id) image_nums += 1;
-                if (tokens[i + 1] == video_token_id) return error.VideoUnsupported;
+                if (tokens[i + 1] == video_token_id) video_nums += 1;
             }
         }
     }
@@ -123,15 +129,42 @@ pub fn getRopeIndex(
         }
     }.f;
 
-    var img: usize = 0;
-    while (img < image_nums) : (img += 1) {
-        // First image-pad at/after st.
-        var ed: usize = st;
-        while (ed < seq and tokens[ed] != image_token_id) : (ed += 1) {}
-        if (ed >= seq) return error.MalformedVisionSequence;
-        if (image_index >= images.len) return error.MissingImageGrid;
-        const g = images[image_index];
-        image_index += 1;
+    var remain_images = image_nums;
+    var remain_videos = video_nums;
+    var blk: usize = 0;
+    while (blk < image_nums + video_nums) : (blk += 1) {
+        // First occurrence at/after st of each remaining modality's pad token;
+        // a modality with nothing left (or nothing found) sentinels past `seq`
+        // so it is never picked by the `<` comparison below.
+        var ed_image: usize = seq + 1;
+        if (remain_images > 0) {
+            var k = st;
+            while (k < seq and tokens[k] != image_token_id) : (k += 1) {}
+            if (k < seq) ed_image = k;
+        }
+        var ed_video: usize = seq + 1;
+        if (remain_videos > 0) {
+            var k = st;
+            while (k < seq and tokens[k] != video_token_id) : (k += 1) {}
+            if (k < seq) ed_video = k;
+        }
+        const use_image = ed_image < ed_video;
+        const ed = if (use_image) ed_image else ed_video;
+        if (ed > seq) return error.MalformedVisionSequence;
+
+        const g = if (use_image) g: {
+            if (image_index >= images.len) return error.MissingImageGrid;
+            const gg = images[image_index];
+            image_index += 1;
+            remain_images -= 1;
+            break :g gg;
+        } else g: {
+            if (video_index >= videos.len) return error.MissingVideoGrid;
+            const gg = videos[video_index];
+            video_index += 1;
+            remain_videos -= 1;
+            break :g gg;
+        };
 
         const llm_t: usize = g.t;
         const llm_h: usize = g.h / merge;
@@ -142,7 +175,7 @@ pub fn getRopeIndex(
         try appendText(&rows, allocator, st_idx, text_len);
         if (text_len > 0) last_max = st_idx + @as(i32, @intCast(text_len)) - 1;
 
-        // Image block: t = base+frame, h = base+row, w = base+col.
+        // Vision block: t = base+frame, h = base+row, w = base+col.
         const base: i32 = @as(i32, @intCast(text_len)) + st_idx;
         var ti: usize = 0;
         while (ti < llm_t) : (ti += 1) {
@@ -219,7 +252,7 @@ test "mrope get_rope_index single image text+image+text" {
     const VS = 248053;
     const tokens = [_]u32{ 10, 11, 12, VS, IMG, IMG, IMG, IMG, 248054, 20, 21 };
     const images = [_]ImageGrid{.{ .t = 1, .h = 4, .w = 4 }};
-    var ri = try getRopeIndex(a, &tokens, &images, IMG, 248057, VS, 2);
+    var ri = try getRopeIndex(a, &tokens, &images, &.{}, IMG, 248057, VS, 2);
     defer ri.deinit();
 
     const exp_t = [_]i32{ 0, 1, 2, 3, 4, 4, 4, 4, 6, 7, 8 };
@@ -234,12 +267,57 @@ test "mrope get_rope_index single image text+image+text" {
 test "mrope get_rope_index pure text is sequential on all axes" {
     const a = std.testing.allocator;
     const tokens = [_]u32{ 1, 2, 3, 4, 5 };
-    var ri = try getRopeIndex(a, &tokens, &.{}, 248056, 248057, 248053, 2);
+    var ri = try getRopeIndex(a, &tokens, &.{}, &.{}, 248056, 248057, 248053, 2);
     defer ri.deinit();
     inline for (0..3) |axis| {
         for (ri.pos[axis], 0..) |p, i| try std.testing.expectEqual(@as(i32, @intCast(i)), p);
     }
     try std.testing.expectEqual(@as(i32, 0), ri.delta); // 4+1-5
+}
+
+test "mrope get_rope_index video-only exercises the t>1 temporal loop" {
+    const a = std.testing.allocator;
+    // [A,B,C, vision_start, pad×8, TEXT, D,E] with video grid [2,4,4], merge 2 →
+    // llm_t=2 (t is NOT divided by merge), llm_h=llm_w=2 → 2*2*2=8 pad tokens.
+    // Hand-derived from get_rope_index's video branch (t,h,w = video_grid_thw[i]).
+    const VID = 248057;
+    const VS = 248053;
+    const tokens = [_]u32{ 10, 11, 12, VS, VID, VID, VID, VID, VID, VID, VID, VID, 248054, 20, 21 };
+    const videos = [_]ImageGrid{.{ .t = 2, .h = 4, .w = 4 }};
+    var ri = try getRopeIndex(a, &tokens, &.{}, &videos, 248056, VID, VS, 2);
+    defer ri.deinit();
+
+    const exp_t = [_]i32{ 0, 1, 2, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 7, 8 };
+    const exp_h = [_]i32{ 0, 1, 2, 3, 4, 4, 5, 5, 4, 4, 5, 5, 6, 7, 8 };
+    const exp_w = [_]i32{ 0, 1, 2, 3, 4, 5, 4, 5, 4, 5, 4, 5, 6, 7, 8 };
+    try std.testing.expectEqualSlices(i32, &exp_t, ri.pos[0]);
+    try std.testing.expectEqualSlices(i32, &exp_h, ri.pos[1]);
+    try std.testing.expectEqualSlices(i32, &exp_w, ri.pos[2]);
+    try std.testing.expectEqual(@as(i32, -6), ri.delta); // 9-15
+}
+
+test "mrope get_rope_index interleaved image-then-video picks the first marker" {
+    const a = std.testing.allocator;
+    // [A,B, VS, img_pad×4, VS, vid_pad×4, END]. Both grids [1,4,4] merge 2 → 4
+    // pads each, so the two blocks are shape-identical and the test isolates
+    // the interleave control flow (ed_image < ed_video picks image first, then
+    // falls through to the video block once remain_images hits 0).
+    const IMG = 248056;
+    const VID = 248057;
+    const VS = 248053;
+    const tokens = [_]u32{ 1, 2, VS, IMG, IMG, IMG, IMG, VS, VID, VID, VID, VID, 9 };
+    const images = [_]ImageGrid{.{ .t = 1, .h = 4, .w = 4 }};
+    const videos = [_]ImageGrid{.{ .t = 1, .h = 4, .w = 4 }};
+    var ri = try getRopeIndex(a, &tokens, &images, &videos, IMG, VID, VS, 2);
+    defer ri.deinit();
+
+    const exp_t = [_]i32{ 0, 1, 2, 3, 3, 3, 3, 5, 6, 6, 6, 6, 8 };
+    const exp_h = [_]i32{ 0, 1, 2, 3, 3, 4, 4, 5, 6, 6, 7, 7, 8 };
+    const exp_w = [_]i32{ 0, 1, 2, 3, 4, 3, 4, 5, 6, 7, 6, 7, 8 };
+    try std.testing.expectEqualSlices(i32, &exp_t, ri.pos[0]);
+    try std.testing.expectEqualSlices(i32, &exp_h, ri.pos[1]);
+    try std.testing.expectEqualSlices(i32, &exp_w, ri.pos[2]);
+    try std.testing.expectEqual(@as(i32, -4), ri.delta); // 9-13
 }
 
 test "mrope computeInvFreq base case" {

--- a/src/qwen_vision.zig
+++ b/src/qwen_vision.zig
@@ -345,21 +345,22 @@ pub fn imageTokenCount(resized: Resized, patch: u32, merge: u32) u32 {
     return (gh / merge) * (gw / merge);
 }
 
-/// Build the processor's `pixel_values` [N, C*tps*ps*ps] from a normalized CHW
-/// image, in merge-block token order with feature layout [C, tps, py, px] — the
-/// exact ordering of mlx-vlm's `_process_one` transpose. `img_chw` is
-/// `[C, rh, rw]` already rescaled+normalized ((x/255−0.5)/0.5). The temporal
-/// axis duplicates the single frame `tps` times. Caller owns the result.
-pub fn buildPixelValues(
+/// Build one temporal-patch group's `pixel_values` [N, C*tps*ps*ps] from `tps`
+/// REAL consecutive decoded frames, in merge-block token order with feature
+/// layout [C, tps, py, px] — the exact ordering of mlx-vlm's `_process_one`
+/// transpose. Each `frames[tt]` is `[C, rh, rw]`, already rescaled+normalized
+/// and resized to the SAME (rh, rw) as every other frame in the group (a
+/// video's whole frame set shares one patch grid). Caller owns `out`.
+pub fn buildPixelValuesVideo(
     out: []f32,
-    img_chw: []const f32,
+    frames: []const []const f32,
     C: u32,
     rh: u32,
     rw: u32,
     patch: u32,
-    tps: u32,
     merge: u32,
 ) void {
+    const tps: u32 = @intCast(frames.len);
     const gh = rh / patch;
     const gw = rw / patch;
     const mh = gh / merge;
@@ -385,14 +386,14 @@ pub fn buildPixelValues(
                     while (c < C) : (c += 1) {
                         var tt: u32 = 0;
                         while (tt < tps) : (tt += 1) {
+                            const frame = frames[tt];
                             var py: u32 = 0;
                             while (py < patch) : (py += 1) {
                                 const y = row * patch + py;
                                 var px: u32 = 0;
                                 while (px < patch) : (px += 1) {
                                     const x = col * patch + px;
-                                    // Temporal axis duplicates the single frame.
-                                    out[base + f] = img_chw[@as(usize, c) * plane + @as(usize, y) * rw + x];
+                                    out[base + f] = frame[@as(usize, c) * plane + @as(usize, y) * rw + x];
                                     f += 1;
                                 }
                             }
@@ -403,6 +404,26 @@ pub fn buildPixelValues(
             }
         }
     }
+}
+
+/// Build one still IMAGE's `pixel_values` — the `tps` slots the Conv3d-as-Linear
+/// weight expects are filled by duplicating the single frame, per Qwen's own
+/// image processor (there is no second real frame for a still image). Thin
+/// wrapper over `buildPixelValuesVideo`'s real per-frame path.
+pub fn buildPixelValues(
+    out: []f32,
+    img_chw: []const f32,
+    C: u32,
+    rh: u32,
+    rw: u32,
+    patch: u32,
+    tps: u32,
+    merge: u32,
+) void {
+    std.debug.assert(tps <= 8);
+    var reps: [8][]const f32 = undefined;
+    for (0..tps) |i| reps[i] = img_chw;
+    buildPixelValuesVideo(out, reps[0..tps], C, rh, rw, patch, merge);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1044,6 +1065,49 @@ pub const QwenVision = struct {
         try mlx.check(mlx.mlx_reshape(&out, m2, &oshape, 3, self.s));
         return out;
     }
+
+    /// Encode one VIDEO. `patches` is the concatenation of `grid_t` temporal-
+    /// patch groups' pixel_values (see `buildPixelValuesVideo`), each group's
+    /// `grid_h*grid_w` rows packed contiguously. mlx-vlm's `cu_seqlens`
+    /// boundaries fall exactly at temporal-patch-group edges — the ViT never
+    /// attends across frames — so a group is encoded by calling the existing,
+    /// UNCHANGED single-group `forward` (pos-embed and vision-rope are spatial
+    /// only and already correct per group), concatenating the merged token
+    /// outputs along the token axis.
+    pub fn forwardVideo(self: *QwenVision, patches: mlx.mlx_array, grid_t: u32, grid_h: u32, grid_w: u32) !mlx.mlx_array {
+        std.debug.assert(grid_t > 0);
+        if (grid_t == 1) return self.forward(patches, grid_h, grid_w);
+
+        const n_per_group: c_int = @intCast(grid_h * grid_w);
+        const pshape = mlx.getShape(patches);
+        std.debug.assert(pshape.len == 2);
+        const feat = pshape[1];
+
+        var parts = try self.allocator.alloc(mlx.mlx_array, grid_t);
+        defer self.allocator.free(parts);
+        var built: usize = 0;
+        errdefer for (parts[0..built]) |p| { _ = mlx.mlx_array_free(p); };
+
+        var t: u32 = 0;
+        while (t < grid_t) : (t += 1) {
+            var group = mlx.mlx_array_new();
+            defer _ = mlx.mlx_array_free(group);
+            const ti: c_int = @intCast(t);
+            const start = [_]c_int{ ti * n_per_group, 0 };
+            const stop = [_]c_int{ (ti + 1) * n_per_group, feat };
+            const strides = [_]c_int{ 1, 1 };
+            try mlx.check(mlx.mlx_slice(&group, patches, &start, 2, &stop, 2, &strides, 2, self.s));
+            parts[t] = try self.forward(group, grid_h, grid_w);
+            built += 1;
+        }
+        defer for (parts) |p| { _ = mlx.mlx_array_free(p); };
+
+        const cat_vec = mlx.mlx_vector_array_new_data(parts.ptr, parts.len);
+        defer _ = mlx.mlx_vector_array_free(cat_vec);
+        var out = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_concatenate_axis(&out, cat_vec, 1, self.s));
+        return out;
+    }
 };
 
 fn getWeightLocal(weights: *const Weights, buf: *[256]u8, name: []const u8) ?mlx.mlx_array {
@@ -1274,6 +1338,32 @@ test "qwen buildPixelValues merge-order + [C,tps,py,px] feature layout" {
     try std.testing.expectEqualSlices(f32, &expect, pv);
 }
 
+test "qwen buildPixelValuesVideo reads REAL per-frame data, not one frame duplicated" {
+    const a = std.testing.allocator;
+    // Two distinct 2x2 "frames" (single channel, patch=1, merge=2 → one token
+    // covering the whole 2x2 grid). frame0[y,x] = y*10+x; frame1 = frame0+1000
+    // so the two temporal slots are trivially distinguishable in the output.
+    const C: u32 = 1;
+    const rh: u32 = 2;
+    const rw: u32 = 2;
+    var f0: [4]f32 = .{ 0, 1, 10, 11 };
+    var f1: [4]f32 = .{ 1000, 1001, 1010, 1011 };
+    const frames = [_][]const f32{ &f0, &f1 };
+    const pv = try a.alloc(f32, 4 * 2); // 4 tokens × feat 2 (C*tps*1*1)
+    defer a.free(pv);
+    buildPixelValuesVideo(pv, &frames, C, rh, rw, 1, 2);
+    // Merge-block order over the single 2x2 block; each token's feature is
+    // [frame0_px, frame1_px] — proving both real frames land in the output,
+    // not one frame duplicated tps times (that would make both slots equal).
+    const expect = [_]f32{
+        0,    1000, // token0 row0col0
+        1,    1001, // token1 row0col1
+        10,   1010, // token2 row1col0
+        11,   1011, // token3 row1col1
+    };
+    try std.testing.expectEqualSlices(f32, &expect, pv);
+}
+
 test "qwen image token count" {
     try std.testing.expectEqual(@as(u32, 576), imageTokenCount(.{ .h = 768, .w = 768 }, 16, 2));
     try std.testing.expectEqual(@as(u32, 972), imageTokenCount(.{ .h = 1152, .w = 864 }, 16, 2));
@@ -1474,4 +1564,149 @@ test "qwen vision parity vs reference embeddings (QWEN_VISION_TEST_MODEL)" {
     // real bugs (a structural bug blows up mean_abs by 10-100x).
     try std.testing.expect(mean_abs < 0.02);
     try std.testing.expect(gt_030 < ref.len / 1000); // <0.1% of elements may exceed 0.30
+}
+
+test "qwen forwardVideo == per-group forward()+concat (self-consistency)" {
+    // No hermetic reference exists for ViT-forward CORRECTNESS (that needs a
+    // trained checkpoint — see the QWEN_VISION_TEST_MODEL-gated parity test
+    // above). What IS hermetically checkable, and what's new in this task, is
+    // the forwardVideo WRAPPER: does it slice `grid_t` temporal-patch groups
+    // out of the concatenated patches array and route each through the
+    // existing, unmodified single-group `forward` correctly? This builds a
+    // tiny synthetic tower (weight VALUES are arbitrary) and asserts
+    // forwardVideo(3 groups) is bit-identical to manually slicing+forward()ing
+    // each group and concatenating — the exact operation forwardVideo performs
+    // internally, so any slicing/indexing bug in the wrapper shows up here.
+    const a = std.testing.allocator;
+    const s = mlx.mlx_default_gpu_stream_new();
+
+    const mkArr = struct {
+        fn f(shape: []const c_int, val_base: f32) mlx.mlx_array {
+            var buf: [64]f32 = undefined;
+            var total: usize = 1;
+            for (shape) |d| total *= @intCast(d);
+            for (0..total) |i| buf[i] = val_base + @as(f32, @floatFromInt(i)) * 0.01;
+            return mlx.mlx_array_new_data(&buf, shape.ptr, @intCast(shape.len), .float32);
+        }
+    }.f;
+
+    // hidden=4, 1 head of head_dim=4, depth=1, merge=1 (no reduction — keeps
+    // token counts trivial), grid 2x2 (n=4 patches/group) matching
+    // num_grid_per_side=2 exactly (identity pos-embed interpolation).
+    const hidden = [_]c_int{4};
+    const hidden2 = [_]c_int{ 4, 4 };
+    const qkv_w_shape = [_]c_int{ 12, 4 };
+    const qkv_b_shape = [_]c_int{12};
+    const patch_w_shape = [_]c_int{ 4, 1 };
+    const pos_shape = [_]c_int{ 4, 4 };
+
+    var qv = QwenVision{
+        .s = s,
+        .allocator = a,
+        .depth = 1,
+        .hidden = 4,
+        .heads = 1,
+        .head_dim = 4,
+        .merge = 1,
+        .num_grid_per_side = 2,
+        .out_hidden = 4,
+        .patch_w = mkArr(&patch_w_shape, 0.1),
+        .patch_b = mkArr(&hidden, 0.0),
+        .pos_embed = mkArr(&pos_shape, 0.2),
+        .blocks = try a.alloc(QBlock, 1),
+        .merger_norm_w = mkArr(&hidden, 1.0),
+        .merger_norm_b = mkArr(&hidden, 0.0),
+        .merger_fc1_w = mkArr(&hidden2, 0.05),
+        .merger_fc1_b = mkArr(&hidden, 0.0),
+        .merger_fc2_w = mkArr(&hidden2, 0.05),
+        .merger_fc2_b = mkArr(&hidden, 0.0),
+    };
+    qv.blocks[0] = .{
+        .norm1_w = mkArr(&hidden, 1.0),
+        .norm1_b = mkArr(&hidden, 0.0),
+        .norm2_w = mkArr(&hidden, 1.0),
+        .norm2_b = mkArr(&hidden, 0.0),
+        .qkv_w = mkArr(&qkv_w_shape, 0.03),
+        .qkv_b = mkArr(&qkv_b_shape, 0.0),
+        .proj_w = mkArr(&hidden2, 0.04),
+        .proj_b = mkArr(&hidden, 0.0),
+        .fc1_w = mkArr(&hidden2, 0.02),
+        .fc1_b = mkArr(&hidden, 0.0),
+        .fc2_w = mkArr(&hidden2, 0.02),
+        .fc2_b = mkArr(&hidden, 0.0),
+    };
+    defer {
+        _ = mlx.mlx_array_free(qv.patch_w);
+        _ = mlx.mlx_array_free(qv.patch_b);
+        _ = mlx.mlx_array_free(qv.pos_embed);
+        _ = mlx.mlx_array_free(qv.merger_norm_w);
+        _ = mlx.mlx_array_free(qv.merger_norm_b);
+        _ = mlx.mlx_array_free(qv.merger_fc1_w);
+        _ = mlx.mlx_array_free(qv.merger_fc1_b);
+        _ = mlx.mlx_array_free(qv.merger_fc2_w);
+        _ = mlx.mlx_array_free(qv.merger_fc2_b);
+        for (qv.blocks) |b| {
+            _ = mlx.mlx_array_free(b.norm1_w);
+            _ = mlx.mlx_array_free(b.norm1_b);
+            _ = mlx.mlx_array_free(b.norm2_w);
+            _ = mlx.mlx_array_free(b.norm2_b);
+            _ = mlx.mlx_array_free(b.qkv_w);
+            _ = mlx.mlx_array_free(b.qkv_b);
+            _ = mlx.mlx_array_free(b.proj_w);
+            _ = mlx.mlx_array_free(b.proj_b);
+            _ = mlx.mlx_array_free(b.fc1_w);
+            _ = mlx.mlx_array_free(b.fc1_b);
+            _ = mlx.mlx_array_free(b.fc2_w);
+            _ = mlx.mlx_array_free(b.fc2_b);
+        }
+        a.free(qv.blocks);
+    }
+
+    // grid_t=3 groups of a 2x2 grid (n=4 patches/group, feat=1) — 12 rows total.
+    const grid_t: u32 = 3;
+    const n_per_group: usize = 4;
+    var patches_buf: [12]f32 = undefined;
+    for (0..12) |i| patches_buf[i] = @as(f32, @floatFromInt(i)) * 0.1;
+    const all_shape = [_]c_int{ 12, 1 };
+    const patches_all = mlx.mlx_array_new_data(&patches_buf, &all_shape, 2, .float32);
+    defer _ = mlx.mlx_array_free(patches_all);
+
+    const out_video = try qv.forwardVideo(patches_all, grid_t, 2, 2);
+    defer _ = mlx.mlx_array_free(out_video);
+
+    // Manual reference: slice each group from the SAME source buffer, call
+    // forward() directly, concatenate along the token axis.
+    var manual_parts: [3]mlx.mlx_array = undefined;
+    for (0..grid_t) |g| {
+        const group_shape = [_]c_int{ @intCast(n_per_group), 1 };
+        const group_arr = mlx.mlx_array_new_data(patches_buf[g * n_per_group ..].ptr, &group_shape, 2, .float32);
+        defer _ = mlx.mlx_array_free(group_arr);
+        manual_parts[g] = try qv.forward(group_arr, 2, 2);
+    }
+    defer for (manual_parts) |p| { _ = mlx.mlx_array_free(p); };
+    const cat_vec = mlx.mlx_vector_array_new_data(&manual_parts, manual_parts.len);
+    defer _ = mlx.mlx_vector_array_free(cat_vec);
+    var out_manual = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(out_manual);
+    try mlx.check(mlx.mlx_concatenate_axis(&out_manual, cat_vec, 1, s));
+
+    var v_f32 = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(v_f32);
+    try mlx.check(mlx.mlx_astype(&v_f32, out_video, .float32, s));
+    try mlx.check(mlx.mlx_array_eval(v_f32));
+    var m_f32 = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(m_f32);
+    try mlx.check(mlx.mlx_astype(&m_f32, out_manual, .float32, s));
+    try mlx.check(mlx.mlx_array_eval(m_f32));
+
+    const v_shape = mlx.getShape(v_f32);
+    const m_shape = mlx.getShape(m_f32);
+    try std.testing.expectEqualSlices(c_int, m_shape, v_shape);
+    try std.testing.expectEqual(@as(c_int, 1), v_shape[0]);
+    try std.testing.expectEqual(@as(c_int, 12), v_shape[1]); // 3 groups × 4 merged tokens (merge=1)
+
+    const v_data = mlx.mlx_array_data_float32(v_f32) orelse return error.TestUnexpectedNullData;
+    const m_data = mlx.mlx_array_data_float32(m_f32) orelse return error.TestUnexpectedNullData;
+    const total: usize = 12 * 4; // tokens × out_hidden
+    try std.testing.expectEqualSlices(f32, m_data[0..total], v_data[0..total]);
 }

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -840,6 +840,16 @@ pub const VisionImagePixels = struct {
     grid_w: u32 = 0,
 };
 
+/// Qwen3-VL video: pre-patchified pixel_values for ALL `grid_t` temporal-patch
+/// groups, concatenated (see `qwen_vision.buildPixelValuesVideo`). Borrowed;
+/// must outlive the encodeVision call.
+pub const VisionVideoPixels = struct {
+    pixels: []const u8,
+    grid_t: u32,
+    grid_h: u32,
+    grid_w: u32,
+};
+
 /// Phase A4: vision-encode work item. Conn thread fills `images` (raw pixel
 /// data, CPU-only) and calls `Scheduler.encodeVision`, which posts the
 /// request and blocks until the inference thread fills `result` and signals
@@ -853,17 +863,23 @@ pub const VisionEncodeRequest = struct {
     model: *model_registry_mod.LoadedModel,
     /// Per-image float32 CHW pixel buffers. Borrowed; must outlive the call.
     images: []const VisionImagePixels,
+    /// Per-video pre-patchified pixel buffers. Borrowed; must outlive the call.
+    /// Qwen-only (video_token_id != 0) — empty on every other arch.
+    videos: []const VisionVideoPixels = &.{},
     /// Gemma 4 12B unified audio: per-clip raw float32-LE 16 kHz mono sample
     /// buffers. Borrowed; must outlive the call. The inference thread frames
     /// each into 640-sample tokens and projects them through the audio embedder.
     audio: []const []const u8 = &.{},
-    /// Output: encoded embedding tensor on success — vision soft tokens followed
-    /// by audio soft tokens, concatenated along the token axis. Ownership
-    /// transfers to the caller.
+    /// Output: encoded embedding tensor on success — vision soft tokens, then
+    /// video soft tokens, then audio soft tokens, concatenated along the token
+    /// axis (matches the prompt's image/video/audio block insertion order).
+    /// Ownership transfers to the caller.
     result: ?mlx.mlx_array = null,
-    /// Output: number of vision / audio soft tokens in `result` (in that order).
-    /// The caller inserts exactly this many image / audio placeholders.
+    /// Output: number of vision / video / audio soft tokens in `result` (in
+    /// that order). The caller inserts exactly this many image / video / audio
+    /// placeholders.
     n_vision_tokens: usize = 0,
+    n_video_tokens: usize = 0,
     n_audio_tokens: usize = 0,
     /// Output: error name on failure. Owned by `allocator`; caller frees.
     error_name: ?[]const u8 = null,
@@ -3882,14 +3898,15 @@ fn runVisionEncode(sch: *Scheduler, req: *VisionEncodeRequest) void {
         finishVisionRequest(sch, req, "VisionEncoderNotLoaded");
         return;
     };
-    if (req.images.len == 0 and req.audio.len == 0) {
+    if (req.images.len == 0 and req.videos.len == 0 and req.audio.len == 0) {
         finishVisionRequest(sch, req, "EmptyImages");
         return;
     }
 
-    // Encode all soft tokens into `emb_parts`: vision first, then audio, so the
-    // single splice channel scatters them in the same order as the placeholder
-    // blocks the conn thread injected (image block before audio block).
+    // Encode all soft tokens into `emb_parts`: vision, then video, then audio,
+    // so the single splice channel scatters them in the same order as the
+    // placeholder blocks the conn thread injected (image block, then video
+    // block, then audio block).
     var emb_parts = std.ArrayList(mlx.mlx_array).empty;
     defer emb_parts.deinit(req.allocator);
     const failParts = struct {
@@ -3927,6 +3944,26 @@ fn runVisionEncode(sch: *Scheduler, req: *VisionEncodeRequest) void {
         }
         const es = mlx.getShape(emb);
         n_vision += @intCast(es[1]);
+        emb_parts.append(req.allocator, emb) catch |err| {
+            _ = mlx.mlx_array_free(emb);
+            failParts(sch, req, emb_parts.items, @errorName(err));
+            return;
+        };
+    }
+
+    var n_video: usize = 0;
+    for (req.videos) |vid| {
+        const n: usize = @as(usize, vid.grid_t) * vid.grid_h * vid.grid_w;
+        const feat: usize = (vid.pixels.len / 4) / n;
+        const shape = [_]c_int{ @intCast(n), @intCast(feat) };
+        const pixel_arr = mlx.mlx_array_new_data(vid.pixels.ptr, &shape, 2, .float32);
+        defer _ = mlx.mlx_array_free(pixel_arr);
+        const emb = vision_enc.forwardVideoPatches(pixel_arr, vid.grid_t, vid.grid_h, vid.grid_w) catch |err| {
+            failParts(sch, req, emb_parts.items, @errorName(err));
+            return;
+        };
+        const es = mlx.getShape(emb);
+        n_video += @intCast(es[1]);
         emb_parts.append(req.allocator, emb) catch |err| {
             _ = mlx.mlx_array_free(emb);
             failParts(sch, req, emb_parts.items, @errorName(err));
@@ -3995,6 +4032,7 @@ fn runVisionEncode(sch: *Scheduler, req: *VisionEncodeRequest) void {
     defer req.done_mu.unlock(sch.io);
     req.result = combined;
     req.n_vision_tokens = n_vision;
+    req.n_video_tokens = n_video;
     req.n_audio_tokens = n_audio;
     req.done = true;
     req.done_cond.broadcast(sch.io);

--- a/src/server.zig
+++ b/src/server.zig
@@ -3422,6 +3422,7 @@ fn renderModelEntry(
         defer mods.deinit(allocator);
         try mods.appendSlice(allocator, "[\"text\"");
         if (has_vision) try mods.appendSlice(allocator, ",\"image\"");
+        if (has_vision and config.video_token_id != 0) try mods.appendSlice(allocator, ",\"video\"");
         if (has_audio) try mods.appendSlice(allocator, ",\"audio\"");
         try mods.append(allocator, ']');
 
@@ -3579,7 +3580,9 @@ fn renderModelEntry(
     };
     defer allocator.free(caps_part);
 
-    const mods_part: []const u8 = if (sm.found and sm.has_vision)
+    const mods_part: []const u8 = if (sm.found and sm.has_vision and sm.has_video)
+        ",\"input_modalities\":[\"text\",\"image\",\"video\"]"
+    else if (sm.found and sm.has_vision)
         ",\"input_modalities\":[\"text\",\"image\"]"
     else if ((sm.found and sm.has_chat) or is_gguf_stub)
         ",\"input_modalities\":[\"text\"]"
@@ -4923,11 +4926,13 @@ fn handleChatCompletions(
         // Content can be null for assistant messages with tool_calls
         const content_val = obj.get("content");
         var msg_images: ?[]const chat_mod.ImageData = null;
+        var msg_videos: ?[]const chat_mod.VideoData = null;
         var msg_audio: ?[]const chat_mod.AudioData = null;
         const content: []const u8 = if (content_val) |cv| switch (cv) {
             .string => |s| s,
             .array => |arr| blk: {
                 var image_list = std.ArrayList(chat_mod.ImageData).empty;
+                var video_list = std.ArrayList(chat_mod.VideoData).empty;
                 var audio_list = std.ArrayList(chat_mod.AudioData).empty;
                 for (arr.items) |part| {
                     if (part != .object) continue;
@@ -4940,6 +4945,21 @@ fn handleChatCompletions(
                         const url_val = img_obj.object.get("url") orelse continue;
                         if (url_val != .string) continue;
                         appendImageUrlContent(allocator, &image_list, url_val.string, visionPreprocFromConfig(config));
+                    } else if (std.mem.eql(u8, ptype.string, "video_url")) {
+                        // A video is, on the wire, an ordered array of already-
+                        // decoded frame images — no video codec exists anywhere
+                        // in this codebase, so frame extraction is the CLIENT's
+                        // job. Each frame string is an ordinary image data URL.
+                        const vid_obj = part.object.get("video_url") orelse continue;
+                        if (vid_obj != .object) continue;
+                        const frames_val = vid_obj.object.get("frames") orelse continue;
+                        if (frames_val != .array) continue;
+                        var frame_urls = std.ArrayList([]const u8).empty;
+                        defer frame_urls.deinit(allocator);
+                        for (frames_val.array.items) |f| {
+                            if (f == .string) frame_urls.append(allocator, f.string) catch continue;
+                        }
+                        appendVideoUrlContent(allocator, &video_list, frame_urls.items, visionPreprocFromConfig(config));
                     } else if (std.mem.eql(u8, ptype.string, "input_audio")) {
                         // OpenAI-style audio block. For the Gemma 4 12B unified
                         // engine the client sends raw 16 kHz mono float32-LE PCM
@@ -4960,6 +4980,11 @@ fn handleChatCompletions(
                     msg_images = image_list.toOwnedSlice(allocator) catch null;
                 } else {
                     image_list.deinit(allocator);
+                }
+                if (video_list.items.len > 0) {
+                    msg_videos = video_list.toOwnedSlice(allocator) catch null;
+                } else {
+                    video_list.deinit(allocator);
                 }
                 if (audio_list.items.len > 0) {
                     msg_audio = audio_list.toOwnedSlice(allocator) catch null;
@@ -5015,8 +5040,8 @@ fn handleChatCompletions(
         else
             null;
 
-        // Skip messages with no content, no tool_calls, and no images/audio
-        if (content.len == 0 and msg_tool_calls == null and msg_images == null and msg_audio == null and msg_reasoning == null and !std.mem.eql(u8, role_val.string, "tool")) continue;
+        // Skip messages with no content, no tool_calls, and no images/videos/audio
+        if (content.len == 0 and msg_tool_calls == null and msg_images == null and msg_videos == null and msg_audio == null and msg_reasoning == null and !std.mem.eql(u8, role_val.string, "tool")) continue;
 
         try messages.append(allocator, .{
             .role = role_val.string,
@@ -5024,6 +5049,7 @@ fn handleChatCompletions(
             .tool_calls = msg_tool_calls,
             .tool_call_id = tool_call_id,
             .images = msg_images,
+            .videos = msg_videos,
             .audio = msg_audio,
             .reasoning_content = msg_reasoning,
         });
@@ -5389,13 +5415,14 @@ fn handleChatCompletions(
     }
     if (lm.vision_encoder) |ve| {
         var n_vis: usize = 0;
+        var n_vid: usize = 0;
         var n_aud: usize = 0;
-        local_ve = processVisionImages(allocator, lm, ve, messages.items, &n_vis, &n_aud) catch |err| blk: {
+        local_ve = processVisionImages(allocator, lm, ve, messages.items, &n_vis, &n_vid, &n_aud) catch |err| blk: {
             log.warn("Vision encoding failed: {}\n", .{err});
             break :blk null;
         };
         if (local_ve != null) {
-            const new_ids = try insertMultimodalTokens(allocator, prompt_ids_raw, config.image_token_id, n_vis, config.audio_token_id, n_aud, config, messages.items);
+            const new_ids = try insertMultimodalTokens(allocator, prompt_ids_raw, config.image_token_id, n_vis, config.video_token_id, n_vid, config.audio_token_id, n_aud, config, messages.items);
             allocator.free(prompt_ids_raw);
             prompt_ids_raw = new_ids;
         }
@@ -8516,6 +8543,26 @@ test "every continuation surface consults continuationRejectReason before render
     try std.testing.expectEqual(@as(usize, 2), count);
 }
 
+test "every input_modalities gate that advertises image beside a video-capable model also advertises video" {
+    // Video piggybacks the SAME "does this model take image input?" signal —
+    // Qwen3-VL-family checkpoints declare `video_token_id` alongside
+    // `vision_config`/`vision_encoder` — so a future edit to either the READY
+    // (live config) or STUB (unloaded, config.json-only) input_modalities
+    // builder that touches the image gate but forgets video would silently
+    // under-report every video-capable model to the app forever (the attach
+    // menu's video option reads exactly this field). Two independent checks:
+    // the two sites read DIFFERENT underlying signals (config.video_token_id
+    // vs StubMeta.has_video) and must each carry their own gate.
+    const src = @embedFile("server.zig");
+
+    const ready_anchor = "if (has_vision) try mods.appendSlice(allocator, ";
+    const ready_at = std.mem.indexOf(u8, src, ready_anchor) orelse return error.ReadyImageGateMissing;
+    const ready_window = src[ready_at .. ready_at + 260];
+    try std.testing.expect(std.mem.indexOf(u8, ready_window, "video_token_id") != null);
+
+    try std.testing.expect(std.mem.indexOf(u8, src, "sm.found and sm.has_vision and sm.has_video") != null);
+}
+
 test "routeExists answers endpoint existence without consulting the model" {
     // Whether a path EXISTS has nothing to do with which models are loaded, but
     // model resolution runs ahead of dispatch — so on a headless boot (`--serve
@@ -9351,30 +9398,35 @@ fn processVisionImages(
     vision_enc: *VisionEncoder,
     msgs: []const chat_mod.Message,
     out_n_vision: *usize,
+    out_n_video: *usize,
     out_n_audio: *usize,
 ) !?mlx.mlx_array {
     out_n_vision.* = 0;
+    out_n_video.* = 0;
     out_n_audio.* = 0;
     // Only process media from the LAST user message. Previous turns' images /
-    // audio were already processed in their original request; re-processing
-    // wastes context and causes stale feature confusion.
+    // videos / audio were already processed in their original request;
+    // re-processing wastes context and causes stale feature confusion.
     var last_user_images: ?[]const chat_mod.ImageData = null;
+    var last_user_videos: ?[]const chat_mod.VideoData = null;
     var last_user_audio: ?[]const chat_mod.AudioData = null;
     var i = msgs.len;
     while (i > 0) {
         i -= 1;
         if (std.mem.eql(u8, msgs[i].role, "user")) {
             last_user_images = msgs[i].images;
+            last_user_videos = msgs[i].videos;
             last_user_audio = msgs[i].audio;
             break;
         }
     }
 
     const images: []const chat_mod.ImageData = last_user_images orelse &.{};
+    const videos: []const chat_mod.VideoData = last_user_videos orelse &.{};
     const audio: []const chat_mod.AudioData = last_user_audio orelse &.{};
-    if (images.len == 0 and audio.len == 0) return null;
+    if (images.len == 0 and videos.len == 0 and audio.len == 0) return null;
 
-    log.info("Multimodal: processing {d} image(s), {d} audio clip(s)\n", .{ images.len, audio.len });
+    log.info("Multimodal: processing {d} image(s), {d} video(s), {d} audio clip(s)\n", .{ images.len, videos.len, audio.len });
 
     // Phase A4: route encoding to the scheduler's inference thread when
     // available. Conn thread only decodes pixels/PCM (CPU); the mlx ops
@@ -9393,6 +9445,17 @@ fn processVisionImages(
                 .grid_w = img.grid_w,
             });
         }
+        var vid_list = std.ArrayList(scheduler_mod.VisionVideoPixels).empty;
+        defer vid_list.deinit(allocator);
+        try vid_list.ensureTotalCapacity(allocator, videos.len);
+        for (videos) |vid| {
+            vid_list.appendAssumeCapacity(.{
+                .pixels = vid.pixels,
+                .grid_t = vid.grid_t,
+                .grid_h = vid.grid_h,
+                .grid_w = vid.grid_w,
+            });
+        }
         var aud_list = std.ArrayList([]const u8).empty;
         defer aud_list.deinit(allocator);
         try aud_list.ensureTotalCapacity(allocator, audio.len);
@@ -9400,6 +9463,7 @@ fn processVisionImages(
         var req = scheduler_mod.VisionEncodeRequest{
             .model = lm,
             .images = pix_list.items,
+            .videos = vid_list.items,
             .audio = aud_list.items,
             .allocator = allocator,
         };
@@ -9411,10 +9475,11 @@ fn processVisionImages(
             return err;
         };
         out_n_vision.* = req.n_vision_tokens;
+        out_n_video.* = req.n_video_tokens;
         out_n_audio.* = req.n_audio_tokens;
         const ve_shape = mlx.getShape(arr);
         if (ve_shape.len >= 3) {
-            log.info("  Multimodal: → [{d},{d},{d}] tokens ({d} vision + {d} audio)\n", .{ ve_shape[0], ve_shape[1], ve_shape[2], req.n_vision_tokens, req.n_audio_tokens });
+            log.info("  Multimodal: → [{d},{d},{d}] tokens ({d} vision + {d} video + {d} audio)\n", .{ ve_shape[0], ve_shape[1], ve_shape[2], req.n_vision_tokens, req.n_video_tokens, req.n_audio_tokens });
         }
         return arr;
     }
@@ -9447,6 +9512,18 @@ fn processVisionImages(
         }
         const es = mlx.getShape(emb);
         out_n_vision.* += @intCast(es[1]);
+        try emb_parts.append(allocator, emb);
+    }
+
+    for (videos) |vid| {
+        const n: usize = @as(usize, vid.grid_t) * vid.grid_h * vid.grid_w;
+        const feat: usize = (vid.pixels.len / 4) / n;
+        const shape = [_]c_int{ @intCast(n), @intCast(feat) };
+        const pixel_arr = mlx.mlx_array_new_data(vid.pixels.ptr, &shape, 2, .float32);
+        defer _ = mlx.mlx_array_free(pixel_arr);
+        const emb = try vision_enc.forwardVideoPatches(pixel_arr, vid.grid_t, vid.grid_h, vid.grid_w);
+        const es = mlx.getShape(emb);
+        out_n_video.* += @intCast(es[1]);
         try emb_parts.append(allocator, emb);
     }
 
@@ -9578,22 +9655,29 @@ pub const MropeData = struct {
 /// model isn't Qwen-vision or there are no images. Caller owns `pos`.
 fn computeQwenMrope(allocator: std.mem.Allocator, prompt_ids: []const u32, msgs: []const chat_mod.Message, config: *const model_mod.ModelConfig) !MropeData {
     if (!config.qwen_vision) return .{};
-    // Collect the last user message's image grids (full patch grid per image).
-    var grids = std.ArrayList(mrope_mod.ImageGrid).empty;
-    defer grids.deinit(allocator);
+    // Collect the last user message's image AND video grids (full patch grid
+    // per block, in their own modality's document order — getRopeIndex
+    // interleaves the two lists by whichever marker occurs first in tokens).
+    var image_grids = std.ArrayList(mrope_mod.ImageGrid).empty;
+    defer image_grids.deinit(allocator);
+    var video_grids = std.ArrayList(mrope_mod.ImageGrid).empty;
+    defer video_grids.deinit(allocator);
     var i = msgs.len;
     while (i > 0) {
         i -= 1;
         if (std.mem.eql(u8, msgs[i].role, "user")) {
             if (msgs[i].images) |imgs| for (imgs) |im| {
-                if (im.grid_h > 0) try grids.append(allocator, .{ .t = 1, .h = im.grid_h, .w = im.grid_w });
+                if (im.grid_h > 0) try image_grids.append(allocator, .{ .t = 1, .h = im.grid_h, .w = im.grid_w });
+            };
+            if (msgs[i].videos) |vids| for (vids) |vd| {
+                try video_grids.append(allocator, .{ .t = vd.grid_t, .h = vd.grid_h, .w = vd.grid_w });
             };
             break;
         }
     }
-    if (grids.items.len == 0) return .{};
+    if (image_grids.items.len == 0 and video_grids.items.len == 0) return .{};
 
-    var ri = mrope_mod.getRopeIndex(allocator, prompt_ids, grids.items, config.image_token_id, config.video_token_id, config.vision_start_token_id, config.qv_merge) catch |err| {
+    var ri = mrope_mod.getRopeIndex(allocator, prompt_ids, image_grids.items, video_grids.items, config.image_token_id, config.video_token_id, config.vision_start_token_id, config.qv_merge) catch |err| {
         log.warn("M-RoPE get_rope_index failed ({s}); falling back to scalar RoPE\n", .{@errorName(err)});
         return .{};
     };
@@ -9603,7 +9687,7 @@ fn computeQwenMrope(allocator: std.mem.Allocator, prompt_ids: []const u32, msgs:
     @memcpy(flat[0..total], ri.pos[0]);
     @memcpy(flat[total .. 2 * total], ri.pos[1]);
     @memcpy(flat[2 * total .. 3 * total], ri.pos[2]);
-    log.info("  M-RoPE: {d} images, position ids over {d} tokens, decode delta {d}\n", .{ grids.items.len, total, ri.delta });
+    log.info("  M-RoPE: {d} images, {d} videos, position ids over {d} tokens, decode delta {d}\n", .{ image_grids.items.len, video_grids.items.len, total, ri.delta });
     return .{ .pos = flat, .total = total, .delta = ri.delta };
 }
 
@@ -9676,20 +9760,23 @@ fn insertMultimodalTokens(
     prompt_ids: []const u32,
     image_token_id: u32,
     n_image: usize,
+    video_token_id: u32,
+    n_video: usize,
     audio_token_id: u32,
     n_audio: usize,
     config: *const model_mod.ModelConfig,
     msgs: []const chat_mod.Message,
 ) ![]u32 {
     const want_image = image_token_id != 0 and n_image > 0;
+    const want_video = video_token_id != 0 and n_video > 0;
     const want_audio = audio_token_id != 0 and n_audio > 0;
-    if (!want_image and !want_audio) return try allocator.dupe(u32, prompt_ids);
+    if (!want_image and !want_video and !want_audio) return try allocator.dupe(u32, prompt_ids);
 
     const insert_pos = userTurnInsertPos(prompt_ids, config);
 
-    // Qwen3-VL wraps the image-pad run with <|vision_start|>/<|vision_end|>
-    // (get_rope_index keys on vision_start immediately followed by image tokens);
-    // Gemma uses BOI/EOI.
+    // Qwen3-VL wraps the image-pad run (and, identically, the video-pad run)
+    // with <|vision_start|>/<|vision_end|> (get_rope_index keys on vision_start
+    // immediately followed by an image OR video token); Gemma uses BOI/EOI.
     const boi = if (config.qwen_vision) config.vision_start_token_id else config.boi_token_id;
     const eoi = if (config.qwen_vision) config.vision_end_token_id else config.eoi_token_id;
     const boa = config.boa_token_id;
@@ -9709,6 +9796,11 @@ fn insertMultimodalTokens(
             if (eoi > 0) try seg.append(allocator, eoi);
         }
     }
+    if (want_video) {
+        if (boi > 0) try seg.append(allocator, boi);
+        try seg.appendNTimes(allocator, video_token_id, n_video);
+        if (eoi > 0) try seg.append(allocator, eoi);
+    }
     if (want_audio) {
         if (boa > 0) try seg.append(allocator, boa);
         try seg.appendNTimes(allocator, audio_token_id, n_audio);
@@ -9721,7 +9813,7 @@ fn insertMultimodalTokens(
     @memcpy(result[insert_pos .. insert_pos + seg.items.len], seg.items);
     @memcpy(result[insert_pos + seg.items.len ..], prompt_ids[insert_pos..]);
 
-    log.info("  Inserted {d} image + {d} audio soft tokens at position {d} (prompt: {d} -> {d} tokens)\n", .{ n_image, n_audio, insert_pos, prompt_ids.len, new_len });
+    log.info("  Inserted {d} image + {d} video + {d} audio soft tokens at position {d} (prompt: {d} -> {d} tokens)\n", .{ n_image, n_video, n_audio, insert_pos, prompt_ids.len, new_len });
     return result;
 }
 
@@ -10188,6 +10280,108 @@ fn decodeImageToPixels(allocator: std.mem.Allocator, encoded: []const u8, vp: ch
 
     log.info("  Decoded {d}x{d} image → {d}x{d} float32 CHW\n", .{ src_w, src_h, target, target });
     return .{ .pixels = out_buf, .width = target, .height = target };
+}
+
+/// Decode a `video_url` block's `frames` array — already-decoded-by-the-client
+/// JPEG/PNG data URLs, one per sampled frame; no video codec exists anywhere in
+/// this codebase, so frame extraction is the client's job — into ONE
+/// `chat_mod.VideoData`. All frames share ONE smart-resize target, computed
+/// from the FIRST frame and applied to every frame (a video's whole patch grid
+/// must be identical across frames), then grouped into `vp.tps`-sized temporal-
+/// patch groups — the last group pads by repeating its final frame, matching
+/// HF's video processor. Qwen-only: the only family declaring `video_token_id`.
+fn decodeVideoUrlContent(allocator: std.mem.Allocator, frame_urls: []const []const u8, vp: chat_mod.VisionPreproc) ?chat_mod.VideoData {
+    if (vp.mode != .qwen or frame_urls.len == 0) return null;
+    const factor = std.math.mul(u32, vp.patch, vp.merge) catch return null;
+    if (factor == 0 or vp.tps == 0 or vp.tps > 8) return null;
+
+    // Decode every frame to RGB8 first — frame 0's natural size decides the
+    // resize target every later frame must also resize to.
+    var decoded = std.ArrayList(DecodedRgb).empty;
+    defer {
+        for (decoded.items) |d| d.deinit(allocator);
+        decoded.deinit(allocator);
+    }
+    for (frame_urls) |url| {
+        const sep = std.mem.indexOf(u8, url, ";base64,") orelse return null;
+        const b64 = url[sep + 8 ..];
+        const decoded_size = std.base64.standard.Decoder.calcSizeForSlice(b64) catch return null;
+        const raw = allocator.alloc(u8, decoded_size) catch return null;
+        defer allocator.free(raw);
+        std.base64.standard.Decoder.decode(raw, b64) catch return null;
+        const rgb = decodeRgbOwned(allocator, raw) orelse return null;
+        decoded.append(allocator, rgb) catch {
+            rgb.deinit(allocator);
+            return null;
+        };
+    }
+
+    const min_pixels = if (vp.min_pixels > 0) vp.min_pixels else qwen_vision.MIN_PIXELS;
+    const max_pixels = if (vp.max_pixels >= min_pixels) vp.max_pixels else @max(qwen_vision.MAX_PIXELS, min_pixels);
+    const first = decoded.items[0];
+    const rs = qwen_vision.smartResizeImage(first.h, first.w, factor, min_pixels, max_pixels);
+    const rh = rs.h;
+    const rw = rs.w;
+    const C: u32 = 3;
+    const gh = rh / vp.patch;
+    const gw = rw / vp.patch;
+    const n_per_group: usize = @as(usize, gh) * gw;
+    const feat: usize = @as(usize, C) * vp.tps * vp.patch * vp.patch;
+
+    // Resize every frame to the shared (rh, rw) target.
+    var frames_chw = std.ArrayList([]f32).empty;
+    defer {
+        for (frames_chw.items) |f| allocator.free(f);
+        frames_chw.deinit(allocator);
+    }
+    for (decoded.items) |d| {
+        const source_len: usize = @as(usize, d.h) * d.w * C;
+        const chw = allocator.alloc(f32, @as(usize, C) * rh * rw) catch return null;
+        qwen_vision.resizeRgbNormalizedChw(allocator, chw, d.rgb[0..source_len], d.h, d.w, rh, rw, resampleFilterFor(vp)) catch {
+            allocator.free(chw);
+            return null;
+        };
+        frames_chw.append(allocator, chw) catch {
+            allocator.free(chw);
+            return null;
+        };
+    }
+
+    // Group into tps-sized temporal patches, padding the last group by
+    // repeating its final frame.
+    const grid_t: usize = (frames_chw.items.len + vp.tps - 1) / vp.tps;
+    const pv_bytes = allocator.alloc(u8, grid_t * n_per_group * feat * 4) catch return null;
+    const pv_f32 = @as([*]f32, @ptrCast(@alignCast(pv_bytes.ptr)))[0 .. grid_t * n_per_group * feat];
+
+    var group_frames: [8][]const f32 = undefined;
+    var g: usize = 0;
+    while (g < grid_t) : (g += 1) {
+        var k: usize = 0;
+        while (k < vp.tps) : (k += 1) {
+            const idx = @min(g * vp.tps + k, frames_chw.items.len - 1);
+            group_frames[k] = frames_chw.items[idx];
+        }
+        const out_slice = pv_f32[g * n_per_group * feat ..][0 .. n_per_group * feat];
+        qwen_vision.buildPixelValuesVideo(out_slice, group_frames[0..vp.tps], C, rh, rw, vp.patch, vp.merge);
+    }
+
+    log.info("  Decoded {d} frames → qwen video grid_t={d} grid {d}x{d} ({d} tokens, resized {d}x{d})\n", .{
+        frame_urls.len, grid_t, gh, gw, grid_t * n_per_group / (@as(usize, vp.merge) * vp.merge), rw, rh,
+    });
+    return .{ .pixels = pv_bytes, .grid_t = @intCast(grid_t), .grid_h = gh, .grid_w = gw };
+}
+
+/// Decode a `video_url` block's `frames` array into `list`, mirroring
+/// `appendImageUrlContent`'s append-or-drop shape.
+pub fn appendVideoUrlContent(
+    allocator: std.mem.Allocator,
+    list: *std.ArrayList(chat_mod.VideoData),
+    frame_urls: []const []const u8,
+    vp: chat_mod.VisionPreproc,
+) void {
+    if (decodeVideoUrlContent(allocator, frame_urls, vp)) |vid| {
+        list.append(allocator, vid) catch allocator.free(vid.pixels);
+    }
 }
 
 // ── Anthropic Messages API ──
@@ -10867,13 +11061,14 @@ fn handleAnthropicMessages(
     }
     if (lm.vision_encoder) |ve| {
         var n_vis: usize = 0;
+        var n_vid: usize = 0;
         var n_aud: usize = 0;
-        local_ve = processVisionImages(allocator, lm, ve, messages.items, &n_vis, &n_aud) catch |err| blk: {
+        local_ve = processVisionImages(allocator, lm, ve, messages.items, &n_vis, &n_vid, &n_aud) catch |err| blk: {
             log.warn("Vision encoding failed: {}\n", .{err});
             break :blk null;
         };
         if (local_ve != null) {
-            const new_ids = try insertMultimodalTokens(allocator, prompt_ids_raw, config.image_token_id, n_vis, config.audio_token_id, n_aud, config, messages.items);
+            const new_ids = try insertMultimodalTokens(allocator, prompt_ids_raw, config.image_token_id, n_vis, config.video_token_id, n_vid, config.audio_token_id, n_aud, config, messages.items);
             allocator.free(prompt_ids_raw);
             prompt_ids_raw = new_ids;
         }
@@ -12438,13 +12633,14 @@ fn handleResponses(
     }
     if (lm.vision_encoder) |ve| {
         var n_vis: usize = 0;
+        var n_vid: usize = 0;
         var n_aud: usize = 0;
-        local_ve = processVisionImages(allocator, lm, ve, pi.messages.items, &n_vis, &n_aud) catch |err| blk: {
+        local_ve = processVisionImages(allocator, lm, ve, pi.messages.items, &n_vis, &n_vid, &n_aud) catch |err| blk: {
             log.warn("Vision encoding failed: {}\n", .{err});
             break :blk null;
         };
         if (local_ve != null) {
-            const new_ids = try insertMultimodalTokens(allocator, prompt_ids_raw, config.image_token_id, n_vis, config.audio_token_id, n_aud, config, pi.messages.items);
+            const new_ids = try insertMultimodalTokens(allocator, prompt_ids_raw, config.image_token_id, n_vis, config.video_token_id, n_vid, config.audio_token_id, n_aud, config, pi.messages.items);
             allocator.free(prompt_ids_raw);
             prompt_ids_raw = new_ids;
         }
@@ -15155,8 +15351,8 @@ test "insertMultimodalTokens lays out image block then audio block at the user t
     config.eoa_token_id = 301; // EOA
 
     const prompt = [_]u32{ 2, 500, 105, 2364, 107, 900, 901 };
-    // image_token=999 ×2, audio_token=888 ×3.
-    const out = try insertMultimodalTokens(testing.allocator, &prompt, 999, 2, 888, 3, &config, &.{});
+    // image_token=999 ×2, video absent (token=777, n=0), audio_token=888 ×3.
+    const out = try insertMultimodalTokens(testing.allocator, &prompt, 999, 2, 777, 0, 888, 3, &config, &.{});
     defer testing.allocator.free(out);
 
     // Inserted after marker (position 5): [BOI 999 999 EOI][BOA 888 888 888 EOA].
@@ -15169,7 +15365,34 @@ test "insertMultimodalTokens lays out image block then audio block at the user t
     try testing.expectEqualSlices(u32, &expected, out);
 }
 
-test "insertMultimodalTokens handles audio-only and image-only" {
+test "insertMultimodalTokens lays out image block then video block then audio block" {
+    // Qwen3-VL-style: image and video pad runs both wrap in vision_start/end
+    // (get_rope_index keys on vision_start immediately followed by EITHER
+    // pad token), inserted image-block-first, then video, then audio.
+    var config = model_mod.ModelConfig{};
+    config.qwen_vision = true;
+    config.user_turn_marker_ids[0] = 105;
+    config.user_turn_marker_len = 1;
+    config.vision_start_token_id = 200;
+    config.vision_end_token_id = 201;
+    config.boa_token_id = 300;
+    config.eoa_token_id = 301;
+    const prompt = [_]u32{ 1, 105, 7 };
+
+    // image_token=999 ×2, video_token=777 ×3, audio_token=888 ×1.
+    const out = try insertMultimodalTokens(testing.allocator, &prompt, 999, 2, 777, 3, 888, 1, &config, &.{});
+    defer testing.allocator.free(out);
+    const expected = [_]u32{
+        1, 105,
+        200, 999, 999, 201, // image block
+        200, 777, 777, 777, 201, // video block
+        300, 888, 301, // audio block
+        7,
+    };
+    try testing.expectEqualSlices(u32, &expected, out);
+}
+
+test "insertMultimodalTokens handles audio-only, image-only, and video-only" {
     var config = model_mod.ModelConfig{};
     config.user_turn_marker_ids[0] = 105;
     config.user_turn_marker_len = 1;
@@ -15179,18 +15402,25 @@ test "insertMultimodalTokens handles audio-only and image-only" {
     config.eoa_token_id = 301;
     const prompt = [_]u32{ 1, 105, 7 };
 
-    // Audio only (n_image=0) → just the audio block.
-    const ao = try insertMultimodalTokens(testing.allocator, &prompt, 999, 0, 888, 2, &config, &.{});
+    // Audio only (n_image=0, n_video=0) → just the audio block.
+    const ao = try insertMultimodalTokens(testing.allocator, &prompt, 999, 0, 777, 0, 888, 2, &config, &.{});
     defer testing.allocator.free(ao);
     try testing.expectEqualSlices(u32, &[_]u32{ 1, 105, 300, 888, 888, 301, 7 }, ao);
 
-    // Image only (n_audio=0) → just the image block.
-    const io = try insertMultimodalTokens(testing.allocator, &prompt, 999, 2, 888, 0, &config, &.{});
+    // Image only (n_video=0, n_audio=0) → just the image block.
+    const io = try insertMultimodalTokens(testing.allocator, &prompt, 999, 2, 777, 0, 888, 0, &config, &.{});
     defer testing.allocator.free(io);
     try testing.expectEqualSlices(u32, &[_]u32{ 1, 105, 200, 999, 999, 201, 7 }, io);
 
+    // Video only (n_image=0, n_audio=0) → just the video block, wrapped in the
+    // SAME BOI/EOI as an image block (non-Qwen config here; Qwen's vision_start
+    // is exercised by the interleaved test above).
+    const vo = try insertMultimodalTokens(testing.allocator, &prompt, 999, 0, 777, 2, 888, 0, &config, &.{});
+    defer testing.allocator.free(vo);
+    try testing.expectEqualSlices(u32, &[_]u32{ 1, 105, 200, 777, 777, 201, 7 }, vo);
+
     // Neither → unchanged.
-    const none = try insertMultimodalTokens(testing.allocator, &prompt, 999, 0, 888, 0, &config, &.{});
+    const none = try insertMultimodalTokens(testing.allocator, &prompt, 999, 0, 777, 0, 888, 0, &config, &.{});
     defer testing.allocator.free(none);
     try testing.expectEqualSlices(u32, &prompt, none);
 }

--- a/src/vision.zig
+++ b/src/vision.zig
@@ -430,6 +430,15 @@ pub const VisionEncoder = struct {
         return error.NoPatchGridEncoder;
     }
 
+    /// Encode one VIDEO: `patches` holds `grid_t` temporal-patch groups'
+    /// pixel_values concatenated (see `qwen_vision.buildPixelValuesVideo`).
+    /// Only Qwen3-VL-family checkpoints declare `video_token_id` — muse and
+    /// lfm2 have no video path.
+    pub fn forwardVideoPatches(self: *VisionEncoder, patches: mlx.mlx_array, grid_t: u32, grid_h: u32, grid_w: u32) !mlx.mlx_array {
+        if (self.qwen) |*qv| return qv.forwardVideo(patches, grid_t, grid_h, grid_w);
+        return error.NoVideoEncoder;
+    }
+
     /// Apply a quantized (or dense) Linear y = x · Wᵀ (+ optional bias). `sc`
     /// non-empty (ndim>0) selects the quantized path; otherwise a plain matmul.
     fn quantLinear(self: *VisionEncoder, x: mlx.mlx_array, w: mlx.mlx_array, sc: mlx.mlx_array, qb: mlx.mlx_array, bits: u32, bias: ?mlx.mlx_array) !mlx.mlx_array {

--- a/tests/test_qwen_video_input.sh
+++ b/tests/test_qwen_video_input.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Qwen3-VL video input end-to-end over HTTP: a `video_url` content block
+# carrying multiple DISTINCT frame images (house / robot / street signs / a
+# "not hot dog" app screenshot — no real video clip is checked into fixtures/,
+# so genuinely different still images stand in for genuinely different
+# frames). This is the class guard for the video wire path: a wiring bug that
+# threads only frame 0 into every temporal-patch group (the exact regression
+# `qwen_vision.zig`'s "buildPixelValuesVideo reads REAL per-frame data, not
+# one frame duplicated" unit test guards in isolation) would still answer
+# plausibly here — it would just describe ONE subject instead of several, so
+# the model is asked to enumerate what it saw across frames rather than
+# describe "an image".
+#
+# Usage: tests/test_qwen_video_input.sh [model_dir] [port]
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+MODEL="${1:-${QWEN_VISION_MODEL:-$HOME/.mlx-serve/models/mlx-community/Qwen3.5-0.8B-MLX-4bit}}"
+PORT="${2:-11386}"
+F1="tests/fixtures/house.jpeg"
+F2="tests/fixtures/robot.png"
+F3="tests/fixtures/street-name-signs.jpg"
+F4="tests/fixtures/not_hot_dog_app.webp"
+
+if [ ! -f "$MODEL/config.json" ]; then echo "SKIP: model not found at $MODEL"; exit 0; fi
+for f in "$F1" "$F2" "$F3" "$F4"; do
+  if [ ! -f "$f" ]; then echo "SKIP: fixture $f missing"; exit 0; fi
+done
+
+LOG=$(mktemp)
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null; sleep 1
+./zig-out/bin/mlx-serve --model "$MODEL" --serve --port "$PORT" --log-level info > "$LOG" 2>&1 &
+SRV=$!
+cleanup() { kill "$SRV" 2>/dev/null; }
+trap cleanup EXIT
+
+for i in $(seq 1 90); do curl -s "localhost:$PORT/health" >/dev/null 2>&1 && break; sleep 1; done
+if ! curl -s "localhost:$PORT/health" >/dev/null 2>&1; then echo "FAIL: server never came up"; cat "$LOG"; exit 1; fi
+
+mime_for() {
+  case "$1" in
+    *.jpeg|*.jpg) echo "image/jpeg" ;;
+    *.png) echo "image/png" ;;
+    *.webp) echo "image/webp" ;;
+  esac
+}
+frame_json() {
+  local f="$1" mime; mime=$(mime_for "$f")
+  printf '"data:%s;base64,%s"' "$mime" "$(base64 -i "$f")"
+}
+FAIL=0
+
+echo "== /v1/models advertises video capability =="
+MODELS=$(curl -s "localhost:$PORT/v1/models")
+echo "$MODELS" | grep -q '"video"' && echo "  OK: video in input_modalities" || { echo "  FAIL: no video capability advertised"; FAIL=1; }
+
+echo "== OpenAI /v1/chat/completions with a video_url block (4 distinct frames) =="
+BODY=$(cat <<EOF
+{"model":"qwen","max_tokens":128,"temperature":0,"messages":[{"role":"user","content":[
+ {"type":"text","text":"Each frame of this video shows something different. List, in one short sentence per item, every distinct subject you can identify across all the frames."},
+ {"type":"video_url","video_url":{"frames":[$(frame_json "$F1"),$(frame_json "$F2"),$(frame_json "$F3"),$(frame_json "$F4")]}}]}]}
+EOF
+)
+RESP=$(echo "$BODY" | curl -s "localhost:$PORT/v1/chat/completions" -H 'content-type: application/json' -d @-)
+TEXT=$(echo "$RESP" | python3 -c "import sys,json;print(json.load(sys.stdin)['choices'][0]['message']['content'])" 2>/dev/null)
+echo "  -> $TEXT"
+if [ -z "$TEXT" ]; then echo "  FAIL: no completion text (request likely errored)"; echo "$RESP" | head -c 500; FAIL=1; fi
+
+# The class guard: a pipeline that collapsed all frames to one would still
+# answer plausibly but would only ever mention ONE of these subjects. At
+# least two of the four distinct fixtures should surface in the answer.
+HITS=0
+echo "$TEXT" | grep -qiE "house|home|building" && HITS=$((HITS + 1))
+echo "$TEXT" | grep -qiE "robot" && HITS=$((HITS + 1))
+echo "$TEXT" | grep -qiE "street|sign|road" && HITS=$((HITS + 1))
+echo "$TEXT" | grep -qiE "hot ?dog|app|screenshot|phone" && HITS=$((HITS + 1))
+echo "  matched $HITS/4 distinct-frame subjects"
+if [ "$HITS" -lt 2 ]; then echo "  FAIL: fewer than 2 distinct subjects recognized (frames may have collapsed to one)"; FAIL=1; fi
+
+echo "== Video decode + M-RoPE engagement (server log) =="
+grep -qE "Decoded 4 frames → qwen video" "$LOG" && echo "  OK: video decode ran (4 real frames)" || { echo "  FAIL: video decode did not engage"; FAIL=1; }
+grep -qE "M-RoPE: 0 images, 1 videos" "$LOG" && echo "  OK: M-RoPE engaged on the video block" || { echo "  FAIL: M-RoPE did not engage for video"; FAIL=1; }
+
+if [ "$FAIL" = "0" ]; then echo "PASS: qwen video input e2e"; else echo "FAIL: qwen video input e2e"; cat "$LOG" | tail -30; fi
+exit $FAIL


### PR DESCRIPTION
## Summary
- Adds `video_url` content-block support for chat, routed through the existing Qwen3-VL vision tower (temporal patches over per-frame data, not one frame duplicated) — covers every Qwen3-VL-family checkpoint including Qwen3.8-VL "Alis" packs, since the gate is config-driven (`video_token_id`) rather than a hardcoded model_type list.
- App side: attach videos via drag-and-drop or the composer, frame extraction via `VideoPreprocessor`, wired through history/turn-config plumbing.

Closes #245

## Testing

- `zig build test -Doptimize=ReleaseFast`: 6/6 steps pass
- `cd app && swift build -c release`: builds clean
- `swift test --filter VideoPreprocessorTests`: 3/3 pass