### PR TITLE
feat: gpt-oss

### DIFF
--- a/app/Sources/MLXServe/Models/HFModels.swift
+++ b/app/Sources/MLXServe/Models/HFModels.swift
@@ -30,6 +30,7 @@ private let supportedArchitectureTagPrefixes: [String] = [
     "muse",       // meta-models Muse-Glimmer-30B — repos tag "muse_glimmer" (and *_text)
     "bailing",    // inclusionAI Ling 3.0 — repos tag "bailing_moe_v3" and/or "bailing_hybrid"
     "ling",       // …and/or the family name
+    "gpt_oss",    // GPT-OSS family tags (e.g. mlx-community/gpt-oss-20b-MXFP4-Q8)
 ]
 
 /// model_type values from config.json that the Zig server can load.
@@ -56,6 +57,7 @@ let supportedModelTypes: Set<String> = [
     // "deepseek_v4" = DeepSeek-V4-Flash via the ds4 engine. Both are served, so
     // neither should be flagged "unsupported architecture" in the model browser.
     "gguf", "deepseek_v4",
+    "gpt_oss",
 ]
 
 /// model_type prefixes/exact values for native media-generation checkpoints

--- a/app/Tests/MLXCoreTests/HFSearchTests.swift
+++ b/app/Tests/MLXCoreTests/HFSearchTests.swift
@@ -710,6 +710,14 @@ final class HFModelQuantGateTests: XCTestCase {
         XCTAssertTrue(supportedModelTypes.contains("lfm2_vl"),
                       "config.json spells it lfm2_vl; a hyphen here silently unsupports every LFM2-VL download")
     }
+
+    func testGptOssTagIsSupportedArchitecture() {
+        let m = mlx(id: "mlx-community/gpt-oss-20b-MXFP4-Q8",
+                    tags: ["mlx", "safetensors", "gpt_oss", "text-generation", "conversational"])
+        XCTAssertTrue(m.isSupportedArchitecture,
+                      "gpt_oss tags should be treated as supported architecture")
+        XCTAssertNil(m.incompatibleReason)
+    }
 }
 
 // MARK: - HFModel.quantization label parsing

--- a/src/chat.zig
+++ b/src/chat.zig
@@ -615,7 +615,14 @@ fn renderChatTemplate(
 
     // Serialize messages to JSON — Gemma 4 templates handle role:"tool" natively
     // (producing <|turn>tool in the rendered output). No transformation needed.
-    const messages_json = try serializeMessagesJson(allocator, effective_messages);
+    // Harmony (gpt_oss) indexes into `message.content` after only checking that
+    // the KEY exists, so a null there breaks every tool round-trip. Sniffed off
+    // the template's own channel marker, like the reasoning drop above.
+    const empty_content: EmptyContent = if (std.mem.indexOf(u8, tpl, "<|channel|>") != null)
+        .empty_string
+    else
+        .null_literal;
+    const messages_json = try serializeMessagesJsonOpts(allocator, effective_messages, empty_content);
     defer allocator.free(messages_json);
 
     // Build extra context (bos_token, eos_token, enable_thinking, effort)
@@ -850,7 +857,29 @@ fn synthesizeToolFallbackMessages(
     return out.toOwnedSlice(arena);
 }
 
+/// How an assistant message with NO content should serialize.
+///
+/// Most templates read `message.content is none` / `if message.content`, and
+/// `null` is what they expect. Harmony (gpt_oss) does BOTH of these in
+/// sequence on every assistant message:
+///
+///     {%- if "content" in message %}
+///         {%- if "<|channel|>analysis<|message|>" in message.content ... %}
+///
+/// The first test asks whether the KEY exists, the second indexes into the
+/// VALUE — so `"content": null` passes the guard and then substring-searches
+/// None. A tool-calling assistant turn is exactly the message that carries no
+/// content, so every tool round-trip hit it (live 2026-08-12: the reply came
+/// back with reasoning and raw `<|channel|>final>` markers in the content).
+/// Serializing `""` satisfies both readings — the key exists, and it is falsy
+/// everywhere the template branches on it.
+pub const EmptyContent = enum { null_literal, empty_string };
+
 pub fn serializeMessagesJson(allocator: std.mem.Allocator, messages: []const Message) ![]const u8 {
+    return serializeMessagesJsonOpts(allocator, messages, .null_literal);
+}
+
+pub fn serializeMessagesJsonOpts(allocator: std.mem.Allocator, messages: []const Message, empty_content: EmptyContent) ![]const u8 {
     var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
 
@@ -863,8 +892,9 @@ pub fn serializeMessagesJson(allocator: std.mem.Allocator, messages: []const Mes
         try buf.appendSlice(allocator, ",\"content\":");
         if (msg.content.len > 0) {
             try appendJsonString(allocator, &buf, msg.content);
-        } else {
-            try buf.appendSlice(allocator, "null");
+        } else switch (empty_content) {
+            .null_literal => try buf.appendSlice(allocator, "null"),
+            .empty_string => try buf.appendSlice(allocator, "\"\""),
         }
 
         if (msg.tool_calls) |tcs| {
@@ -1670,6 +1700,234 @@ const MUSE_MSG_TAG = "<|message|>";
 const MUSE_EOM_TAG = "<|eom|>";
 const MUSE_EOT_TAG = "<|eot|>";
 
+// ── gpt_oss / harmony channels ──
+//
+// After the generation prompt's bare `<|start|>assistant`, the model emits
+// channel segments:
+//   `<|channel|>analysis<|message|>REASONING<|end|>`
+//   `<|start|>assistant<|channel|>final<|message|>ANSWER<|return|>`
+//   `<|start|>assistant to=functions.NAME<|channel|>commentary <|constrain|>json`
+//       `<|message|>{args}<|call|>`
+//
+// Muse is this format's descendant and shares `<|start|>`/`<|message|>`, so
+// `<|message|>` alone CANNOT discriminate the two families. `<|channel|>` is
+// harmony's and only harmony's — both routers key on it, one to claim and one
+// to decline.
+const HARMONY_START_TAG = "<|start|>";
+const HARMONY_CHANNEL_TAG = "<|channel|>";
+const HARMONY_MSG_TAG = "<|message|>";
+const HARMONY_END_TAG = "<|end|>";
+const HARMONY_RETURN_TAG = "<|return|>";
+const HARMONY_CALL_TAG = "<|call|>";
+
+const HarmonySegment = struct { channel: []const u8, recipient: []const u8, body: []const u8 };
+
+/// Channel, recipient and body of the segment in text[seg_start..seg_end].
+/// null when the header never resolved — a header still streaming in is never
+/// content.
+///
+/// The recipient is searched for across the WHOLE header because harmony
+/// permits it on either side of the channel name (`assistant to=functions.x
+/// <|channel|>commentary` and `<|channel|>commentary to=functions.x` are the
+/// same call).
+fn harmonySegmentAt(text: []const u8, seg_start: usize, seg_end: usize) ?HarmonySegment {
+    const seg = text[seg_start..seg_end];
+    const msg_rel = std.mem.indexOf(u8, seg, HARMONY_MSG_TAG) orelse return null;
+    const header = seg[0..msg_rel];
+    const chan_rel = std.mem.indexOf(u8, header, HARMONY_CHANNEL_TAG) orelse return null;
+
+    // Channel name = the identifier run right after the marker.
+    const after = header[chan_rel + HARMONY_CHANNEL_TAG.len ..];
+    var n: usize = 0;
+    while (n < after.len and museIsRecipientChar(after[n])) n += 1;
+    const channel = after[0..n];
+
+    const recipient: []const u8 = if (std.mem.indexOf(u8, header, "to=")) |t| blk: {
+        const r = header[t + 3 ..];
+        var m: usize = 0;
+        while (m < r.len and museIsRecipientChar(r[m])) m += 1;
+        break :blk r[0..m];
+    } else "";
+
+    var body = seg[msg_rel + HARMONY_MSG_TAG.len ..];
+    for ([_][]const u8{ HARMONY_END_TAG, HARMONY_RETURN_TAG, HARMONY_CALL_TAG }) |tag| {
+        if (std.mem.indexOf(u8, body, tag)) |e| body = body[0..e];
+    }
+    return .{ .channel = channel, .recipient = recipient, .body = body };
+}
+
+/// gpt_oss channel split. Claims the text only when `<|channel|>` is present.
+/// First segment of each destination wins. A tool segment's body rides out as
+/// content ONLY when there is no final segment, so the KeepingMarkup callers
+/// can still see the call and the trim wrapper cuts it from display — the same
+/// contract muse's splitter honours.
+fn splitHarmonyChannels(text: []const u8) ?ThinkSplit {
+    if (std.mem.indexOf(u8, text, HARMONY_CHANNEL_TAG) == null) return null;
+    var reasoning: ?[]const u8 = null;
+    var content: ?[]const u8 = null;
+    var tool_body: ?[]const u8 = null;
+    var routed = false;
+
+    var seg_start: usize = 0;
+    while (true) {
+        const next = std.mem.indexOfPos(u8, text, seg_start + 1, HARMONY_START_TAG);
+        const seg_end = next orelse text.len;
+        if (harmonySegmentAt(text, seg_start, seg_end)) |s| {
+            routed = true;
+            if (std.mem.startsWith(u8, s.recipient, "functions.")) {
+                // A tool call, whatever channel it rode in on.
+                if (tool_body == null) tool_body = s.body;
+            } else if (std.mem.eql(u8, s.channel, "analysis")) {
+                if (reasoning == null) {
+                    const r = std.mem.trim(u8, s.body, "\n ");
+                    if (r.len > 0) reasoning = r;
+                }
+            } else {
+                // `final`, and a bare `commentary` preamble addressed to no
+                // tool — both are user-visible.
+                if (content == null) content = std.mem.trim(u8, s.body, "\n ");
+            }
+        }
+        seg_start = next orelse break;
+    }
+    if (!routed) return null;
+    return .{
+        .reasoning_content = reasoning,
+        .content = content orelse (tool_body orelse ""),
+    };
+}
+
+/// What a harmony segment header at the START of a streaming buffer means.
+/// Mirrors `museThinkOpenerAt`: the streaming loop consumes the header bytes
+/// and latches a close tag, so the close matcher's pos/len model then works on
+/// reasoning that really does begin at byte 0.
+pub const HarmonyOpener = union(enum) {
+    /// `<|channel|>analysis<|message|>` — reasoning follows, closes at <|end|>.
+    /// Payload is the header length to strip.
+    analysis: usize,
+    /// A resolved header for any OTHER channel (`final`, bare `commentary`):
+    /// the answer starts immediately, with no reasoning at all.
+    direct: usize,
+    /// A header still arriving token by token — decide nothing yet, or its
+    /// text leaks as reasoning.
+    growing,
+    not_harmony,
+};
+
+pub fn harmonyThinkOpenerAt(buf: []const u8) HarmonyOpener {
+    var i: usize = 0;
+    if (std.mem.startsWith(u8, buf, HARMONY_START_TAG)) {
+        i = HARMONY_START_TAG.len;
+        while (i < buf.len and museIsRecipientChar(buf[i])) i += 1;
+    } else if (HARMONY_START_TAG.len > buf.len and std.mem.startsWith(u8, HARMONY_START_TAG, buf)) {
+        // A strict prefix of `<|start|>` — could still become one.
+        return if (buf.len == 0) .not_harmony else .growing;
+    }
+    const rest = buf[i..];
+    if (!std.mem.startsWith(u8, rest, HARMONY_CHANNEL_TAG)) {
+        // Partial `<|channel|>` still arriving.
+        if (rest.len < HARMONY_CHANNEL_TAG.len and rest.len > 0 and
+            std.mem.startsWith(u8, HARMONY_CHANNEL_TAG, rest)) return .growing;
+        return .not_harmony;
+    }
+    const after_chan = i + HARMONY_CHANNEL_TAG.len;
+    const msg = std.mem.indexOfPos(u8, buf, after_chan, HARMONY_MSG_TAG) orelse return .growing;
+    const hdr_len = msg + HARMONY_MSG_TAG.len;
+    if (std.mem.startsWith(u8, buf[after_chan..], "analysis")) return .{ .analysis = hdr_len };
+    return .{ .direct = hdr_len };
+}
+
+/// Byte length of a leading harmony ANALYSIS header
+/// (`[<|start|>assistant]<|channel|>analysis<|message|>`), or null when `buf`
+/// does not open with one.
+///
+/// The streaming split identifies a reasoning block by a close tag and emits
+/// everything before it, which assumes the reasoning starts at byte 0. Harmony
+/// puts a header there instead, and every byte of it is ordinary text — so
+/// without this the first reasoning delta opens with a literal
+/// `<|channel|>analysis<|message|>` (live 2026-08-12).
+pub fn harmonyAnalysisHeaderLen(buf: []const u8) ?usize {
+    var i: usize = 0;
+    if (std.mem.startsWith(u8, buf, HARMONY_START_TAG)) {
+        // Skip `<|start|>` + the role that follows it.
+        i = HARMONY_START_TAG.len;
+        while (i < buf.len and museIsRecipientChar(buf[i])) i += 1;
+    }
+    if (!std.mem.startsWith(u8, buf[i..], HARMONY_CHANNEL_TAG)) return null;
+    const after_chan = i + HARMONY_CHANNEL_TAG.len;
+    if (!std.mem.startsWith(u8, buf[after_chan..], "analysis")) return null;
+    const msg = std.mem.indexOfPos(u8, buf, after_chan, HARMONY_MSG_TAG) orelse return null;
+    return msg + HARMONY_MSG_TAG.len;
+}
+
+/// Drop a leading harmony segment header of ANY channel — the answer arrives
+/// as its own `<|start|>assistant<|channel|>final<|message|>` segment once the
+/// analysis channel closes, and that header is ordinary text that would
+/// otherwise ride out as the first bytes of content.
+pub fn stripHarmonySegmentHeader(text: []const u8) []const u8 {
+    var i: usize = 0;
+    if (std.mem.startsWith(u8, text, HARMONY_START_TAG)) {
+        i = HARMONY_START_TAG.len;
+        while (i < text.len and museIsRecipientChar(text[i])) i += 1;
+    }
+    if (!std.mem.startsWith(u8, text[i..], HARMONY_CHANNEL_TAG)) return text;
+    const msg = std.mem.indexOfPos(u8, text, i, HARMONY_MSG_TAG) orelse return text;
+    return text[msg + HARMONY_MSG_TAG.len ..];
+}
+
+/// gpt_oss streaming verdict, decided from the channel markers alone.
+/// null = not harmony traffic (fall through to the generic think gate).
+///
+/// The header between `<|channel|>` and `<|message|>` is ORDINARY text —
+/// only the delimiters are single special tokens — so an unresolved header
+/// always HOLDS. Flushing it leaks `analysis` / `commentary to=functions.…`
+/// fragments into the user's stream, which is the muse ` to=user` bug in a
+/// different alphabet.
+fn harmonyStreamVerdict(buf: []const u8) ?StreamThinkGate {
+    if (std.mem.indexOf(u8, buf, HARMONY_CHANNEL_TAG) == null) return null;
+    const seg_start = std.mem.lastIndexOf(u8, buf, HARMONY_START_TAG) orelse 0;
+    const seg = buf[seg_start..];
+    const chan_rel = std.mem.indexOf(u8, seg, HARMONY_CHANNEL_TAG) orelse return .hold_thinking;
+    const msg_rel = std.mem.indexOfPos(u8, seg, chan_rel, HARMONY_MSG_TAG) orelse return .hold_thinking;
+    const header = seg[0..msg_rel];
+
+    const after = header[chan_rel + HARMONY_CHANNEL_TAG.len ..];
+    var n: usize = 0;
+    while (n < after.len and museIsRecipientChar(after[n])) n += 1;
+    const channel = after[0..n];
+
+    const recipient: []const u8 = if (std.mem.indexOf(u8, header, "to=")) |t| blk: {
+        const r = header[t + 3 ..];
+        var m: usize = 0;
+        while (m < r.len and museIsRecipientChar(r[m])) m += 1;
+        break :blk r[0..m];
+    } else "";
+
+    // Tool payload: the tools path buffers before this gate is consulted;
+    // hold defensively on a no-tools request rather than leak raw arguments.
+    if (std.mem.startsWith(u8, recipient, "functions.")) return .hold_thinking;
+    if (std.mem.eql(u8, channel, "analysis")) {
+        const closed = std.mem.indexOf(u8, seg, HARMONY_END_TAG) != null or
+            std.mem.indexOf(u8, seg, HARMONY_RETURN_TAG) != null;
+        return if (closed) .split_think else .hold_thinking;
+    }
+    return .split_think;
+}
+
+/// gpt_oss streaming tool hold: true while a segment header is unresolved
+/// (the next token decides whether it names a tool) or already resolved to a
+/// `functions.` recipient (the body is call arguments — parsed on the end
+/// flush, never streamed).
+fn harmonyHeaderHoldsForTools(buf: []const u8) bool {
+    const chan = std.mem.lastIndexOf(u8, buf, HARMONY_CHANNEL_TAG) orelse return false;
+    // Header runs from the segment's `<|start|>` (the `to=` may sit on either
+    // side of the channel marker) to `<|message|>`. No `<|message|>` yet means
+    // the header is still growing — hold, the next token may name a tool.
+    const msg_rel = std.mem.indexOfPos(u8, buf, chan, HARMONY_MSG_TAG) orelse return true;
+    const seg_start = std.mem.lastIndexOf(u8, buf, HARMONY_START_TAG) orelse 0;
+    return std.mem.indexOf(u8, buf[seg_start..msg_rel], "to=functions.") != null;
+}
+
 fn museIsRecipientChar(c: u8) bool {
     return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
         (c >= '0' and c <= '9') or c == '_' or c == '-' or c == '.';
@@ -1702,6 +1960,11 @@ fn museSegmentAt(text: []const u8, seg_start: usize, seg_end: usize) ?MuseSegmen
 /// still see it and the trim wrapper cuts it from display.
 fn splitMuseChannels(text: []const u8) ?ThinkSplit {
     if (std.mem.indexOf(u8, text, MUSE_MSG_TAG) == null) return null;
+    // `<|message|>` is NOT unique to muse: harmony (gpt_oss), muse's own
+    // format ancestor, emits the same marker. Decline harmony traffic here —
+    // its `analysis` header carries no `to=`, so muse's recipient rules would
+    // route the model's private reasoning into user-visible content.
+    if (std.mem.indexOf(u8, text, HARMONY_CHANNEL_TAG) != null) return null;
     var reasoning: ?[]const u8 = null;
     var content: ?[]const u8 = null;
     var tool_body: ?[]const u8 = null;
@@ -1990,9 +2253,13 @@ pub fn splitThinkBlock(text: []const u8, thinking: bool, opened_by_template: boo
 /// Every arm below returns raw slices; the cut is applied ONCE in the wrapper
 /// above so a new arm cannot forget it.
 pub fn splitThinkBlockKeepingMarkup(text: []const u8, thinking: bool, opened_by_template: bool) ThinkSplit {
+    // gpt_oss / harmony channel segments (`analysis` / `final` /
+    // `commentary to=functions.X`). Keyed on `<|channel|>`; must run BEFORE
+    // the muse arm, which shares the `<|message|>` marker.
+    if (splitHarmonyChannels(text)) |split| return split;
     // Muse-Glimmer channel segments (`to=self` / `to=user` / tool). Keyed on
-    // the `<|message|>` marker no other family emits; runs regardless of the
-    // `thinking` flag because the headers need stripping either way.
+    // the `<|message|>` marker, minus harmony's `<|channel|>`; runs regardless
+    // of the `thinking` flag because the headers need stripping either way.
     if (splitMuseChannels(text)) |split| return split;
     // Inkling (inkling_mm_model) message channels: the model emits role-less
     // MESSAGES — `<|content_thinking|>R<|end_message|>` then
@@ -2274,6 +2541,8 @@ pub fn streamShouldBufferForTools(buf: []const u8) bool {
     // Muse segment-header hold: between <|start|> and <|message|> only the
     // role+recipient text flows, and a non-self/user recipient names a TOOL.
     if (museHeaderHoldsForTools(buf)) return true;
+    // gpt_oss/harmony segment-header hold: same shape, `<|channel|>`-keyed.
+    if (harmonyHeaderHoldsForTools(buf)) return true;
 
     // Inkling NAME hold: with a message-boundary marker present (a family
     // signal no other template emits), a segment that is still a bare
@@ -2486,6 +2755,9 @@ pub fn streamThinkGateScan(
     prompt_opened_think: bool,
     scan: *ThinkScan,
 ) StreamThinkGate {
+    // Harmony (gpt_oss) decides before muse — both emit <|message|>, and only
+    // the <|channel|> marker tells them apart.
+    if (harmonyStreamVerdict(buf)) |v| return v;
     if (museStreamVerdict(buf)) |v| return v;
     {
         const ihead = inklingStripMessageHead(buf);
@@ -2506,6 +2778,9 @@ pub fn streamThinkGateScan(
 }
 
 pub fn streamThinkGate2(buf: []const u8, enable_thinking: bool, think_closed: bool, prompt_opened_think: bool) StreamThinkGate {
+    // Harmony (gpt_oss) channels decide first — the muse arm below shares the
+    // <|message|> marker and would otherwise claim this traffic.
+    if (harmonyStreamVerdict(buf)) |v| return v;
     // Muse channels decide early — the recipient header is ordinary text and
     // must never flush unresolved.
     if (museStreamVerdict(buf)) |v| return v;
@@ -2650,6 +2925,11 @@ pub fn parseToolCalls(allocator: std.mem.Allocator, text: []const u8) !?[]Parsed
     // tool segments arrive wrapped in channel headers the think-strip above
     // would misjudge.
     try parseAtemToolCalls(allocator, text, &calls);
+    // gpt_oss / harmony (`to=functions.NAME<|channel|>commentary…<|message|>`):
+    // the name lives in the header, not the payload, so no generic scan can
+    // recover it. Runs on the FULL text for the same reason ATEM does — the
+    // call arrives wrapped in channel headers the think-strip would misjudge.
+    try parseHarmonyToolCalls(allocator, text, &calls);
     // DeepSeek-V4 native DSML (`<｜DSML｜invoke …>`): distinctive fullwidth-bar
     // marker no other family emits, and the generic `<tool` scan never sees
     // it (the byte before "tool_calls" is `｜`, not `<`).
@@ -4355,6 +4635,63 @@ const ATEM_INVOKE_TAG = "<atem:invoke";
 const ATEM_PARAM_TAG = "<atem:parameter";
 const ATEM_PARAM_CLOSE = "</atem:parameter>";
 const ATEM_INVOKE_CLOSE = "</atem:invoke>";
+
+/// gpt_oss / harmony tool calls. Structurally unlike every other family here:
+/// the function NAME is not in the payload at all, it is the segment header's
+/// recipient (`to=functions.NAME`), and the body is already a JSON arguments
+/// object rather than a markup block to assemble.
+///
+///     <|start|>assistant to=functions.get_weather<|channel|>commentary
+///     <|constrain|>json<|message|>{"location":"SF"}<|call|>
+///
+/// Keyed on `to=functions.` sitting in a resolved channel header, a shape no
+/// other family emits. A body that is not a COMPLETE balanced JSON object is
+/// a truncated call: ship the name with `{}` rather than a fragment, per the
+/// same rule the ATEM and DSML parsers follow.
+fn parseHarmonyToolCalls(allocator: std.mem.Allocator, text: []const u8, calls: *std.ArrayList(ParsedToolCall)) !void {
+    if (std.mem.indexOf(u8, text, HARMONY_CHANNEL_TAG) == null) return;
+    var seg_start: usize = 0;
+    while (true) {
+        const next = std.mem.indexOfPos(u8, text, seg_start + 1, HARMONY_START_TAG);
+        const seg_end = next orelse text.len;
+        defer seg_start = next orelse text.len;
+
+        const seg = text[seg_start..seg_end];
+        // Only a RESOLVED header can name a call — an unterminated one is
+        // still arriving and its recipient may yet change.
+        const msg_rel = std.mem.indexOf(u8, seg, HARMONY_MSG_TAG) orelse {
+            if (next == null) break;
+            continue;
+        };
+        const header = seg[0..msg_rel];
+        const fn_at = std.mem.indexOf(u8, header, "to=functions.") orelse {
+            if (next == null) break;
+            continue;
+        };
+        const raw_name = header[fn_at + "to=functions.".len ..];
+        var n: usize = 0;
+        while (n < raw_name.len and museIsRecipientChar(raw_name[n])) n += 1;
+        // A tool name never carries a channel marker (corpus invariant).
+        const name_slice = raw_name[0..n];
+        if (name_slice.len == 0) {
+            if (next == null) break;
+            continue;
+        }
+
+        var body = seg[msg_rel + HARMONY_MSG_TAG.len ..];
+        for ([_][]const u8{ HARMONY_CALL_TAG, HARMONY_END_TAG, HARMONY_RETURN_TAG }) |tag| {
+            if (std.mem.indexOf(u8, body, tag)) |e| body = body[0..e];
+        }
+        const args_src = balancedJsonObject(std.mem.trim(u8, body, " \n\t\r")) orelse "{}";
+
+        const name = try allocator.dupe(u8, name_slice);
+        errdefer allocator.free(name);
+        const arguments = try allocator.dupe(u8, args_src);
+        try calls.append(allocator, .{ .name = name, .arguments = arguments, .inferred = false });
+
+        if (next == null) break;
+    }
+}
 
 fn parseAtemToolCalls(allocator: std.mem.Allocator, text: []const u8, calls: *std.ArrayList(ParsedToolCall)) !void {
     var pos: usize = 0;
@@ -11630,6 +11967,97 @@ test "splitMuseChannels: headerless first segment (prompt-committed header) is c
     try testing.expect(hdr.reasoning_content == null);
 }
 
+test "harmonyAnalysisHeaderLen: measures the header the streaming split must skip" {
+    // With and without the leading <|start|>assistant (the generation prompt
+    // commits that part on the FIRST segment, so the model's first bytes are
+    // the bare <|channel|>).
+    const bare = "<|channel|>analysis<|message|>thinking...";
+    try std.testing.expectEqual(@as(?usize, "<|channel|>analysis<|message|>".len), harmonyAnalysisHeaderLen(bare));
+    const full = "<|start|>assistant<|channel|>analysis<|message|>x";
+    try std.testing.expectEqual(@as(?usize, "<|start|>assistant<|channel|>analysis<|message|>".len), harmonyAnalysisHeaderLen(full));
+    // A header still arriving has no length yet — the split must not fire.
+    try std.testing.expectEqual(@as(?usize, null), harmonyAnalysisHeaderLen("<|channel|>analysis"));
+    // Only the ANALYSIS channel: `final` is content, not reasoning.
+    try std.testing.expectEqual(@as(?usize, null), harmonyAnalysisHeaderLen("<|channel|>final<|message|>hi"));
+    try std.testing.expectEqual(@as(?usize, null), harmonyAnalysisHeaderLen("plain text"));
+}
+
+test "stripHarmonySegmentHeader: drops a leading segment header of any channel" {
+    try std.testing.expectEqualStrings(
+        "The answer.",
+        stripHarmonySegmentHeader("<|start|>assistant<|channel|>final<|message|>The answer."),
+    );
+    try std.testing.expectEqualStrings(
+        "Working.",
+        stripHarmonySegmentHeader("<|channel|>commentary<|message|>Working."),
+    );
+    // Nothing to strip — returned untouched, never truncated.
+    try std.testing.expectEqualStrings("plain content", stripHarmonySegmentHeader("plain content"));
+    try std.testing.expectEqualStrings(
+        "<|start|>assistant<|channel|>fin",
+        stripHarmonySegmentHeader("<|start|>assistant<|channel|>fin"),
+    );
+}
+
+test "splitHarmonyChannels: analysis→reasoning, final→content, headers stripped" {
+    // What gpt-oss emits after the generation prompt's bare `<|start|>assistant`.
+    const text = "<|channel|>analysis<|message|>Let me think.<|end|>" ++
+        "<|start|>assistant<|channel|>final<|message|>The answer is 4.<|return|>";
+    const split = splitHarmonyChannels(text).?;
+    try std.testing.expectEqualStrings("Let me think.", split.reasoning_content.?);
+    try std.testing.expectEqualStrings("The answer is 4.", split.content);
+}
+
+test "splitHarmonyChannels: commentary to=functions.X is a TOOL body, never content" {
+    // A tool call rides the commentary channel with a `functions.` recipient.
+    // Routing it to content would print raw JSON at the user; routing it to
+    // reasoning would lose the call entirely.
+    const text = "<|channel|>analysis<|message|>Need weather.<|end|>" ++
+        "<|start|>assistant to=functions.get_weather<|channel|>commentary <|constrain|>json<|message|>" ++
+        "{\"location\":\"SF\"}<|call|>";
+    const split = splitHarmonyChannels(text).?;
+    try std.testing.expectEqualStrings("Need weather.", split.reasoning_content.?);
+    try std.testing.expectEqualStrings("{\"location\":\"SF\"}", split.content);
+}
+
+test "splitHarmonyChannels: recipient may sit AFTER the channel name" {
+    // Harmony allows `<|channel|>commentary to=functions.x`; the header is
+    // scanned as a whole so both orderings resolve to the same recipient.
+    const text = "<|start|>assistant<|channel|>commentary to=functions.ping<|message|>{}<|call|>";
+    const split = splitHarmonyChannels(text).?;
+    try std.testing.expectEqualStrings("{}", split.content);
+    try std.testing.expect(split.reasoning_content == null);
+}
+
+test "splitHarmonyChannels: bare commentary (no recipient) is user-visible content" {
+    const text = "<|channel|>commentary<|message|>Working on it.<|end|>";
+    const split = splitHarmonyChannels(text).?;
+    try std.testing.expectEqualStrings("Working on it.", split.content);
+}
+
+test "splitHarmonyChannels: an unresolved header is never content" {
+    // A header still streaming in (no <|message|> yet) must not be claimed.
+    try std.testing.expect(splitHarmonyChannels("<|channel|>anal") == null);
+    try std.testing.expect(splitHarmonyChannels("<|start|>assistant<|channel|>fin") == null);
+}
+
+test "splitHarmonyChannels: declines muse traffic (no <|channel|> marker)" {
+    // Both families emit <|message|>, so the muse router cannot be the one
+    // that keys on it alone — <|channel|> is the discriminator, and harmony
+    // must not claim a muse turn (or vice versa).
+    try std.testing.expect(splitHarmonyChannels(" to=self<|message|>notes<|eom|>") == null);
+}
+
+test "splitMuseChannels: declines harmony traffic (<|channel|> present)" {
+    // The mirror of the case above. Without this, gpt-oss reasoning routes
+    // through muse's recipient rules — an `analysis` header carries no `to=`,
+    // so it would land in CONTENT and the answer would be preceded by the
+    // model's private reasoning.
+    const harmony = "<|channel|>analysis<|message|>secret<|end|>" ++
+        "<|start|>assistant<|channel|>final<|message|>hi<|return|>";
+    try std.testing.expect(splitMuseChannels(harmony) == null);
+}
+
 test "splitMuseChannels: to=self reasoning + to=user content, headers stripped" {
     // The exact shape muse emits after the prompt's `<|start|>assistant`.
     const text = " to=self<|message|>Let me think.<|eom|><|start|>assistant to=user<|message|>The answer is 4.";
@@ -11667,6 +12095,128 @@ test "splitMuseChannels: tool segment markup never rides out as content (wrapper
     // KeepingMarkup split: the markup survives for the tool parser.
     const keeping = splitThinkBlockKeepingMarkup(text, true, false);
     try testing.expect(std.mem.indexOf(u8, keeping.content, "<atem:invoke") != null);
+}
+
+test "serializeMessagesJsonOpts: harmony gets \"\" for empty content, everyone else keeps null" {
+    // The harmony template guards with `if \"content\" in message` and then
+    // does `\"…\" in message.content`. A null passes the first and breaks the
+    // second, and the message that carries no content is precisely the
+    // tool-calling assistant turn — so this is the whole tool round-trip.
+    const allocator = testing.allocator;
+    const messages = [_]Message{
+        .{ .role = "user", .content = "weather?" },
+        .{ .role = "assistant", .content = "", .tool_calls = &[_]ToolCall{
+            .{ .id = "call_1", .name = "get_weather", .arguments = "{\"location\":\"SF\"}" },
+        } },
+    };
+
+    const harmony = try serializeMessagesJsonOpts(allocator, &messages, .empty_string);
+    defer allocator.free(harmony);
+    const hp = try std.json.parseFromSlice(std.json.Value, allocator, harmony, .{});
+    defer hp.deinit();
+    const hmsg = hp.value.array.items[1].object;
+    try testing.expect(hmsg.get("content").? == .string);
+    try testing.expectEqualStrings("", hmsg.get("content").?.string);
+    // The tool call itself still round-trips.
+    try testing.expectEqualStrings(
+        "get_weather",
+        hmsg.get("tool_calls").?.array.items[0].object.get("function").?.object.get("name").?.string,
+    );
+
+    // Every other family keeps the null it has always been given.
+    const legacy = try serializeMessagesJson(allocator, &messages);
+    defer allocator.free(legacy);
+    const lp = try std.json.parseFromSlice(std.json.Value, allocator, legacy, .{});
+    defer lp.deinit();
+    try testing.expect(lp.value.array.items[1].object.get("content").? == .null);
+}
+
+test "parseHarmonyToolCalls: name comes from the HEADER, arguments from the body" {
+    // gpt-oss puts the tool name in the segment header's recipient
+    // (`to=functions.NAME`) and the arguments — already JSON — in the body.
+    // Nothing in the body names the function, so a body-only parser finds
+    // an anonymous JSON object and infers nothing.
+    const text = "<|start|>assistant to=functions.get_weather<|channel|>commentary " ++
+        "<|constrain|>json<|message|>{\"location\": \"SF\", \"unit\": \"c\"}<|call|>";
+    var calls: std.ArrayList(ParsedToolCall) = .empty;
+    defer {
+        for (calls.items) |tc| {
+            std.testing.allocator.free(tc.name);
+            std.testing.allocator.free(tc.arguments);
+        }
+        calls.deinit(std.testing.allocator);
+    }
+    try parseHarmonyToolCalls(std.testing.allocator, text, &calls);
+    try std.testing.expectEqual(@as(usize, 1), calls.items.len);
+    try std.testing.expectEqualStrings("get_weather", calls.items[0].name);
+    try std.testing.expectEqualStrings("{\"location\": \"SF\", \"unit\": \"c\"}", calls.items[0].arguments);
+    try std.testing.expect(!calls.items[0].inferred);
+}
+
+test "parseHarmonyToolCalls: recipient after the channel name parses the same" {
+    const text = "<|start|>assistant<|channel|>commentary to=functions.ping<|message|>{\"n\":1}<|call|>";
+    var calls: std.ArrayList(ParsedToolCall) = .empty;
+    defer {
+        for (calls.items) |tc| {
+            std.testing.allocator.free(tc.name);
+            std.testing.allocator.free(tc.arguments);
+        }
+        calls.deinit(std.testing.allocator);
+    }
+    try parseHarmonyToolCalls(std.testing.allocator, text, &calls);
+    try std.testing.expectEqual(@as(usize, 1), calls.items.len);
+    try std.testing.expectEqualStrings("ping", calls.items[0].name);
+    try std.testing.expectEqualStrings("{\"n\":1}", calls.items[0].arguments);
+}
+
+test "parseHarmonyToolCalls: truncated arguments ship NAME + {}, never a fragment" {
+    // Cut mid-value. The call is real (the header resolved), so the name must
+    // survive, but a partial value must never be presented as an argument.
+    const text = "<|start|>assistant to=functions.search<|channel|>commentary<|message|>{\"q\": \"how do I";
+    var calls: std.ArrayList(ParsedToolCall) = .empty;
+    defer {
+        for (calls.items) |tc| {
+            std.testing.allocator.free(tc.name);
+            std.testing.allocator.free(tc.arguments);
+        }
+        calls.deinit(std.testing.allocator);
+    }
+    try parseHarmonyToolCalls(std.testing.allocator, text, &calls);
+    try std.testing.expectEqual(@as(usize, 1), calls.items.len);
+    try std.testing.expectEqualStrings("search", calls.items[0].name);
+    try std.testing.expectEqualStrings("{}", calls.items[0].arguments);
+}
+
+test "parseHarmonyToolCalls: analysis and final segments are NOT tool calls" {
+    const text = "<|channel|>analysis<|message|>thinking<|end|>" ++
+        "<|start|>assistant<|channel|>final<|message|>done<|return|>";
+    var calls: std.ArrayList(ParsedToolCall) = .empty;
+    defer {
+        for (calls.items) |tc| {
+            std.testing.allocator.free(tc.name);
+            std.testing.allocator.free(tc.arguments);
+        }
+        calls.deinit(std.testing.allocator);
+    }
+    try parseHarmonyToolCalls(std.testing.allocator, text, &calls);
+    try std.testing.expectEqual(@as(usize, 0), calls.items.len);
+}
+
+test "parseHarmonyToolCalls: two tool segments both parse" {
+    const text = "<|start|>assistant to=functions.a<|channel|>commentary<|message|>{\"x\":1}<|call|>" ++
+        "<|start|>assistant to=functions.b<|channel|>commentary<|message|>{\"y\":2}<|call|>";
+    var calls: std.ArrayList(ParsedToolCall) = .empty;
+    defer {
+        for (calls.items) |tc| {
+            std.testing.allocator.free(tc.name);
+            std.testing.allocator.free(tc.arguments);
+        }
+        calls.deinit(std.testing.allocator);
+    }
+    try parseHarmonyToolCalls(std.testing.allocator, text, &calls);
+    try std.testing.expectEqual(@as(usize, 2), calls.items.len);
+    try std.testing.expectEqualStrings("a", calls.items[0].name);
+    try std.testing.expectEqualStrings("b", calls.items[1].name);
 }
 
 test "parseAtemToolCalls: canonical block — raw strings, spelled types, schema untouched" {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -101,6 +101,11 @@ pub const aliases = [_]Alias{
     // 8-bit attention/router/shared, MTP layer included. ~110 GB on disk;
     // needs a 128 GB Mac.
     .{ .name = "hy3", .tag = "295b", .repo = "mlx-community/Hy3-oQ2e", .is_default = true },
+    // OpenAI gpt-oss. The MXFP4-Q8 conversions keep the native mxfp4 expert
+    // banks (what the model was released in) and put attention/embeddings at
+    // affine 8-bit: ~12 GB for the 20B, ~63 GB for the 120B.
+    .{ .name = "gpt-oss", .tag = "20b", .repo = "mlx-community/gpt-oss-20b-MXFP4-Q8", .is_default = true },
+    .{ .name = "gpt-oss", .tag = "120b", .repo = "mlx-community/gpt-oss-120b-MXFP4-Q8" },
     .{ .name = "bge-small", .tag = "en", .repo = "mlx-community/bge-small-en-v1.5-8bit", .is_default = true },
 };
 

--- a/src/model.zig
+++ b/src/model.zig
@@ -166,6 +166,20 @@ pub const ModelConfig = struct {
     scale_embeddings: bool = true,
     has_pre_ff_norm: bool = true,
     has_qk_norm: bool = true,
+    // Learned per-head attention sinks (gpt_oss `self_attn.sinks`, [n_heads]):
+    // one extra logit column that lands in the softmax DENOMINATOR only, so
+    // every head can attend to "nothing". mlx's fused SDPA takes them
+    // natively (`mlx_fast_scaled_dot_product_attention`'s `sinks` argument);
+    // this flag is what makes the loader fetch the weight and the forward
+    // pass it instead of the null array.
+    has_attn_sinks: bool = false,
+    // gpt_oss clamped SwiGLU. Non-zero limit selects
+    //   clip(gate, max=limit) * sigmoid(alpha*gate) * (clip(up, ±limit) + 1)
+    // over the standard silu(gate)*up. The `+ 1` on the linear branch and the
+    // asymmetric clip are both load-bearing; `hidden_act` in a gpt_oss
+    // config.json says "silu" and is never read by the reference.
+    swiglu_limit: f32 = 0.0,
+    swiglu_alpha: f32 = 1.702,
 
     // MoE
     num_experts: u32 = 0,
@@ -934,6 +948,22 @@ pub const ModelConfig = struct {
         if (!self.isEosToken(120025)) self.addEosToken(120025);
     }
 
+    /// gpt_oss / harmony terminators, merged ADDITIVELY onto whatever the
+    /// config declared. A harmony assistant turn can end two ways and the
+    /// config names only one of them:
+    ///   <|return|> (200002) — the declared eos, ends a normal answer.
+    ///   <|call|>   (200012) — ends a TOOL CALL. Never the eos, so a
+    ///                         tools request that stops only on eos runs to
+    ///                         max_tokens with the call already complete.
+    /// <|end|> (200007) is deliberately NOT here: it closes the analysis
+    /// channel MID-turn, immediately before `<|start|>assistant<|channel|>final`
+    /// opens. Terminating on it would truncate every thinking response to its
+    /// reasoning and never emit an answer.
+    pub fn ensureGptOssTerminators(self: *ModelConfig) void {
+        if (!self.isEosToken(200002)) self.addEosToken(200002);
+        if (!self.isEosToken(200012)) self.addEosToken(200012);
+    }
+
     /// The head width the PREFILL SCORE tensor is actually built at. Normally
     /// `head_dim`, but an arch can score at a different width than it stores
     /// values at (an MLA q.k can contract over nope+rope widths while
@@ -968,6 +998,16 @@ pub const ModelConfig = struct {
         // delivered rather than paid-and-dropped). A plain chat request
         // defaults to the prompt-committed to=user channel instead
         // (chat.noThinkTailSuffix) — no reasoning pass runs at all.
+        // gpt_oss: UNCONDITIONALLY on. Harmony has no thinking-off mode — the
+        // template's `Reasoning: low|medium|high` sets depth, not presence, and
+        // the model opens `<|channel|>analysis<|message|>` on every turn no
+        // matter what we ask. Defaulting a silent request to off did not stop
+        // the reasoning pass, it just routed the analysis channel down the
+        // flush-text streaming branch, which leaked `<|channel|>analysis` and
+        // the reasoning itself into visible content (live 2026-08-12).
+        // Thinking-off here would have to be enforced in the PROMPT, and
+        // harmony offers no way to do it.
+        if (std.mem.eql(u8, self.model_type, "gpt_oss")) return true;
         if (has_tools and std.mem.eql(u8, self.model_type, "muse_glimmer")) return true;
         // bailing_hybrid (Ling 3.0): thinking-on with or without tools. The
         // checkpoint's own template normalizes an undefined `enable_thinking`
@@ -2129,6 +2169,79 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
         if (cfg_obj.get("query_pre_attn_scalar") == null) {
             config.query_pre_attn_scalar = config.head_dim;
         }
+    } else if (std.mem.eql(u8, model_type, "gpt_oss")) {
+        // OpenAI gpt-oss (20B-A3.6B / 120B-A5.1B). A plain dense-attention MoE
+        // that rides the qwen3_moe forward arms — no linear/SSM layers, no
+        // module-owned decode state, so prefix cache, batched decode and spec
+        // decode all apply normally. Family-specific pieces:
+        //   1. Learned per-head attention SINKS (self_attn.sinks) — an extra
+        //      softmax-denominator column. mlx's fused SDPA takes them.
+        //   2. Clamped SwiGLU (swiglu_limit, alpha 1.702, +1 on the linear
+        //      branch) instead of silu(gate)*up.
+        //   3. Additive biases everywhere: q/k/v/o_proj.bias, mlp.router.bias
+        //      and per-expert gate/up/down bias — all living BESIDE the affine
+        //      quantizer's `.biases` tensors in the same checkpoint.
+        //   4. No QK norm.
+        // Router is softmax-over-top-k, which is algebraically identical to
+        // the existing softmax-all → top-k → renorm chain, so moe_route_norm
+        // stays true and moe_sigmoid_router stays false.
+        config.model_type = "gpt_oss";
+        config.weight_prefix = "model";
+        config.norm_has_offset = false;
+        config.scale_embeddings = false;
+        config.has_pre_ff_norm = false;
+        config.has_qk_norm = false;
+        config.hidden_act = .silu;
+        config.has_attn_sinks = true;
+        // ONE theta for both layer types. The Gemma-flavored default of 10000
+        // would silently mis-base every sliding layer — the muse
+        // first-turn-repetition class (deterministic "coherent then loops").
+        config.rope_local_base_freq = config.rope_theta;
+        config.rope_scaling_factor = 1.0;
+        if (cfg_obj.get("query_pre_attn_scalar") == null) {
+            config.query_pre_attn_scalar = config.head_dim;
+        }
+        // Expert count rides `num_local_experts`; the generic block only knows
+        // `num_experts`. Top-k has two spellings and both appear in shipped
+        // configs (`num_experts_per_tok` is generic, `experts_per_token` is not).
+        if (cfg_obj.get("num_local_experts")) |v| {
+            if (v == .integer) config.num_experts = @intCast(v.integer);
+        }
+        if (cfg_obj.get("experts_per_token")) |v| {
+            if (v == .integer) config.num_experts_per_tok = @intCast(v.integer);
+        }
+        // There is no moe_intermediate_size key: the expert width IS
+        // intermediate_size (2880 on both sizes).
+        if (config.moe_intermediate_size == 0) {
+            config.moe_intermediate_size = config.intermediate_size;
+        }
+        if (cfg_obj.get("swiglu_limit")) |v| config.swiglu_limit = jsonFloat(v);
+        // Flat YaRN block. mscale is COMPUTED, never read: the config ships no
+        // "attention_factor" at all, and mlx-lm's YarnRoPE defaults
+        // (mscale 1 / mscale_all_dim 0) give 0.1*ln(factor) + 1. Laguna
+        // precedent — but note dsv4 is the same shape with the OPPOSITE
+        // answer, so this stays a per-arch decision.
+        if (cfg_obj.get("rope_scaling")) |rs| {
+            if (rs == .object) {
+                const is_yarn = if (rs.object.get("rope_type")) |rt|
+                    (rt == .string and std.mem.eql(u8, rt.string, "yarn"))
+                else
+                    false;
+                if (is_yarn) {
+                    config.rope_yarn = true;
+                    if (rs.object.get("factor")) |x| config.yarn_factor = jsonFloat(x);
+                    if (rs.object.get("beta_fast")) |x| config.yarn_beta_fast = jsonFloat(x);
+                    if (rs.object.get("beta_slow")) |x| config.yarn_beta_slow = jsonFloat(x);
+                    if (rs.object.get("original_max_position_embeddings")) |x| {
+                        if (x == .integer) config.yarn_orig_max_pos = @intCast(x.integer);
+                    }
+                    if (config.yarn_factor > 1.0) {
+                        config.yarn_attention_factor = 0.1 * @log(config.yarn_factor) + 1.0;
+                    }
+                }
+            }
+        }
+        config.ensureGptOssTerminators();
     } else if (std.mem.eql(u8, model_type, "hy_v3")) {
         // Tencent Hunyuan 3 (Hy3, 295B-A21B MoE; July 2026). Pure
         // full-attention MoE that rides the qwen3_moe forward arms: GQA with
@@ -3726,6 +3839,15 @@ test "defaultEnableThinking: opt-in per arch, and every existing arch stays off"
     const ling = ModelConfig{ .model_type = "bailing_hybrid" };
     try testing.expect(ling.defaultEnableThinking(false));
     try testing.expect(ling.defaultEnableThinking(true));
+    // gpt_oss opts in with AND without tools. Unlike muse there is no
+    // thinking-off prompt to commit: harmony's `Reasoning: low|medium|high`
+    // sets depth, not presence, so the model opens an analysis channel on
+    // every turn. Defaulting a silent request off did not skip the reasoning
+    // pass — it sent the analysis channel down the flush-text streaming
+    // branch, leaking `<|channel|>analysis` and the reasoning into content.
+    const goss = ModelConfig{ .model_type = "gpt_oss" };
+    try testing.expect(goss.defaultEnableThinking(false));
+    try testing.expect(goss.defaultEnableThinking(true));
 }
 
 test "defaultEnableThinking: the checkpoint's own generation_config default outranks the arch allowlist" {
@@ -4246,6 +4368,106 @@ test "ModelConfig parses laguna (poolside Laguna-S-2.1): per-layer heads, softpl
     try testing.expectEqual(@as(usize, 2), eos.len);
     try testing.expectEqual(@as(u32, 2), eos[0]);
     try testing.expectEqual(@as(u32, 24), eos[1]);
+}
+
+test "ModelConfig: gpt_oss (OpenAI gpt-oss-20b) config parse" {
+    // Trimmed from mlx-community/gpt-oss-20b-MXFP4-Q8/config.json. The 120B is
+    // the same shape (36 layers, 128 experts), so one block serves both.
+    const json =
+        \\{
+        \\  "architectures": ["GptOssForCausalLM"],
+        \\  "model_type": "gpt_oss",
+        \\  "attention_bias": true,
+        \\  "head_dim": 64,
+        \\  "hidden_act": "silu",
+        \\  "hidden_size": 2880,
+        \\  "initial_context_length": 4096,
+        \\  "intermediate_size": 2880,
+        \\  "layer_types": ["sliding_attention", "full_attention", "sliding_attention", "full_attention"],
+        \\  "max_position_embeddings": 131072,
+        \\  "num_attention_heads": 64,
+        \\  "num_hidden_layers": 24,
+        \\  "num_key_value_heads": 8,
+        \\  "num_local_experts": 32,
+        \\  "num_experts_per_tok": 4,
+        \\  "experts_per_token": 4,
+        \\  "rms_norm_eps": 1e-05,
+        \\  "rope_scaling": {
+        \\    "beta_fast": 32.0, "beta_slow": 1.0, "factor": 32.0,
+        \\    "original_max_position_embeddings": 4096,
+        \\    "rope_type": "yarn", "truncate": false
+        \\  },
+        \\  "rope_theta": 150000,
+        \\  "sliding_window": 128,
+        \\  "swiglu_limit": 7.0,
+        \\  "tie_word_embeddings": false,
+        \\  "vocab_size": 201088,
+        \\  "eos_token_id": 200002,
+        \\  "quantization": {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+        \\}
+    ;
+    const config = try parseConfigFromJson(testing.allocator, json);
+    try testing.expectEqualStrings("gpt_oss", config.model_type);
+    try testing.expectEqualStrings("model", config.weight_prefix);
+    // Qwen-style norm/embedding flags; gpt-oss has NO QK norm.
+    try testing.expect(!config.norm_has_offset);
+    try testing.expect(!config.scale_embeddings);
+    try testing.expect(!config.has_pre_ff_norm);
+    try testing.expect(!config.has_qk_norm);
+    // MoE dims: num_local_experts is the spelling, and the expert width is
+    // plain intermediate_size (no moe_intermediate_size key).
+    try testing.expectEqual(@as(u32, 32), config.num_experts);
+    try testing.expectEqual(@as(u32, 4), config.num_experts_per_tok);
+    try testing.expectEqual(@as(u32, 2880), config.moe_intermediate_size);
+    // Router is a plain softmax-over-top-k with an ADDITIVE bias, not hy3's
+    // sigmoid+selection-bias chain.
+    try testing.expect(!config.moe_sigmoid_router);
+    try testing.expect(config.moe_route_norm);
+    // Attention shape: hd 64, GQA 64/8, scale = head_dim^-0.5.
+    try testing.expectEqual(@as(u32, 64), config.head_dim);
+    try testing.expectEqual(@as(u32, 64), config.num_attention_heads);
+    try testing.expectEqual(@as(u32, 8), config.num_key_value_heads);
+    try testing.expectEqual(@as(u32, 64), config.query_pre_attn_scalar);
+    // Learned per-head attention sinks (self_attn.sinks) — the softmax
+    // denominator gets an extra column; SDPA takes them natively.
+    try testing.expect(config.has_attn_sinks);
+    // Alternating layer types, sliding FIRST (layer 0 is local).
+    try testing.expect(config.has_explicit_layer_types);
+    try testing.expect(!config.isGlobalLayer(0));
+    try testing.expect(config.isGlobalLayer(1));
+    try testing.expect(config.has_sliding_window);
+    try testing.expectEqual(@as(u32, 128), config.sliding_window);
+    // ONE theta for both layer types. Leaving rope_local_base_freq at the
+    // Gemma-flavored 10000 default would mis-base every sliding layer — the
+    // muse first-turn-repetition class (deterministic "coherent then loops").
+    try testing.expectApproxEqAbs(@as(f32, 150000.0), config.rope_theta, 1.0);
+    try testing.expectApproxEqAbs(@as(f32, 150000.0), config.rope_local_base_freq, 1.0);
+    // YaRN: mscale is COMPUTED (0.1*ln(32)+1), matching mlx-lm's YarnRoPE
+    // defaults (mscale 1 / mscale_all_dim 0) — the config ships no
+    // attention_factor at all. Laguna precedent.
+    try testing.expect(config.rope_yarn);
+    try testing.expectApproxEqAbs(@as(f32, 32.0), config.yarn_factor, 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 32.0), config.yarn_beta_fast, 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 1.0), config.yarn_beta_slow, 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 1.3465735902799727), config.yarn_attention_factor, 1e-9);
+    try testing.expectEqual(@as(u32, 4096), config.yarn_orig_max_pos);
+    // Clamped SwiGLU: clip(gate, max=limit) * sigmoid(alpha*gate) * (clip(up, ±limit) + 1).
+    // `hidden_act: "silu"` in the config is a lie — the reference never uses it.
+    try testing.expectApproxEqAbs(@as(f32, 7.0), config.swiglu_limit, 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 1.702), config.swiglu_alpha, 1e-6);
+    // Quant: mxfp4 gs32 for the expert banks (attention/embed/lm_head ride
+    // per-tensor affine-8 overrides resolved at weight-load time).
+    try testing.expectEqual(QuantMode.mxfp4, config.quant_mode);
+    try testing.expectEqual(@as(u32, 4), config.quant_bits);
+    try testing.expectEqual(@as(u32, 32), config.quant_group_size);
+    // Terminators merge ADDITIVELY: <|return|> (200002, the declared eos) and
+    // <|call|> (200012, which ends a tool call and is NEVER the eos).
+    // <|end|> (200007) is deliberately absent — it closes the analysis channel
+    // MID-generation, before the final channel opens.
+    const eos = config.eosTokenSlice();
+    try testing.expectEqual(@as(usize, 2), eos.len);
+    try testing.expectEqual(@as(u32, 200002), eos[0]);
+    try testing.expectEqual(@as(u32, 200012), eos[1]);
 }
 
 test "ModelConfig: laguna YaRN mscale is COMPUTED, never read from attention_factor (Laguna-XS ships 1.0)" {

--- a/src/model_discovery.zig
+++ b/src/model_discovery.zig
@@ -51,6 +51,7 @@ const supported_model_types = [_][]const u8{
     "muse_glimmer", // meta-models Muse-Glimmer-30B (dense VL; text served, vision pending)
     "muse_glimmer_text",
     "bailing_hybrid", // inclusionAI Ling 3.0 (KDA + MLA hybrid MoE)
+    "gpt_oss", // OpenAI gpt-oss (20B-A3.6B / 120B-A5.1B MoE, harmony format)
 };
 
 /// Native media-generation archs (image / audio / video / 3D), served by the

--- a/src/server.zig
+++ b/src/server.zig
@@ -7038,6 +7038,7 @@ fn handleStreamingGeneration(
     // answer into reasoning_content and left `content` empty (live 2026-08-13).
     // A model that opens the block itself is picked up by `saw_think_open`.
     var in_think_block = prompt_opened_think;
+    const gated_stream = has_tools or std.mem.eql(u8, config.model_type, "gpt_oss");
     var think_closed = false; // a complete think block was already split+emitted this stream
     // Leading whitespace is suppressed until the first visible byte, so the
     // stream reaches the same content bytes as splitThinkBlock's own
@@ -7135,7 +7136,7 @@ fn handleStreamingGeneration(
         };
 
         // Accumulate for stop sequence and tool call detection
-        if (has_tools or stop_sequences.len > 0) {
+        if (gated_stream or stop_sequences.len > 0) {
             try text_buf.appendSlice(allocator, token_text);
         }
 
@@ -7155,7 +7156,7 @@ fn handleStreamingGeneration(
             }
         }
 
-        if (has_tools) {
+        if (gated_stream) {
             // Stream tokens until we detect a tool call pattern starting, then buffer.
             // Detection rules live in `chat.streamShouldBufferForTools` — it
             // covers the full `<tool…>` family (including bare DSV4 `<tool>`),
@@ -7310,6 +7311,27 @@ fn handleStreamingGeneration(
                     try think_buf.appendSlice(allocator, remaining);
                     allocator.free(remaining);
                     skipped_think_open = true;
+                } else if (chat_mod.harmonyThinkOpenerAt(think_buf.items) == .analysis) {
+                    // gpt_oss: `[<|start|>assistant]<|channel|>analysis<|message|>`
+                    // opens a reasoning segment that closes at <|end|>. Consume
+                    // the header — every byte of it is ordinary text, and the
+                    // close matcher below assumes reasoning starts at byte 0.
+                    const skip = switch (chat_mod.harmonyThinkOpenerAt(think_buf.items)) {
+                        .analysis => |hl| hl,
+                        else => unreachable,
+                    };
+                    saw_think_open = true;
+                    think_close_tag = "<|end|>";
+                    var skip2 = skip;
+                    while (skip2 < think_buf.items.len and think_buf.items[skip2] == '\n') skip2 += 1;
+                    const remaining = try allocator.dupe(u8, think_buf.items[skip2..]);
+                    think_buf.clearAndFree(allocator);
+                    try think_buf.appendSlice(allocator, remaining);
+                    allocator.free(remaining);
+                    skipped_think_open = true;
+                } else if (chat_mod.harmonyThinkOpenerAt(think_buf.items) == .growing) {
+                    // Harmony header still arriving — wait, or `<|channel|>anal`
+                    // leaks as reasoning.
                 } else if (chat_mod.museThinkOpenerAt(think_buf.items) == .self_opened) {
                     // Muse-Glimmer reasoning segment (` to=self<|message|>`) —
                     // closes at <|eom|>. The direct-answer header
@@ -7403,7 +7425,21 @@ fn handleStreamingGeneration(
                 }
                 break :blk_m null;
             };
+            // Harmony (gpt_oss): the analysis channel closes at <|end|> (or
+            // <|return|>, if the model skipped straight to a return). Its
+            // reasoning also has a HEADER prefix to drop, which the pos/len
+            // shape can't express — `harmony_reason_from` below carries that.
+            const harmony_close: ?struct { pos: usize, len: usize } = blk_h: {
+                if (!std.mem.eql(u8, think_close_tag, "<|end|>")) break :blk_h null;
+                if (std.mem.indexOf(u8, think_buf.items, "<|end|>")) |q|
+                    break :blk_h .{ .pos = q, .len = "<|end|>".len };
+                // The model can skip straight to the return without an <|end|>.
+                if (std.mem.indexOf(u8, think_buf.items, "<|return|>")) |q|
+                    break :blk_h .{ .pos = q, .len = "<|return|>".len };
+                break :blk_h null;
+            };
             const close_match: ?struct { pos: usize, len: usize, is_channel: bool } = blk: {
+                if (harmony_close) |m| break :blk .{ .pos = m.pos, .len = m.len, .is_channel = false };
                 if (muse_close) |m| break :blk .{ .pos = m.pos, .len = m.len, .is_channel = false };
                 if (inkling_pos) |p| break :blk .{ .pos = p, .len = inkling_len, .is_channel = false };
                 if (think_match == null and channel_pos == null) break :blk null;
@@ -7429,6 +7465,11 @@ fn handleStreamingGeneration(
                 // content message ends at its own <|end_message|>.
                 if (std.mem.startsWith(u8, content_after, "<|message_model|>")) content_after = content_after["<|message_model|>".len..];
                 if (std.mem.startsWith(u8, content_after, "<|content_text|>")) content_after = content_after["<|content_text|>".len..];
+                // Harmony: the answer arrives as a whole new segment —
+                // `<|start|>assistant<|channel|>final<|message|>` — and every
+                // byte of that header is ordinary text that would otherwise
+                // ride out as content.
+                content_after = chat_mod.stripHarmonySegmentHeader(content_after);
                 if (std.mem.indexOf(u8, content_after, "<|end_message|>")) |em| content_after = content_after[0..em];
                 // Strip a muse next-segment header (<|start|>assistant
                 // to=user<|message|>). A header still ARRIVING (start marker,
@@ -7535,7 +7576,7 @@ fn handleStreamingGeneration(
 
     // Check for tool calls in accumulated text
     var finish_reason: []const u8 = if (client_gone) "client_disconnect" else if (stopped) "stop" else ts.finish_reason;
-    if (has_tools and !client_gone) {
+    if (gated_stream and !client_gone) {
         log.debug("  checking {d} bytes of streamed text for tool calls\n", .{text_buf.items.len});
         if (log.isDebug() and text_buf.items.len > 0) {
             log.debug("  raw generated text before tool parse ({d}b): {s}\n", .{ text_buf.items.len, text_buf.items[0..@min(text_buf.items.len, 4000)] });
@@ -7553,7 +7594,7 @@ fn handleStreamingGeneration(
         const norm_owned = try chat_mod.normalizeEmbeddedThinkBlocks(allocator, text_buf.items);
         defer if (norm_owned) |n| allocator.free(n);
         const gen_text: []const u8 = norm_owned orelse text_buf.items;
-        const found_calls = try parseToolCallsForRequest(allocator, gen_text, tools_json, allow_parallel_tools);
+        const found_calls = if (has_tools) try parseToolCallsForRequest(allocator, gen_text, tools_json, allow_parallel_tools) else null;
         if (found_calls) |tool_calls| {
             defer {
                 for (tool_calls) |tc| {
@@ -11828,6 +11869,7 @@ fn handleAnthropicStreaming(
     // answer into reasoning_content and left `content` empty (live 2026-08-13).
     // A model that opens the block itself is picked up by `saw_think_open`.
     var in_think_block = prompt_opened_think;
+    const gated_stream = has_tools or std.mem.eql(u8, config.model_type, "gpt_oss");
     // Set once the buffered think block has been split + emitted (tools
     // branch). Releases the buffer hold AND tells the end-of-stream split
     // that the remaining text has no template-opened semantics.
@@ -11918,7 +11960,7 @@ fn handleAnthropicStreaming(
             break :blk with_carry;
         };
 
-        if (has_tools or stop_sequences.len > 0) {
+        if (gated_stream or stop_sequences.len > 0) {
             try text_buf.appendSlice(allocator, token_text);
         }
 
@@ -11938,7 +11980,7 @@ fn handleAnthropicStreaming(
             }
         }
 
-        if (has_tools) {
+        if (gated_stream) {
             // Buffer for tool detection. Detection rules live in
             // `chat.streamShouldBufferForTools` — the SAME predicate as the
             // chat-completions stream (this path once carried its own inline
@@ -12077,6 +12119,34 @@ fn handleAnthropicStreaming(
                         try sendAnthropicEvent(stream, "content_block_start", sd);
                         thinking_block_open = true;
                     }
+                } else if (chat_mod.harmonyThinkOpenerAt(think_buf.items) == .analysis) {
+                    // gpt_oss: `[<|start|>assistant]<|channel|>analysis<|message|>`
+                    // opens a reasoning segment that closes at <|end|>. Consume
+                    // the header — every byte of it is ordinary text, and the
+                    // close matcher below assumes reasoning starts at byte 0.
+                    const skip = switch (chat_mod.harmonyThinkOpenerAt(think_buf.items)) {
+                        .analysis => |hl| hl,
+                        else => unreachable,
+                    };
+                    think_close_tag = "<|end|>";
+                    var skip2 = skip;
+                    while (skip2 < think_buf.items.len and think_buf.items[skip2] == '\n') skip2 += 1;
+                    const remaining = try allocator.dupe(u8, think_buf.items[skip2..]);
+                    think_buf.clearAndFree(allocator);
+                    try think_buf.appendSlice(allocator, remaining);
+                    allocator.free(remaining);
+                    skipped_think_open = true;
+                    if (!thinking_block_open) {
+                        const sd = try std.fmt.allocPrint(allocator,
+                            \\{{"type":"content_block_start","index":{d},"content_block":{{"type":"thinking","thinking":"","signature":""}}}}
+                        , .{block_index});
+                        defer allocator.free(sd);
+                        try sendAnthropicEvent(stream, "content_block_start", sd);
+                        thinking_block_open = true;
+                    }
+                } else if (chat_mod.harmonyThinkOpenerAt(think_buf.items) == .growing) {
+                    // Harmony header still arriving — wait, or `<|channel|>anal`
+                    // leaks as reasoning.
                 } else if (chat_mod.museThinkOpenerAt(think_buf.items) == .self_opened) {
                     // Muse-Glimmer reasoning segment (` to=self<|message|>`) —
                     // closes at <|eom|>. The direct-answer header closes via
@@ -12166,7 +12236,21 @@ fn handleAnthropicStreaming(
                 }
                 break :blk_m null;
             };
+            // Harmony (gpt_oss): the analysis channel closes at <|end|> (or
+            // <|return|>, if the model skipped straight to a return). Its
+            // reasoning also has a HEADER prefix to drop, which the pos/len
+            // shape can't express — `harmony_reason_from` below carries that.
+            const harmony_close: ?struct { pos: usize, len: usize } = blk_h: {
+                if (!std.mem.eql(u8, think_close_tag, "<|end|>")) break :blk_h null;
+                if (std.mem.indexOf(u8, think_buf.items, "<|end|>")) |q|
+                    break :blk_h .{ .pos = q, .len = "<|end|>".len };
+                // The model can skip straight to the return without an <|end|>.
+                if (std.mem.indexOf(u8, think_buf.items, "<|return|>")) |q|
+                    break :blk_h .{ .pos = q, .len = "<|return|>".len };
+                break :blk_h null;
+            };
             const close_match: ?struct { pos: usize, len: usize, is_channel: bool } = blk: {
+                if (harmony_close) |m| break :blk .{ .pos = m.pos, .len = m.len, .is_channel = false };
                 if (muse_close) |m| break :blk .{ .pos = m.pos, .len = m.len, .is_channel = false };
                 if (inkling_pos) |p| break :blk .{ .pos = p, .len = inkling_len, .is_channel = false };
                 if (think_match == null and channel_pos == null) break :blk null;
@@ -12191,6 +12275,11 @@ fn handleAnthropicStreaming(
                 if (std.mem.startsWith(u8, content_after, "<|channel>")) content_after = content_after[10..];
                 if (std.mem.startsWith(u8, content_after, "<|message_model|>")) content_after = content_after["<|message_model|>".len..];
                 if (std.mem.startsWith(u8, content_after, "<|content_text|>")) content_after = content_after["<|content_text|>".len..];
+                // Harmony: the answer arrives as a whole new segment —
+                // `<|start|>assistant<|channel|>final<|message|>` — and every
+                // byte of that header is ordinary text that would otherwise
+                // ride out as content.
+                content_after = chat_mod.stripHarmonySegmentHeader(content_after);
                 if (std.mem.indexOf(u8, content_after, "<|end_message|>")) |em| content_after = content_after[0..em];
                 // Muse next-segment header: strip when complete, arm the
                 // plain-arm skip when still arriving.
@@ -12279,7 +12368,7 @@ fn handleAnthropicStreaming(
     // Handle tool calls
     var finish_reason: []const u8 = if (client_gone) "client_disconnect" else if (stopped) "stop" else ts.finish_reason;
 
-    if (has_tools and !client_gone) {
+    if (gated_stream and !client_gone) {
         if (log.isDebug() and text_buf.items.len > 0) {
             log.debug("  raw generated text before tool parse ({d}b): {s}\n", .{ text_buf.items.len, text_buf.items[0..@min(text_buf.items.len, 4000)] });
             if (std.c.getenv("MLX_SERVE_RAW_DUMP_FILE")) |dump_path| {
@@ -12292,7 +12381,7 @@ fn handleAnthropicStreaming(
         const norm_owned = try chat_mod.normalizeEmbeddedThinkBlocks(allocator, text_buf.items);
         defer if (norm_owned) |n| allocator.free(n);
         const gen_text: []const u8 = norm_owned orelse text_buf.items;
-        const found_calls = try parseToolCallsForRequest(allocator, gen_text, tools_json, allow_parallel_tools);
+        const found_calls = if (has_tools) try parseToolCallsForRequest(allocator, gen_text, tools_json, allow_parallel_tools) else null;
         if (found_calls) |tool_calls| {
             defer {
                 for (tool_calls) |tc| {

--- a/src/tokenizer.zig
+++ b/src/tokenizer.zig
@@ -21,6 +21,26 @@ pub const FlaggedSpecial = struct { id: u32, content: []const u8 };
 /// regardless of what produced it (a collapsed distribution can rank one top-5 at a
 /// degenerate position); the substring rule errs toward exemption, which can
 /// only ever keep a token reachable.
+/// Specials a model legitimately EMITS but that no template ever RENDERS.
+///
+/// `reservedOutputIds` derives legitimacy from presence in the chat template,
+/// which is right for every marker that appears on both sides of the
+/// conversation (role markers, think tags, tool wrappers) — the model emits
+/// what it was shown. An output-only marker breaks that symmetry: it exists
+/// purely in generated text, so the template cannot vouch for it and the
+/// derivation files it as reserved. Masking one does not merely drop it; the
+/// model substitutes whatever it can still draw, and a malformed structure is
+/// worse than a missing token.
+///
+/// Kept to markers that are unambiguous across families, since this is the one
+/// place the derivation is overridden by name.
+fn isOutputOnlySpecial(content: []const u8) bool {
+    // harmony (gpt_oss): declares a tool call's argument content type inside
+    // the header the MODEL writes — `to=functions.x <|constrain|>json`. The
+    // template renders tool calls only when replaying history, and omits it.
+    return std.mem.eql(u8, content, "<|constrain|>");
+}
+
 pub fn reservedOutputIds(
     allocator: std.mem.Allocator,
     flagged: []const FlaggedSpecial,
@@ -35,6 +55,7 @@ pub fn reservedOutputIds(
             if (sp.id == e) continue :outer;
         }
         if (std.mem.indexOf(u8, template_source, sp.content) != null) continue;
+        if (isOutputOnlySpecial(sp.content)) continue;
         try out.append(allocator, sp.id);
     }
     return out.toOwnedSlice(allocator);
@@ -2146,6 +2167,32 @@ test "parseMergePair handles both array and space-joined-string formats" {
         defer p.deinit();
         try testing.expect(parseMergePair(p.value) == null);
     }
+}
+
+test "reservedOutputIds: an OUTPUT-ONLY special is legit output the template cannot vouch for" {
+    // Live 2026-08-12, gpt-oss-20b. Harmony declares a tool call's argument
+    // content type INSIDE the segment header the model generates:
+    //   ...to=functions.get_weather <|constrain|>json<|message|>{...}<|call|>
+    // The chat template renders tool calls only for HISTORY, and that rendering
+    // omits <|constrain|> entirely — so the token appears nowhere in the
+    // template source and the template-presence derivation filed it as
+    // reserved. Masked, the model substituted the nearest thing it could still
+    // draw and produced `to=functions.get_weather <|channel|>commentary 1.0`,
+    // a malformed header that sent it into a repetition loop.
+    const alloc = testing.allocator;
+    const flagged = [_]FlaggedSpecial{
+        .{ .id = 200003, .content = "<|constrain|>" },
+        .{ .id = 200005, .content = "<|channel|>" },
+        .{ .id = 200013, .content = "<|reserved_200013|>" },
+    };
+    // A harmony template: mentions <|channel|>, never <|constrain|>.
+    const template = "<|start|>assistant<|channel|>final<|message|>{{ content }}";
+    const eos = [_]u32{200002};
+    const ids = try reservedOutputIds(alloc, &flagged, template, &eos);
+    defer alloc.free(ids);
+    // Only the genuinely-reserved slot is suppressed.
+    try testing.expectEqual(@as(usize, 1), ids.len);
+    try testing.expectEqual(@as(u32, 200013), ids[0]);
 }
 
 test "reservedOutputIds: specials minus template markers minus eos" {

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -4476,6 +4476,20 @@ const FullAttnWeights = struct {
     idx_qk_b: mlx.mlx_array = .{ .ctx = null },
     idx_q_norm: mlx.mlx_array = .{ .ctx = null },
     idx_k_norm: mlx.mlx_array = .{ .ctx = null },
+    // gpt_oss: ADDITIVE projection biases (`self_attn.{q,k,v,o}_proj.bias`).
+    // These are NOT the affine quantizer's `*_b` zero-points above — a gpt_oss
+    // checkpoint carries BOTH spellings on the same projection
+    // (`q_proj.bias` next to `q_proj.biases`), with different shapes and
+    // different meanings. Null-ctx on every other arch.
+    q_bias: mlx.mlx_array = .{ .ctx = null },
+    k_bias: mlx.mlx_array = .{ .ctx = null },
+    v_bias: mlx.mlx_array = .{ .ctx = null },
+    o_bias: mlx.mlx_array = .{ .ctx = null },
+    // gpt_oss: learned per-head attention sinks (`self_attn.sinks`, [n_heads]).
+    // One extra column in the softmax DENOMINATOR, letting a head attend to
+    // "nothing". Passed straight to mlx's fused SDPA, which takes them as a
+    // function constant (`_has_sinks_`) — no unfused fallback.
+    sinks: mlx.mlx_array = .{ .ctx = null },
 };
 
 /// qwen4_exp gated residual ("hyper connection"). `norm_w` is the grouped
@@ -4664,6 +4678,16 @@ pub const MoeMlpWeights = struct {
     // scores for top-k SELECTION only (weights come from the unbiased scores).
     // Non-null expert_bias routes moeMLP2 through hy3RoutingChain.
     expert_bias: ?mlx.mlx_array = null,
+    // gpt_oss ADDITIVE biases. `router_bias` ([num_experts]) is a plain Linear
+    // bias added to the router logits BEFORE top-k — unlike hy3's
+    // `expert_bias`, which is a selection-only score correction that never
+    // reaches the weights. The switch_* biases are the SwitchGLU per-expert
+    // biases ([num_experts, out]), gathered by expert index and added after
+    // each gather_qmm. All null-ctx on every other arch.
+    router_bias: mlx.mlx_array = .{ .ctx = null },
+    switch_gate_bias: mlx.mlx_array = .{ .ctx = null },
+    switch_up_bias: mlx.mlx_array = .{ .ctx = null },
+    switch_down_bias: mlx.mlx_array = .{ .ctx = null },
     route_norm: bool = true,
     route_scale: f32 = 1.0,
     // Hy3 shared expert is ALWAYS added, with no shared_expert_gate.
@@ -8883,6 +8907,36 @@ pub const Transformer = struct {
         return result;
     }
 
+    /// Add a gpt_oss SwitchGLU per-expert bias to a gather_qmm result, in
+    /// place. `bias` is the stacked [num_experts, out] bank; `sel` is the
+    /// per-slot expert index the matmul was gathered with, so row i of the
+    /// output gets `bias[sel[i]]`. No-op when the arch has no such bias.
+    ///
+    /// `sel` MUST be the same index vector the matmul used, in the same order:
+    /// on the sorted path that is `sorted_inds`, and the result is still in
+    /// sorted order until the inverse permutation runs.
+    fn addExpertBias(self: *const Transformer, out: *mlx.mlx_array, bias: mlx.mlx_array, sel: mlx.mlx_array) !void {
+        if (bias.ctx == null) return;
+        var rows = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(rows);
+        try mlx.check(mlx.mlx_take_axis(&rows, bias, sel, 0, self.s));
+        var summed = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_add(&summed, out.*, rows, self.s));
+        _ = mlx.mlx_array_free(out.*);
+        out.* = summed;
+    }
+
+    /// gpt_oss clamped SwiGLU, dispatched instead of `computeGeglu` when the
+    /// config declares a `swiglu_limit`. Kept OUT of `computeGeglu` on purpose:
+    /// that helper's two fast paths (`compiled_geglu`, `fusedSwiGLU`) both bake
+    /// in `silu(gate)*up`, and `fusedSwiGLU`'s exactness argument rests on a
+    /// sigmoid lookup table built for that exact expression. Routing a
+    /// different activation through them would be silently wrong rather than
+    /// slow, so the dispatch happens one level up.
+    fn computeGptOssSwiGLU(self: *const Transformer, gate: mlx.mlx_array, up: mlx.mlx_array) !mlx.mlx_array {
+        return gptOssSwiGLU(self.s, gate, up, self.config.swiglu_limit, self.config.swiglu_alpha);
+    }
+
     /// Fused logit softcap: tanh(x/cap) * cap in a single compiled kernel.
     fn applySoftcap(self: *const Transformer, logits: mlx.mlx_array) !mlx.mlx_array {
         if (self.compiled_softcap) |compiled| {
@@ -12147,6 +12201,7 @@ pub const Transformer = struct {
         const is_laguna = std.mem.eql(u8, cfg.model_type, "laguna");
         const is_inkling = cfg.isInkling();
         const is_mla = cfg.isMla();
+        const is_gpt_oss = std.mem.eql(u8, cfg.model_type, "gpt_oss");
 
         // PLD spec-decode: thread the per-position SSM capture flag down to the
         // GatedDeltaNet layers (which don't take the ctx). Reset on exit so it
@@ -12194,13 +12249,17 @@ pub const Transformer = struct {
         try self.beginMropeChunk(ctx, @intCast(offset), @intCast(seq_len), .bfloat16);
         defer endMropeChunk(ctx);
 
-        // Precompute sliding window masks (Gemma 4 + Laguna sliding layers)
+        // Precompute sliding window masks (Gemma 4 + Laguna + gpt_oss sliding
+        // layers). An arch whose attention arm reads these masks MUST appear
+        // in this gate — a missing arm here hands that arm an empty mask
+        // handle, and its decode branch then attends over the whole history
+        // with no error anywhere.
         var local_prefill_mask = mlx.mlx_array_new();
         defer _ = mlx.mlx_array_free(local_prefill_mask);
         var local_decode_mask = mlx.mlx_array_new();
         defer _ = mlx.mlx_array_free(local_decode_mask);
 
-        if ((is_gemma4 or is_laguna) and cfg.has_sliding_window) {
+        if ((is_gemma4 or is_laguna or is_gpt_oss) and cfg.has_sliding_window) {
             const sw: c_int = @intCast(cfg.sliding_window);
             const total_kv: c_int = @as(c_int, @intCast(offset)) + seq_len;
             const sliding = slidingViewFor(cfg, total_kv, seq_len);
@@ -12264,6 +12323,8 @@ pub const Transformer = struct {
                     break :blk r.out;
                 } else if (is_mla)
                     try self.mlaAttnWith(ctx, normed, &fa, li, @intCast(offset), batch, seq_len, is_prefill)
+                else if (is_gpt_oss)
+                    try self.gptOssAttnWith(ctx, normed, &fa, li, @intCast(offset), batch, seq_len, is_prefill, &local_prefill_mask, local_decode_mask)
                 else if (is_laguna)
                     try self.lagunaAttnWith(ctx, normed, &fa, li, @intCast(offset), batch, seq_len, is_prefill, &local_prefill_mask, local_decode_mask)
                 else if (is_gemma4)
@@ -14441,6 +14502,180 @@ pub const Transformer = struct {
             }
         }
         return self.qmatmul(x, w, sc, bi);
+    }
+
+    /// `attnProj` plus an ADDITIVE projection bias when one is present.
+    /// Separate from `qmatmulMaybeBias` so the decode-attn-quant side copy
+    /// still applies underneath — the bias is added to whatever the projection
+    /// produced, quantized or not.
+    inline fn attnProjBias(self: *Transformer, x: mlx.mlx_array, w: mlx.mlx_array, sc: mlx.mlx_array, bi: mlx.mlx_array, bias: mlx.mlx_array, decode_shape: bool, layer: u32) !mlx.mlx_array {
+        const mm = try self.attnProj(x, w, sc, bi, decode_shape, layer);
+        if (bias.ctx == null) return mm;
+        defer _ = mlx.mlx_array_free(mm);
+        var out = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_add(&out, mm, bias, self.s));
+        return out;
+    }
+
+    /// gpt_oss attention. Plain GQA (64/8 at hd 64 on the 20B) with four
+    /// departures from `gatedFullAttnWith`, which is why it is its own arm:
+    ///
+    ///   1. LEARNED PER-HEAD SINKS. `fa.sinks` rides into mlx's fused SDPA as
+    ///      an extra softmax-denominator column. It is a function constant
+    ///      (`_has_sinks_`) in the Metal kernel, so this costs no fallback.
+    ///   2. ALTERNATING SLIDING/FULL layers (`layer_types`), window 128.
+    ///      `gatedFullAttnWith` has no local-mask path at all.
+    ///   3. ADDITIVE q/k/v/o biases.
+    ///   4. NO QK norm.
+    ///
+    /// RoPE is ONE configuration for every layer — sliding and full alike take
+    /// the same YaRN-scaled freqs at the same theta. That is the reference's
+    /// shape (a single `initialize_rope` shared by all blocks) and it is why
+    /// there is no `is_full` branch on the rope here, unlike laguna.
+    ///
+    /// The fused quantized-KV attention path is deliberately NOT wired: those
+    /// kernels are ours and take no sink argument, so engaging them would drop
+    /// the sinks silently. Under `--kv-quant` this arm reads the dequantized
+    /// `DenseKVView` that `cache.update` already returns.
+    fn gptOssAttnWith(
+        self: *Transformer,
+        ctx: *ForwardCtx,
+        x: mlx.mlx_array,
+        fa: *const FullAttnWeights,
+        layer: u32,
+        offset: c_int,
+        batch: c_int,
+        seq_len: c_int,
+        is_prefill: bool,
+        local_prefill_mask: *mlx.mlx_array,
+        local_decode_mask: mlx.mlx_array,
+    ) !mlx.mlx_array {
+        const cfg = &self.config;
+        const is_full = cfg.isGlobalLayer(layer);
+        const h_count: c_int = @intCast(cfg.num_attention_heads);
+        const kv_h: c_int = @intCast(cfg.num_key_value_heads);
+        const hd: c_int = @intCast(cfg.head_dim);
+        const attn_scale: f32 = 1.0 / @sqrt(@as(f32, @floatFromInt(cfg.query_pre_attn_scalar)));
+        const q_shape = [_]c_int{ batch, seq_len, h_count, hd };
+        const kv_shape = [_]c_int{ batch, seq_len, kv_h, hd };
+        const flat_shape = [_]c_int{ batch, seq_len, h_count * hd };
+        const perm = [_]c_int{ 0, 2, 1, 3 };
+        const perm_back = [_]c_int{ 0, 2, 1, 3 };
+        const decode_shape = batch == 1 and !is_prefill;
+
+        const use_yarn = self.rope_freqs_yarn != null;
+        const rope_base = mlx.mlx_optional_float{
+            .value = cfg.rope_theta,
+            .has_value = !use_yarn, // precomputed yarn freqs override the base
+        };
+        const rope_freqs: mlx.mlx_array = if (use_yarn) self.rope_freqs_yarn.? else .{ .ctx = null };
+
+        const none_mask = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(none_mask);
+
+        // Q/K/V projections, each with its additive bias.
+        const q_proj = try self.attnProjBias(x, fa.q_w, fa.q_s, fa.q_b, fa.q_bias, decode_shape, layer);
+        defer _ = mlx.mlx_array_free(q_proj);
+        const k_proj = try self.attnProjBias(x, fa.k_w, fa.k_s, fa.k_b, fa.k_bias, decode_shape, layer);
+        defer _ = mlx.mlx_array_free(k_proj);
+        const v_proj = try self.attnProjBias(x, fa.v_w, fa.v_s, fa.v_b, fa.v_bias, decode_shape, layer);
+        defer _ = mlx.mlx_array_free(v_proj);
+
+        // Reshape → transpose to [B, H, S, D] → RoPE. No QK norm on this arch.
+        var q_r = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(q_r);
+        try mlx.check(mlx.mlx_reshape(&q_r, q_proj, &q_shape, 4, self.s));
+        var q_t = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(q_t);
+        try mlx.check(mlx.mlx_transpose_axes(&q_t, q_r, &perm, 4, self.s));
+
+        var k_r = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(k_r);
+        try mlx.check(mlx.mlx_reshape(&k_r, k_proj, &kv_shape, 4, self.s));
+        var k_t = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(k_t);
+        try mlx.check(mlx.mlx_transpose_axes(&k_t, k_r, &perm, 4, self.s));
+
+        var q_rope = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(q_rope);
+        var k_rope = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(k_rope);
+        try mlx.check(mlx.mlx_fast_rope(&q_rope, q_t, hd, false, rope_base, 1.0, offset, rope_freqs, self.s));
+        try mlx.check(mlx.mlx_fast_rope(&k_rope, k_t, hd, false, rope_base, 1.0, offset, rope_freqs, self.s));
+
+        // YaRN mscale on the rotated dims (full rotary here, so the whole
+        // head). Cast to q/k's dtype first — an f32 table would promote the
+        // product and upcast every downstream weight read (measured 3x on
+        // Laguna XS).
+        if (use_yarn) {
+            if (self.yarn_mscale) |ms_f32| {
+                const ms = try constTableAs(ms_f32, mlx.mlx_array_dtype(q_rope), &self.yarn_mscale_cast, self.s);
+                var q_scaled = mlx.mlx_array_new();
+                try mlx.check(mlx.mlx_multiply(&q_scaled, q_rope, ms, self.s));
+                _ = mlx.mlx_array_free(q_rope);
+                q_rope = q_scaled;
+                var k_scaled = mlx.mlx_array_new();
+                try mlx.check(mlx.mlx_multiply(&k_scaled, k_rope, ms, self.s));
+                _ = mlx.mlx_array_free(k_rope);
+                k_rope = k_scaled;
+            }
+        }
+
+        var v_r = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(v_r);
+        try mlx.check(mlx.mlx_reshape(&v_r, v_proj, &kv_shape, 4, self.s));
+        var v_t = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(v_t);
+        try mlx.check(mlx.mlx_transpose_axes(&v_t, v_r, &perm, 4, self.s));
+
+        // Sliding layers read only the tail their queries can reach, and the
+        // width is a property of the whole BLOCK: `window + q_len - 1`,
+        // because the FIRST query of the block reaches back furthest. That is
+        // `slidingViewFor`'s job, and it is the SAME call every mask below is
+        // built from — hand the view one width and the mask another and SDPA
+        // fails to broadcast them, which is an uncatchable MLX error rather
+        // than a bad answer. `cfg.sliding_window` here reads correct at
+        // q_len == 1 (span == window) and kills the process on the first
+        // spec-verify block or prefill chunk past the window.
+        const sliding = slidingViewFor(cfg, offset + seq_len, seq_len);
+        const max_kv: u32 = if (is_full) 0 else sliding.span;
+        var kv_view = try ctx.cache.update(layer, k_rope, v_t, self.s, max_kv);
+        defer kv_view.deinit();
+        const full_k = kv_view.k;
+        const full_v = kv_view.v;
+
+        var attn_out = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(attn_out);
+        if (is_full) {
+            const mode: [*:0]const u8 = if (is_prefill) "causal" else "";
+            try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&attn_out, q_rope, full_k, full_v, attn_scale, mode, none_mask, fa.sinks, false, self.s));
+        } else {
+            const sw: c_int = @intCast(cfg.sliding_window);
+            const total_kv: c_int = offset + seq_len;
+            if (is_prefill and total_kv <= sw) {
+                // Window degenerates to plain causal.
+                try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&attn_out, q_rope, full_k, full_v, attn_scale, "causal", none_mask, fa.sinks, false, self.s));
+            } else if (is_prefill) {
+                if (local_prefill_mask.ctx == null) {
+                    // Built at the TRIMMED width, matching the view above.
+                    local_prefill_mask.* = try self.createSlidingWindowMask(seq_len, sliding.kv_len, sw);
+                }
+                try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&attn_out, q_rope, full_k, full_v, attn_scale, "array", local_prefill_mask.*, fa.sinks, false, self.s));
+            } else if (@as(c_int, @intCast(ctx.cache.seqLen(layer))) <= sw) {
+                try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&attn_out, q_rope, full_k, full_v, attn_scale, "", none_mask, fa.sinks, false, self.s));
+            } else {
+                try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&attn_out, q_rope, full_k, full_v, attn_scale, "array", local_decode_mask, fa.sinks, false, self.s));
+            }
+        }
+
+        // [B,H,S,D] → [B,S,H*D] → o_proj (+ additive bias).
+        var attn_t = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(attn_t);
+        try mlx.check(mlx.mlx_transpose_axes(&attn_t, attn_out, &perm_back, 4, self.s));
+        var attn_flat = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(attn_flat);
+        try mlx.check(mlx.mlx_reshape(&attn_flat, attn_t, &flat_shape, 3, self.s));
+        return self.attnProjBias(attn_flat, fa.o_w, fa.o_s, fa.o_b, fa.o_bias, decode_shape, layer);
     }
 
     fn lagunaAttnWith(
@@ -16935,6 +17170,19 @@ pub const Transformer = struct {
             router_logits = try qmatmulBits(router_x, mw.router_w, mw.router_s, mw.router_b, router_qp.bits, router_qp.group_size, router_qp.mode, self.s);
         }
 
+        // gpt_oss: the router is a Linear WITH a bias, and the bias is added
+        // before top-k, so it changes which experts are selected — not just
+        // their weights. (Contrast hy3's `expert_bias`, applied to selection
+        // only and deliberately kept out of the weights.) Selecting top-k and
+        // then softmaxing those k values, as the reference does, is exactly
+        // the softmax-all → top-k → renormalize chain below.
+        if (mw.router_bias.ctx != null) {
+            var biased = mlx.mlx_array_new();
+            try mlx.check(mlx.mlx_add(&biased, router_logits, mw.router_bias, self.s));
+            _ = mlx.mlx_array_free(router_logits);
+            router_logits = biased;
+        }
+
         // Top-K + softmax/renormalize as a single fused kernel (when compiled).
         // Hy3 (expert_bias bound): sigmoid+bias selection instead of softmax.
         const routed = if (mw.expert_bias) |bias|
@@ -17006,10 +17254,17 @@ pub const Transformer = struct {
         const inds_shape = mlx.getShape(inds);
         const K = inds_shape[inds_shape.len - 1];
         const total_inds: c_int = B * S * K;
-        // Any multi-row input (prefill S>1 OR a batched-decode group B>1)
-        // takes the sort path: the gather_qmm arm below squeezes EVERY
-        // singleton axis, which is only unambiguous at B*S == 1.
-        const do_sort = B * S > 1 or total_inds >= 64;
+        // Per-expert ADDITIVE biases (gpt_oss) force the sorted path. The three
+        // decode fast paths below are all fused kernels that compute
+        // `act(gate) * up` straight out of gather_qmm with nowhere to add a
+        // per-expert bias term, and `moeDecodeGatherQmv` additionally bakes in
+        // the standard SwiGLU. Engaging any of them here would silently drop
+        // both the biases and the clamp. The sorted path's argsort costs
+        // essentially nothing at decode width (N = K = 4 here).
+        const has_expert_bias = mw.switch_gate_bias.ctx != null or
+            mw.switch_up_bias.ctx != null or
+            mw.switch_down_bias.ctx != null;
+        const do_sort = B * S > 1 or total_inds >= 64 or has_expert_bias;
         const no_idx = mlx.mlx_array{ .ctx = null };
 
         var down_out = mlx.mlx_array_new();
@@ -17073,6 +17328,7 @@ pub const Transformer = struct {
             var gate_out = mlx.mlx_array_new();
             defer _ = mlx.mlx_array_free(gate_out);
             try mlx.check(mlx.mlx_squeeze(&gate_out, gate_out_3d, self.s));
+            try self.addExpertBias(&gate_out, mw.switch_gate_bias, sorted_inds);
 
             var up_out_3d = mlx.mlx_array_new();
             defer _ = mlx.mlx_array_free(up_out_3d);
@@ -17080,8 +17336,13 @@ pub const Transformer = struct {
             var up_out = mlx.mlx_array_new();
             defer _ = mlx.mlx_array_free(up_out);
             try mlx.check(mlx.mlx_squeeze(&up_out, up_out_3d, self.s));
+            try self.addExpertBias(&up_out, mw.switch_up_bias, sorted_inds);
 
-            const expert_act = try self.computeGeglu(gate_out, up_out);
+            // gpt_oss swaps the activation itself, not just its inputs.
+            const expert_act = if (cfg.swiglu_limit > 0.0)
+                try self.computeGptOssSwiGLU(gate_out, up_out)
+            else
+                try self.computeGeglu(gate_out, up_out);
             defer _ = mlx.mlx_array_free(expert_act);
 
             // down: expand inner singleton → [N,1,intermediate] → gather_qmm → [N,1,hidden]
@@ -17094,6 +17355,9 @@ pub const Transformer = struct {
             var down_squeezed = mlx.mlx_array_new();
             defer _ = mlx.mlx_array_free(down_squeezed);
             try mlx.check(mlx.mlx_squeeze(&down_squeezed, down_3d, self.s)); // [N, hidden]
+            // Still in SORTED order here, which is the order `sorted_inds`
+            // indexes — the bias must be added before the inverse permutation.
+            try self.addExpertBias(&down_squeezed, mw.switch_down_bias, sorted_inds);
 
             // Inverse permute → original order, then reshape back to [B,S,K,hidden].
             var down_unsorted = mlx.mlx_array_new();
@@ -17741,6 +18005,7 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
     const is_inkling = std.mem.eql(u8, config.model_type, "inkling_mm_model");
     const is_bailing = std.mem.eql(u8, config.model_type, "bailing_hybrid");
     const is_qwen4 = config.isQwen4();
+    const is_gpt_oss = std.mem.eql(u8, config.model_type, "gpt_oss");
 
     for (0..config.num_hidden_layers) |i| {
         const li: u32 = @intCast(i);
@@ -18149,8 +18414,19 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
                 else
                     try getLayerScaleOrEmpty(weights, name_buf, prefix, li, "self_attn.o_proj.scales", config.quant_bits),
                 .o_b = try getLayerBias(weights, name_buf, prefix, li, "self_attn.o_proj.biases", &config),
-                .q_norm = try getLayerWeight(weights, name_buf, prefix, li, "self_attn.q_norm.weight"),
-                .k_norm = try getLayerWeight(weights, name_buf, prefix, li, "self_attn.k_norm.weight"),
+                // An arch that DECLARES QK norm must ship it (a missing weight
+                // there is a broken checkpoint, not a variant). One that
+                // declares it off — gpt_oss — has no q_norm/k_norm tensors at
+                // all, and the mandatory getter's `unreachable` would kill the
+                // process on load rather than report anything.
+                .q_norm = if (config.has_qk_norm)
+                    try getLayerWeight(weights, name_buf, prefix, li, "self_attn.q_norm.weight")
+                else
+                    (getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.q_norm.weight") orelse mlx.mlx_array_new()),
+                .k_norm = if (config.has_qk_norm)
+                    try getLayerWeight(weights, name_buf, prefix, li, "self_attn.k_norm.weight")
+                else
+                    (getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.k_norm.weight") orelse mlx.mlx_array_new()),
             } };
             {
                 // Dense bf16 (null-ctx scales): pre-transpose [out,in]→[in,out] so
@@ -18183,6 +18459,23 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
                     fa.idx_q_norm = try getLayerWeight(weights, name_buf, prefix, li, "self_attn.indexer.q_layernorm.weight");
                     fa.idx_k_norm = try getLayerWeight(weights, name_buf, prefix, li, "self_attn.indexer.k_layernorm.weight");
                     try maybeTransposeForBf16(&fa.idx_qk_w, fa.idx_qk_s, &owned_bf16, allocator, s);
+                }
+                // gpt_oss: ADDITIVE projection biases + per-head sinks.
+                //
+                // `.bias` and `.biases` are DIFFERENT TENSORS living side by
+                // side on the same projection in this checkpoint:
+                //   self_attn.q_proj.bias    [n_heads*head_dim]  additive
+                //   self_attn.q_proj.biases  [out, groups]       affine zero-points
+                // The affine ones are already bound above as `q_b`/`k_b`/…
+                // via getLayerBias. Reading either name for the other is a
+                // shape error at best and silently wrong output at worst, so
+                // the two suffixes stay spelled out in full at every site.
+                if (is_gpt_oss) {
+                    fa.q_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.q_proj.bias") orelse .{ .ctx = null };
+                    fa.k_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.k_proj.bias") orelse .{ .ctx = null };
+                    fa.v_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.v_proj.bias") orelse .{ .ctx = null };
+                    fa.o_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.o_proj.bias") orelse .{ .ctx = null };
+                    fa.sinks = getLayerWeightOpt(weights, name_buf, prefix, li, "self_attn.sinks") orelse .{ .ctx = null };
                 }
             }
         }
@@ -18562,6 +18855,62 @@ fn initMoeLayers(allocator: std.mem.Allocator, config: ModelConfig, weights: *co
                 try maybeTransposeForBf16(&mw.shared_up_w, mw.shared_up_s, &owned_bf16, allocator, s);
                 try maybeTransposeForBf16(&mw.shared_down_w, mw.shared_down_s, &owned_bf16, allocator, s);
             }
+        } else if (layer_is_moe and is_gpt_oss) {
+            // gpt_oss MoE. Same stacked [E, out, in] expert banks as qwen3.5,
+            // under a different container name (`mlp.experts.*` rather than
+            // `mlp.switch_mlp.*`) and a differently-named router
+            // (`mlp.router.*` rather than `mlp.gate.*`). No shared expert.
+            //
+            // The `.bias`/`.biases` split from the attention binding repeats
+            // here and matters more, because BOTH are per-expert and 2-D:
+            //   mlp.experts.gate_proj.bias    [E, inter]        additive
+            //   mlp.experts.gate_proj.scales  [E, inter, groups] quant scales
+            //   mlp.experts.gate_proj.biases  — absent under mxfp4 (fp modes
+            //                                    store no zero-points at all)
+            // so the additive bias is the ONLY `bias`-ish tensor present on a
+            // gpt_oss expert bank, and binding it into `*_b` would hand
+            // gather_qmm a zero-point tensor of the wrong rank.
+            lw.mlp = .{ .moe = .{
+                .router_w = try getLayerWeight(weights, name_buf, prefix, li, "mlp.router.weight"),
+                .router_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.router.scales") orelse mlx.mlx_array_new(),
+                .router_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.router.biases") orelse mlx.mlx_array_new(),
+                .router_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.router.bias") orelse .{ .ctx = null },
+                .switch_gate_w = try getLayerWeight(weights, name_buf, prefix, li, "mlp.experts.gate_proj.weight"),
+                .switch_gate_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.gate_proj.scales") orelse mlx.mlx_array_new(),
+                .switch_gate_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.gate_proj.biases") orelse mlx.mlx_array_new(),
+                .switch_gate_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.gate_proj.bias") orelse .{ .ctx = null },
+                .switch_up_w = try getLayerWeight(weights, name_buf, prefix, li, "mlp.experts.up_proj.weight"),
+                .switch_up_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.up_proj.scales") orelse mlx.mlx_array_new(),
+                .switch_up_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.up_proj.biases") orelse mlx.mlx_array_new(),
+                .switch_up_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.up_proj.bias") orelse .{ .ctx = null },
+                .switch_down_w = try getLayerWeight(weights, name_buf, prefix, li, "mlp.experts.down_proj.weight"),
+                .switch_down_s = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.down_proj.scales") orelse mlx.mlx_array_new(),
+                .switch_down_b = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.down_proj.biases") orelse mlx.mlx_array_new(),
+                .switch_down_bias = getLayerWeightOpt(weights, name_buf, prefix, li, "mlp.experts.down_proj.bias") orelse .{ .ctx = null },
+                // No shared expert: empty handles, and shared_expert_gate_w
+                // stays null so the forward never reads them.
+                .shared_gate_w = mlx.mlx_array_new(),
+                .shared_gate_s = mlx.mlx_array_new(),
+                .shared_gate_b = mlx.mlx_array_new(),
+                .shared_up_w = mlx.mlx_array_new(),
+                .shared_up_s = mlx.mlx_array_new(),
+                .shared_up_b = mlx.mlx_array_new(),
+                .shared_down_w = mlx.mlx_array_new(),
+                .shared_down_s = mlx.mlx_array_new(),
+                .shared_down_b = mlx.mlx_array_new(),
+                .shared_expert_gate_w = null,
+                .shared_expert_gate_s = null,
+                .shared_expert_gate_b = null,
+                .route_norm = config.moe_route_norm,
+                .route_scale = config.router_scaling_factor,
+            } };
+            {
+                const mw = &lw.mlp.moe;
+                try maybeTransposeForBf16(&mw.router_w, mw.router_s, &owned_bf16, allocator, s);
+                try maybeTransposeForBf16(&mw.switch_gate_w, mw.switch_gate_s, &owned_bf16, allocator, s);
+                try maybeTransposeForBf16(&mw.switch_up_w, mw.switch_up_s, &owned_bf16, allocator, s);
+                try maybeTransposeForBf16(&mw.switch_down_w, mw.switch_down_s, &owned_bf16, allocator, s);
+            }
         } else if (layer_is_moe) {
             // Qwen3.5 MoE — also serves Qwen3-30B-A3B (`qwen3_moe`), which shares
             // this exact router/switch_mlp layout. Each `*_s`/`*_b` is loaded
@@ -18905,6 +19254,73 @@ fn appendStructArrays(vec: mlx.mlx_vector_array, w: anytype) void {
         const arr = @field(w, field.name);
         if (arr.ctx != null) _ = mlx.mlx_vector_array_append_value(vec, arr);
     }
+}
+
+/// gpt_oss clamped SwiGLU (mlx-lm `gpt_oss.swiglu`):
+///
+///     x_glu    = clip(gate, max=limit)        // asymmetric — no lower clip
+///     x_linear = clip(up, -limit, +limit)
+///     out      = x_glu * sigmoid(alpha * x_glu) * (x_linear + 1)
+///
+/// The `+ 1` on the linear branch is part of the trained function, not a
+/// numerical guard — dropping it changes every expert's output. Scalars are
+/// built in the activation's own dtype so a bf16 stream is not promoted to f32
+/// for the rest of the layer.
+fn gptOssSwiGLU(s: mlx.mlx_stream, gate: mlx.mlx_array, up: mlx.mlx_array, limit: f32, alpha: f32) !mlx.mlx_array {
+    const dt = mlx.mlx_array_dtype(gate);
+
+    const lim_f = mlx.mlx_array_new_float(limit);
+    defer _ = mlx.mlx_array_free(lim_f);
+    var lim = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(lim);
+    try mlx.check(mlx.mlx_astype(&lim, lim_f, dt, s));
+
+    const neg_lim_f = mlx.mlx_array_new_float(-limit);
+    defer _ = mlx.mlx_array_free(neg_lim_f);
+    var neg_lim = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(neg_lim);
+    try mlx.check(mlx.mlx_astype(&neg_lim, neg_lim_f, dt, s));
+
+    const alpha_f = mlx.mlx_array_new_float(alpha);
+    defer _ = mlx.mlx_array_free(alpha_f);
+    var alpha_a = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(alpha_a);
+    try mlx.check(mlx.mlx_astype(&alpha_a, alpha_f, dt, s));
+
+    const one_f = mlx.mlx_array_new_float(1.0);
+    defer _ = mlx.mlx_array_free(one_f);
+    var one = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(one);
+    try mlx.check(mlx.mlx_astype(&one, one_f, dt, s));
+
+    // x_glu = min(gate, limit) — upper clip only.
+    var x_glu = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(x_glu);
+    try mlx.check(mlx.mlx_minimum(&x_glu, gate, lim, s));
+
+    // x_linear = clip(up, -limit, +limit)
+    var x_lin = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(x_lin);
+    try mlx.check(mlx.mlx_clip(&x_lin, up, neg_lim, lim, s));
+
+    var scaled = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(scaled);
+    try mlx.check(mlx.mlx_multiply(&scaled, x_glu, alpha_a, s));
+    var sig = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(sig);
+    try mlx.check(mlx.mlx_sigmoid(&sig, scaled, s));
+
+    var out_glu = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(out_glu);
+    try mlx.check(mlx.mlx_multiply(&out_glu, x_glu, sig, s));
+
+    var lin_plus1 = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(lin_plus1);
+    try mlx.check(mlx.mlx_add(&lin_plus1, x_lin, one, s));
+
+    var out = mlx.mlx_array_new();
+    try mlx.check(mlx.mlx_multiply(&out, out_glu, lin_plus1, s));
+    return out;
 }
 
 fn appendFullAttnWeights(vec: mlx.mlx_vector_array, fa: *const FullAttnWeights) void {
@@ -24686,6 +25102,45 @@ test "FUSED256_MIN_Q_LEN is the single source for the decline and the band predi
     // Neither may respell the floor as a literal.
     try testing.expect(std.mem.indexOf(u8, src, "if (qs[2] < 1" ++ "6)") == null);
     try testing.expect(std.mem.indexOf(u8, src, "cfg.head_dim == 256 and seq_len >= " ++ "2") == null);
+}
+
+test "every sliding attention arm sizes its KV view from slidingViewFor, never the raw window" {
+    // The mask and the K/V view are ONE decision. `slidingViewFor` is the
+    // chokepoint that makes them agree: an arm passes `sliding.span` to
+    // `cache.update` and builds every mask at `sliding.kv_len`. Spelling the
+    // view width as `cfg.sliding_window` instead looks equivalent because it
+    // IS equivalent at q_len == 1 — and then the first block-wide forward past
+    // the window (a spec-verify block, or a prefill chunk) asks SDPA to
+    // broadcast a `window + q_len - 1` mask against a `window` view, which is
+    // an uncatchable MLX error: gpt_oss shipped exactly that and killed the
+    // process a few hundred tokens into every generation.
+    //
+    // Needles are assembled at comptime so this test's own source cannot
+    // satisfy the scan.
+    const src = @embedFile("transformer.zig");
+    const needle = "const max_kv: u32 " ++ "= ";
+    var i: usize = 0;
+    var seen: usize = 0;
+    while (std.mem.indexOfPos(u8, src, i, needle)) |pos| {
+        const line_end = std.mem.indexOfScalarPos(u8, src, pos, '\n') orelse src.len;
+        const line = src[pos..line_end];
+        // The full-attention arm of the ternary keeps everything (0); the
+        // sliding arm must read the chokepoint, directly or through the one
+        // alias pinned below.
+        try testing.expect(std.mem.indexOf(u8, line, "sliding.span") != null or
+            std.mem.indexOf(u8, line, "sliding_span") != null);
+        seen += 1;
+        i = line_end;
+    }
+    // forwardStandardWith, gemma4, laguna, inkling, gpt_oss — a rewrite that
+    // drops the binding entirely must not read as a pass.
+    try testing.expect(seen >= 5);
+    // The alias is only as good as what it is assigned from.
+    try testing.expect(std.mem.indexOf(u8, src, "const sliding_span " ++ "= sliding.span;") != null);
+
+    // And no arm may respell the width as the bare window.
+    try testing.expect(std.mem.indexOf(u8, src, "max_kv: u32 = if (is_full) 0 else " ++ "cfg.sliding_window") == null);
+    try testing.expect(std.mem.indexOf(u8, src, "max_kv: u32 = if (is_global) 0 else " ++ "cfg.sliding_window") == null);
 }
 
 test "KVCache trims the tail view for a BLOCK-wide update, not just decode" {
@@ -34711,6 +35166,52 @@ fn moeDownReduceParityCase(s: mlx.mlx_stream, rnd: std.Random, t: anytype, E: us
         try mlx.check(mlx.mlx_reshape(&fused, fused_flat, &f3, 3, s));
 
         try t.expectEqual(@as(f32, 0.0), try attn256MaxDiff(fused, composed, s));
+    }
+}
+
+test "gpt_oss clamped SwiGLU matches the reference formula (f64 oracle)" {
+    // Reference (mlx-lm gpt_oss.swiglu):
+    //   x_glu    = clip(gate, max=limit)          — ASYMMETRIC: no lower clip
+    //   x_linear = clip(up,  -limit, +limit)
+    //   out      = x_glu * sigmoid(alpha*x_glu) * (x_linear + 1)
+    // The three easy things to get wrong are all covered by the sweep below:
+    // clipping gate on BOTH sides, forgetting the `+ 1` on the linear branch,
+    // and applying alpha to the product rather than inside the sigmoid.
+    const s = mlx.gpuStream();
+    const t = std.testing;
+    const limit: f32 = 7.0;
+    const alpha: f32 = 1.702;
+
+    // Values that straddle both clip boundaries in both directions.
+    const vals = [_]f32{ -20.0, -8.5, -7.0, -3.25, -0.5, 0.0, 0.5, 3.25, 7.0, 8.5, 20.0 };
+    const n: c_int = @intCast(vals.len * vals.len);
+    var gate_h = try t.allocator.alloc(f32, vals.len * vals.len);
+    defer t.allocator.free(gate_h);
+    var up_h = try t.allocator.alloc(f32, vals.len * vals.len);
+    defer t.allocator.free(up_h);
+    for (vals, 0..) |g, i| {
+        for (vals, 0..) |u, j| {
+            gate_h[i * vals.len + j] = g;
+            up_h[i * vals.len + j] = u;
+        }
+    }
+    const shape = [_]c_int{n};
+    const gate = mlx.mlx_array_new_data(gate_h.ptr, &shape, 1, .float32);
+    defer _ = mlx.mlx_array_free(gate);
+    const up = mlx.mlx_array_new_data(up_h.ptr, &shape, 1, .float32);
+    defer _ = mlx.mlx_array_free(up);
+
+    const out = try gptOssSwiGLU(s, gate, up, limit, alpha);
+    defer _ = mlx.mlx_array_free(out);
+    try mlx.check(mlx.mlx_array_eval(out));
+    const got: [*]const f32 = @ptrCast(@alignCast(mlx.mlx_array_data_float32(out)));
+
+    for (gate_h, up_h, 0..) |g, u, i| {
+        const gd: f64 = @min(@as(f64, g), @as(f64, limit));
+        const ud: f64 = @max(@min(@as(f64, u), @as(f64, limit)), -@as(f64, limit));
+        const sig: f64 = 1.0 / (1.0 + @exp(-@as(f64, alpha) * gd));
+        const want: f64 = gd * sig * (ud + 1.0);
+        try t.expectApproxEqAbs(want, @as(f64, got[i]), 1e-4);
     }
 }
 

--- a/tests/test_sliding_window_trim.sh
+++ b/tests/test_sliding_window_trim.sh
@@ -26,7 +26,8 @@
 #
 # Usage:
 #   SLIDING_GEMMA4_MOE_MODEL=/path SLIDING_LAGUNA_MODEL=/path \
-#   SLIDING_INKLING_MODEL=/path ./tests/test_sliding_window_trim.sh [port]
+#   SLIDING_INKLING_MODEL=/path SLIDING_GPT_OSS_MODEL=/path \
+#   ./tests/test_sliding_window_trim.sh [port]
 
 set -u
 
@@ -44,6 +45,7 @@ SSD="/Volumes/G Drive SSD/models"
 GEMMA4_MOE="${SLIDING_GEMMA4_MOE_MODEL:-$SSD/mlx-community/gemma-4-26b-a4b-it-4bit}"
 LAGUNA="${SLIDING_LAGUNA_MODEL:-$SSD/poolside/Laguna-XS-2.1-NVFP4-mlx}"
 INKLING="${SLIDING_INKLING_MODEL:-$SSD/mlx-community/Inkling-Small-mlx-2bit}"
+GPT_OSS="${SLIDING_GPT_OSS_MODEL:-$HOME/.mlx-serve/models/mlx-community/gpt-oss-20b-MXFP4-Q8}"
 
 FAILURES=0
 RAN=0
@@ -176,6 +178,18 @@ check_arch "laguna" "$LAGUNA" "--no-pld" 96 320
 # inkling: hd 128, window 512, 35/42 local layers, RelativeLogits bias instead
 # of RoPE — the bias is the thing that has to be view-relative here.
 check_arch "inkling" "$INKLING" "--no-pld" 96 320
+
+# gpt-oss: hd 64, window 128 — by far the smallest here, so the prompt is a
+# fraction of the others': anything past ~130 tokens already makes every PLD
+# verify block a trimmed one, and a 20B at this machine's 8k prefill budget is
+# what the size is actually bounded by. This arm is the regression test for the
+# shape mismatch: the arm sized its K/V view with the raw `cfg.sliding_window`
+# while building masks at `window + q_len - 1`, which is invisible at q_len 1
+# and an uncatchable MLX error (`[broadcast_shapes] (1,1,6,133) vs
+# (1,64,6,128)`) on the first prefill chunk or spec-verify block past the
+# window. Before the fix the request kills the server outright, so this reads
+# as a failure, not a diff.
+check_arch "gpt-oss" "$GPT_OSS" "--pld" 128 24
 
 pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary
- Adds OpenAI gpt-oss support (20B-A3.6B / 120B-A5.1B MoE, harmony chat format): clamped SwiGLU activation, attention sinks (native MLX SDPA sink support), per-expert gate/up/down biases forcing the sorted MoE path, mxfp4 native expert quantization via NAX gather lanes, single shared RoPE theta across sliding/full layers.
- Fixes two silent-failure classes surfaced during bring-up: the reserved-token suppressor was masking `<|constrain|>` (a structural separator, not a generated-only token), causing malformed tool-call headers and repetition loops; `"content": null` was satisfying the harmony template's `"content" in message` key check while failing its value-indexing check on replay, leaking raw `<|channel|>` markers into round-tripped tool results.
- Sizes the gpt-oss sliding-window K/V view through the shared `slidingViewFor` helper rather than the raw window (correctness + the existing sliding-trim perf win).
- Streaming: gpt-oss reasoning channels now parse correctly out of the streamed token buffer, matching the non-streaming split.

## Test plan
- `zig build test -Doptimize=ReleaseFast`: 1681/1817 pass (136 skipped), 0 failures
- `cd app && swift build -c release`: builds clean
- Live smoke test against `isetnefret/gpt-oss-20b-RichardErkhov-heresy-mlx-4Bit`:
  - Plain chat: correct answer, clean `content`/`reasoning_content` split
  - Tool call: parses correctly (`finish_reason: "tool_calls"`, valid JSON args)
  - Tool-result round-trip: clean final `content` with no leaked `<|channel|>` markers, `finish_reason: "stop"`