### PR TITLE
fix: 404 an unknown model id on a registry server, instead of answering it from the default model

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -1537,6 +1537,76 @@ fn handleConnectionThread(args: *ConnThreadArgs) void {
     args.allocator.destroy(args);
 }
 
+/// Must a `model` id this registry does not hold be REFUSED, rather than
+/// answered by the default model?
+///
+/// Only on a server that was handed model ROOTS (`serve`, `run`, `--model-dir`,
+/// every headless launch the app makes). That registry publishes its ids on
+/// `/v1/models`, so a client naming one is ROUTING — and answering a typo from
+/// whatever else is resident echoes the unknown id back inside a 200 and hands
+/// over another model's reply. Same class as the unload that answered 200
+/// without unloading (#209): success-shaped, and no client can tell it from
+/// the real thing.
+///
+/// A `--model <dir>` launch keeps the fallback exactly as it was: it serves ONE
+/// model and the id is advisory, which is what makes it a drop-in for clients
+/// that hardcode `gpt-4o` (`registry.discovery` is null there — the launch
+/// shape, not a live count, so what a request resolves to cannot change under
+/// it when someone loads a second model). The empty id and the `"mlx-serve"`
+/// alias mean "the default" on every server and are never refused.
+fn unknownModelIdRefused(registry: *ModelRegistry, id: []const u8) bool {
+    if (registry.discovery == null) return false;
+    if (id.len == 0 or std.mem.eql(u8, id, "mlx-serve")) return false;
+    return registry.peek(id) == null;
+}
+
+/// The refusal for `unknownModelIdRefused`, in the shape the calling surface
+/// speaks. It NAMES the ids this server does serve: a refusal that quotes what
+/// it compared against is the difference between "fix the id" and "the server
+/// is broken", and the id list is exactly what the client got wrong. Bounded —
+/// a typo must not be answered with a 4 KB body — with `/v1/models` named for
+/// the tail.
+fn sendUnknownModelError(
+    allocator: std.mem.Allocator,
+    stream: *Conn,
+    registry: *ModelRegistry,
+    path: []const u8,
+    id: []const u8,
+) !void {
+    var ids: std.Io.Writer.Allocating = .init(allocator);
+    defer ids.deinit();
+    {
+        registry.mutex.lockUncancelable(stream.io);
+        defer registry.mutex.unlock(stream.io);
+        var n: usize = 0;
+        var it = registry.entries.valueIterator();
+        while (it.next()) |ep| {
+            if (n == 32) {
+                try ids.writer.writeAll(", ...");
+                break;
+            }
+            if (n > 0) try ids.writer.writeAll(", ");
+            try ids.writer.writeAll(ep.*.id);
+            n += 1;
+        }
+        if (n == 0) try ids.writer.writeAll("(none registered)");
+    }
+    const msg = try std.fmt.allocPrint(
+        allocator,
+        "Unknown model id \"{s}\". This server serves: {s} (GET /v1/models)",
+        .{ id, ids.written() },
+    );
+    defer allocator.free(msg);
+    log.warn("{s} -> 404 (unknown model id {s})\n", .{ path, id });
+    if (std.mem.eql(u8, path, "/v1/messages")) {
+        try sendAnthropicError(allocator, stream, "not_found_error", msg, 404);
+    } else if (std.mem.startsWith(u8, path, "/api/")) {
+        try sendOllamaError(allocator, stream, "404 Not Found", msg);
+    } else {
+        try sendErrorResponse(allocator, stream, "404 Not Found", "model_not_found", msg, 404);
+    }
+}
+
 fn handleConnection(
     allocator: std.mem.Allocator,
     stream: *Conn,
@@ -1828,10 +1898,15 @@ fn handleConnection(
             if (std.mem.startsWith(u8, path, "/api/")) {
                 resolved = ollamaResolveRegistryId(stream.io, registry, requested_model_id);
             }
-            // Unknown id — fall back to the default model rather than 404,
-            // so off-the-shelf SDK clients keep working. Multi-model
-            // clients that care about routing precision pass an exact id
-            // we registered (and `peek` will find it).
+            if (resolved == null and unknownModelIdRefused(registry, requested_model_id)) {
+                try sendUnknownModelError(allocator, stream, registry, path, requested_model_id);
+                return;
+            }
+            // Unknown id on a single-`--model` server — fall back to the
+            // default model rather than 404, so off-the-shelf SDK clients
+            // keep working. A server holding model ROOTS refuses instead
+            // (`unknownModelIdRefused`, above): it publishes its ids, so a
+            // request naming one is routing, not a marketing name.
             requested_model_id = resolved orelse "";
         }
     }
@@ -17542,4 +17617,52 @@ test "the memory guard's vision billing routes through visionPrefillUnchunked at
         at = i + 1;
     }
     try std.testing.expectEqual(@as(usize, 3), n);
+}
+
+test "an unknown model id is refused on a server holding model ROOTS, and served on a --model one" {
+    const a = std.testing.allocator;
+    const io = std.Io.Threaded.global_single_threaded.io();
+
+    // `--model <dir>`: no roots, one model, and the id is advisory — this is
+    // the drop-in that answers a client hardcoding `gpt-4o`. Unchanged.
+    const single = try ModelRegistry.init(a, io, null, 8, 0, null);
+    defer single.deinit();
+    const only = try single.registerStub("gemma-4-e4b-it-4bit", "/m/g", 1);
+    single.default_id = only.id;
+    try std.testing.expect(!unknownModelIdRefused(single, "no-such-model-xyz"));
+    try std.testing.expect(!unknownModelIdRefused(single, "gpt-4o"));
+
+    // `serve` / `run` / `--model-dir`: the registry publishes its ids, so an
+    // id it does not hold is a routing error and answering it from the
+    // default model hands back another model's reply under a 200. Zero
+    // discovered models is enough to build the mode — the LAUNCH SHAPE is
+    // what differs, not how many models happened to be found.
+    const roots = try model_discovery.discoverModelsMany(io, a, &.{});
+    const multi = try ModelRegistry.init(a, io, roots, 8, 0, null);
+    defer multi.deinit();
+    const served = try multi.registerStub("gemma-4-e4b-it-4bit", "/m/g", 1);
+    multi.default_id = served.id;
+    try std.testing.expect(unknownModelIdRefused(multi, "no-such-model-xyz"));
+
+    // Controls, in the SAME registry: a predicate that refuses everything
+    // passes the line above just as well as one that reads the id.
+    try std.testing.expect(!unknownModelIdRefused(multi, "gemma-4-e4b-it-4bit"));
+    // The omitted field and the launcher alias mean "the default" on every
+    // server (`ANTHROPIC_DEFAULT_*_MODEL=mlx-serve`) and are never refused.
+    try std.testing.expect(!unknownModelIdRefused(multi, ""));
+    try std.testing.expect(!unknownModelIdRefused(multi, "mlx-serve"));
+}
+
+test "the unknown-model 404 is answered BEFORE the model is resolved" {
+    // Same rule as the route-existence 404: a refusal must cost NOTHING. If
+    // this gate ever moved below `ensureLoaded`, a typo would cold-load the
+    // default model — the whole multi-GB, minutes-long cost — to earn its
+    // 404, which is the exact shape that cost 2m42s and 121 GB for a wrong
+    // URL.
+    const src = @embedFile("server.zig");
+    const gate = "unknownModelIdRefused(regis" ++ "try, requested_model_id)) {";
+    const resolve = "scheduler.ensureLoaded(" ++ "requested_model_id)";
+    const gate_at = std.mem.indexOf(u8, src, gate) orelse return error.GateMissing;
+    const resolve_at = std.mem.indexOf(u8, src, resolve) orelse return error.ResolveMissing;
+    try std.testing.expect(gate_at < resolve_at);
 }

--- a/tests/test_multi_model_load_failure.sh
+++ b/tests/test_multi_model_load_failure.sh
@@ -14,11 +14,13 @@
 #     skips incomplete media packs). It must be absent from /v1/models.
 #
 # The second case used to be this script's only case, asserting a 500 for it.
-# It cannot produce one: an id the registry does not hold falls back to the
-# default model, deliberately — Claude Code launches with
-# ANTHROPIC_DEFAULT_*_MODEL=mlx-serve, and clients hardcode ids like gpt-4o.
-# Asserting 500 there would break that fallback, so the assertion is now that
-# it is skipped, which is the real behaviour and was previously unpinned.
+# It cannot produce one: discovery never registers it, so naming it is an
+# UNKNOWN ID, not a load failure. On this server — one holding model ROOTS —
+# an unknown id is a 404 naming the ids that ARE served; on a single-`--model`
+# server it still falls back to the default model, which is what lets clients
+# that hardcode gpt-4o (and Claude Code's ANTHROPIC_DEFAULT_*_MODEL=mlx-serve)
+# work. The 404 is asserted below; the single-`--model` fallback is pinned by
+# `unknownModelIdRefused`'s own test in src/server.zig.
 #
 # A valid sibling model keeps working throughout (isolation).
 #
@@ -123,6 +125,29 @@ if [ "$UNKNOWN" = "absent" ]; then
     echo -e "${GREEN}PASS${NC} unknown-arch-model absent from /v1/models"
 else
     echo -e "${RED}FAIL${NC} unknown-arch-model registered as '$UNKNOWN' (discovery should refuse it)"
+    FAIL=1
+fi
+
+echo
+echo "== an id the registry does not hold is a 404, not the default model =="
+BODY=$(curl -s -o /dev/stdout -w '\n%{http_code}' -X POST "$BASE/v1/chat/completions" \
+    -H 'Content-Type: application/json' \
+    -d '{"model":"unknown-arch-model","messages":[{"role":"user","content":"Hi."}],"max_tokens":4}')
+HTTP_STATUS=$(echo "$BODY" | tail -1)
+ERR_BODY=$(echo "$BODY" | sed '$d')
+if [ "$HTTP_STATUS" = "404" ]; then
+    echo -e "${GREEN}PASS${NC} unknown id → HTTP 404"
+else
+    echo -e "${RED}FAIL${NC} unknown id → $HTTP_STATUS (expected 404)"
+    FAIL=1
+fi
+# A 200 here answers a typo from whatever else is resident and echoes the
+# unknown id back — the client cannot tell that from a real answer. The
+# refusal has to name what it compared against, or it is not actionable.
+if echo "$ERR_BODY" | grep -q 'model_not_found' && echo "$ERR_BODY" | grep -q "$VALID_ID"; then
+    echo -e "${GREEN}PASS${NC} the 404 names the served ids"
+else
+    echo -e "${RED}FAIL${NC} 404 body does not name the served ids: $ERR_BODY"
     FAIL=1
 fi
 


### PR DESCRIPTION
Fixes #257.

`POST /v1/chat/completions` with `"model":"no-such-model-xyz"` returns HTTP 200, echoes the unknown id back in `"model"`, and is answered by whatever model is resident — while `/v1/models` lists only the real ids. Same on `/v1/completions`, `/v1/messages` and `/api/chat`; they share the resolver. A client cannot tell that from a real answer: it is another model's reply under the id it asked for, which is the unload-200 class again (#209 / #211).

A server handed model roots (`serve`, `run`, `--model-dir`, every headless launch the app makes) publishes its ids on `/v1/models`, so a request naming one is routing. It now refuses an id it does not hold with a 404 that names the ids it does serve, in the shape the calling surface speaks (OpenAI `model_not_found`, Anthropic `not_found_error`, Ollama `{"error"}`). Refused above `ensureLoaded`, so a typo still loads nothing — pinned by a source-order test, same rule as the route-existence 404.

A single `--model <dir>` launch is unchanged: one model, the id is advisory, and answering a hardcoded `gpt-4o` is the whole drop-in. The discriminator is `registry.discovery` — the launch shape, not a live model count, so what a request resolves to cannot change under a client when a second model loads. Omitted `model` and the `"mlx-serve"` alias still mean the default everywhere.

Verification: `zig build test` 9/9 (and a mutation control — inverting the mode check fails exactly the new test); `tests/test_multi_model_load_failure.sh` 6/6 (its header documented the old fallback and is corrected, plus two new assertions); `cd app && swift test` — Executed 3048 tests, with 24 tests skipped and 0 failures (0 unexpected) in 49.755 (49.908) seconds; verified live on both launch shapes on macOS 26.5.2 / M5 Max with mlx-serve 26.8.9+ (this branch): registry mode → 404 naming the served ids on `/v1/chat/completions`, `/v1/completions`, `/v1/messages`, `/api/chat`, with the served id, the omitted field and `"mlx-serve"` all still 200 and `/v1/models` unchanged (the refusal loaded nothing); single-`--model` mode → `no-such-model-xyz`, `gpt-4o`, `claude-opus-4-5` all still 200.

Two things worth a maintainer's eye: (1) the resolver is shared, so in registry mode `/v1/embeddings`, `/tokenize` and the media endpoints also 404 an unknown id — I read `app/` (`prepareGenModel` uses the id `/v1/load-model` returned; `AgentEngine` sends the exempt `"mlx-serve"`) and believe the app is unaffected, but that is a reading, not a run against the app. (2) `tests/integration_test.sh`'s two `Logprobs` assertions fail on HEAD and on this branch identically — `assert_contains` pipes a body whose `max_tokens:3` tail is a truncated emoji through `grep -q` under a UTF-8 locale, which exits 1 on invalid UTF-8; `LC_ALL=C` fixes it. Separate from this PR.

Small doc note: CONTRIBUTING's build steps omit `scripts/fetch-llama.sh`; without it a fresh clone fails at link (`_ggml_commit` undefined, `lib/llama/lib` missing). Happy to send the one-line fix separately.

Disclosure: written by Syne, an AI agent that John Sampson runs on this machine; measurements are from his box and he reviewed this before it was posted.