### PR TITLE
feat(server): --api-key-strict and --api-key-env

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -308,6 +308,13 @@ fn printUsage(io: std.Io) void {
         \\                        Accepts Authorization: Bearer, x-api-key, HTTP
         \\                        Basic (key = password), or ?api_key=. /health
         \\                        stays open. Unset = no auth (default).
+        \\  --api-key-strict    Require the key from loopback too (localhost is
+        \\                        exempt by default). For embedders that want
+        \\                        "only the key holder drives inference" on a
+        \\                        shared machine. No effect without --api-key.
+        \\  --api-key-env <VAR> Read the key from environment variable VAR
+        \\                        instead of argv (the process table is
+        \\                        world-readable). Unset/empty VAR = no auth.
         \\  --lan-share <all|id,...>
         \\                      Share models with the local network: advertise
         \\                        this server over Bonjour and let LAN clients
@@ -593,6 +600,26 @@ pub fn main(init: std.process.Init) !void {
             i += 1;
             // Borrowed from argv (lives for the process). Empty ⇒ leave open.
             if (args[i].len > 0) server_mod.g_api_key = args[i];
+        } else if (std.mem.eql(u8, args[i], "--api-key-strict")) {
+            server_mod.g_api_key_strict = true;
+        } else if (std.mem.eql(u8, args[i], "--api-key-env") and i + 1 < args.len) {
+            i += 1;
+            // The key read from a named environment variable instead of argv:
+            // the process table is world-readable, argv with it. Same
+            // borrow-for-the-process lifetime as --api-key; empty/unset
+            // leaves the server open, exactly like an empty --api-key.
+            // args are plain slices; getenv needs a C string. A variable
+            // name past the buffer is not one this flag serves.
+            var name_buf: [128:0]u8 = undefined;
+            if (args[i].len < name_buf.len) {
+                @memcpy(name_buf[0..args[i].len], args[i]);
+                name_buf[args[i].len] = 0;
+                const name: [:0]const u8 = name_buf[0..args[i].len :0];
+                if (std.c.getenv(name.ptr)) |value| {
+                    const key = std.mem.span(value);
+                    if (key.len > 0) server_mod.g_api_key = key;
+                }
+            }
         } else if (std.mem.eql(u8, args[i], "--lan-share") and i + 1 < args.len) {
             i += 1;
             // Borrowed from argv, like --api-key. serve() starts the LAN

--- a/src/main.zig
+++ b/src/main.zig
@@ -608,14 +608,14 @@ pub fn main(init: std.process.Init) !void {
             // the process table is world-readable, argv with it. Same
             // borrow-for-the-process lifetime as --api-key; empty/unset
             // leaves the server open, exactly like an empty --api-key.
-            // args are plain slices; getenv needs a C string. A variable
-            // name past the buffer is not one this flag serves.
-            var name_buf: [128:0]u8 = undefined;
-            if (args[i].len < name_buf.len) {
-                @memcpy(name_buf[0..args[i].len], args[i]);
-                name_buf[args[i].len] = 0;
-                const name: [:0]const u8 = name_buf[0..args[i].len :0];
-                if (std.c.getenv(name.ptr)) |value| {
+            // getenv needs a null-terminated name; args[i] is a plain
+            // slice, so print a `:0` copy (process-lifetime, like the argv
+            // borrow --api-key uses). std.c.getenv is how every other env
+            // read in this codebase works. An unset var leaves the server
+            // open, exactly like an empty --api-key.
+            const name = std.fmt.allocPrintSentinel(allocator, "{s}", .{args[i]}, 0) catch null;
+            if (name) |name_z| {
+                if (std.c.getenv(name_z.ptr)) |value| {
                     const key = std.mem.span(value);
                     if (key.len > 0) server_mod.g_api_key = key;
                 }

--- a/src/server.zig
+++ b/src/server.zig
@@ -59,6 +59,15 @@ pub var g_metrics: ?*instr.Metrics = null;
 /// an `?api_key=` / `?key=` query param. null ⇒ fully open (default, unchanged).
 pub var g_api_key: ?[]const u8 = null;
 
+/// `--api-key-strict`: drop the loopback exemption, so the key is required
+/// from 127.0.0.1 too (`/health` and CORS preflight stay open). For hosts
+/// where localhost is NOT one trust domain — an embedding application that
+/// generates a fresh key per start wants "only the process holding the key
+/// can drive inference", and loopback exemption made any local process (and
+/// any browser page via a simple no-preflight POST) a key holder. No effect
+/// unless `--api-key` is set.
+pub var g_api_key_strict: bool = false;
+
 /// Tool-call ARGUMENT auto-correct. When true (default), parsed tool-call
 /// arguments are coerced to the types the request's tool schema declares
 /// (`chat.coerceToolArgsToSchema` — e.g. Python's `False` → JSON `false`, an
@@ -1622,8 +1631,7 @@ fn handleConnection(
     //    exposure. Browser-facing pages get a `WWW-Authenticate: Basic`
     //    challenge so the index + metrics panel prompt for the key; API clients
     //    pass Bearer / x-api-key. null key ⇒ fully open. See `apiKeyAuthorized`.
-    if (g_api_key != null and
-        !peerIsLoopback(stream) and
+    if (apiKeyGateApplies(g_api_key != null, g_api_key_strict, peerIsLoopback(stream)) and
         !std.mem.eql(u8, method, "OPTIONS") and
         !(std.mem.eql(u8, method, "GET") and std.mem.eql(u8, path, "/health")) and
         !apiKeyAuthorized(request[0..header_end_pos], raw_path))
@@ -8156,6 +8164,25 @@ fn ipIsLoopback(addr: std.Io.net.IpAddress) bool {
             break :blk false;
         },
     };
+}
+
+/// Whether the API-key auth gate covers this peer at all: a key must be set,
+/// and the peer must be non-loopback — unless `--api-key-strict` removed the
+/// loopback exemption. Pure so the truth table is hermetically testable.
+fn apiKeyGateApplies(key_set: bool, strict: bool, peer_loopback: bool) bool {
+    return key_set and (!peer_loopback or strict);
+}
+
+test "apiKeyGateApplies: strict removes exactly the loopback exemption" {
+    // No key: fully open regardless of strictness or peer.
+    try std.testing.expect(!apiKeyGateApplies(false, false, true));
+    try std.testing.expect(!apiKeyGateApplies(false, true, false));
+    // Key, default: loopback exempt, network gated.
+    try std.testing.expect(!apiKeyGateApplies(true, false, true));
+    try std.testing.expect(apiKeyGateApplies(true, false, false));
+    // Key, strict: everyone gated.
+    try std.testing.expect(apiKeyGateApplies(true, true, true));
+    try std.testing.expect(apiKeyGateApplies(true, true, false));
 }
 
 fn peerIsLoopback(conn: *const Conn) bool {


### PR DESCRIPTION
## What

Two additive flags on the API-key gate:

- `--api-key-strict` drops the loopback exemption, so a configured key is required from 127.0.0.1 too (`/health` and CORS preflight stay open). Use case: an embedding application that generates a fresh key per start and wants *only the key holder drives inference* on a shared machine — with the exemption, any local process (and any browser page via a simple no-preflight POST) is a key holder. No effect unless `--api-key` is set.
- `--api-key-env <VAR>` reads the key from a named environment variable instead of argv, which the world-readable process table exposes.

## How

The gate condition is extracted into `apiKeyGateApplies(key_set, strict, peer_loopback)` and the `if` in the request path now calls it; the truth table is pinned by a hermetic test at the bottom of `server.zig`. Flag parsing and `--help` follow the surrounding style.

## Test evidence

Compiled this tree and ran the suite on a real Apple Silicon Mac in this session:

```
zig build test --summary all
run test 20 pass (20 total)
zig build -Doptimize=ReleaseFast  # + packaged CLI smoke: ./mlx-serve --version → 26.8.10
```

Motivation from the embedder side: Styrverk pins mlx-serve as a managed sidecar and its security review flagged the open loopback port as its one unauthenticated local surface; this closes it without changing any default.