### PR TITLE
feat: classifier-free guidance for FLUX.2 klein base checkpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ One server, one registry — image/audio/video/3D coexist with chat. Engine slot
 
 - `POST /v1/images/edits` = OpenAI multipart translated by `gen.openaiEditFormToJson` into the `mode:"edit"` JSON body; unhonored fields = NAMED 400.
 - LoRAs are STACKED, ONE grammar across image/LTX/H3: `lora_paths`+`lora_scales` (cap 8, `gen.parseLoraFields`), summed at forward — never merged. Resident backends reconcile via `setLoras`; H3 pre-validates (`lora.validatePath`), Turbo = file 0.
+- **FLUX real CFG** (`guidance_scale`+`negative_prompt`, `gen.ImageEngine.supportsGuidance`): distilled klein bakes guidance into the weights and takes NEITHER field (1.0 default = the unconditional forward never runs, `flux.ditVelocity` called once); the undistilled "base" 9B checkpoint (`flux2-klein-9b-base`, app preset `flux2Klein9BBase_Q4`) needs it — TWO forwards per denoise step, blended `uncond + scale·(cond−uncond)`. Same DiT geometry as the distilled 9B (checkpoint-derived), so nothing else about loading changes.
 - Endpoint/field/backend detail: `docs/reference.md`. Guards: `tests/test_unified_gen.sh` + per-modality scripts; parity via env-gated cos oracles (`tests/dump_*_fixtures.py`).
 
 ## HTTP APIs

--- a/app/Sources/MLXServe/Models/MediaGenSettings.swift
+++ b/app/Sources/MLXServe/Models/MediaGenSettings.swift
@@ -71,6 +71,10 @@ struct ImageGenSettings: Codable, Equatable {
     /// Conditioning rebalance (Advanced): global gain + weights text.
     var condGain: Double = 1.0
     var condWeightsText: String = ""
+    /// Classifier-free guidance (Advanced, `ImageModelPreset.supportsGuidance`
+    /// models only): 1.0 = off. The negative prompt itself is transient, like
+    /// the main prompt — not persisted.
+    var guidanceScale: Double = 1.0
     /// Style LoRAs (Advanced): sticky stack of adapter path + strength pairs.
     /// Empty = none attached.
     var loras: [LoraAdapter] = []
@@ -156,6 +160,7 @@ extension ImageGenSettings {
         if let v = try c.decodeIfPresent(Bool.self, forKey: .editMode) { editMode = v }
         if let v = try c.decodeIfPresent(Double.self, forKey: .condGain) { condGain = v }
         if let v = try c.decodeIfPresent(String.self, forKey: .condWeightsText) { condWeightsText = v }
+        if let v = try c.decodeIfPresent(Double.self, forKey: .guidanceScale) { guidanceScale = v }
         if let v = try c.decodeIfPresent([LoraAdapter].self, forKey: .loras), !v.isEmpty {
             loras = v
         } else {

--- a/app/Sources/MLXServe/Services/ImageGenService.swift
+++ b/app/Sources/MLXServe/Services/ImageGenService.swift
@@ -187,8 +187,9 @@ final class ImageGenService: ObservableObject {
     /// the contract is unit-testable: plain text-to-image bodies carry ONLY the
     /// classic fields; img2img (`image`+`strength`), edit references
     /// (`mode`+`ref_images`), conditioning rebalance
-    /// (`cond_gain`+`cond_weights`), and LoRA (`lora_paths`+`lora_scales`) are
-    /// added only when set, so the server sees no behavior change otherwise.
+    /// (`cond_gain`+`cond_weights`), CFG (`guidance_scale`+`negative_prompt`,
+    /// base klein only), and LoRA (`lora_paths`+`lora_scales`) are added only
+    /// when set, so the server sees no behavior change otherwise.
     static func requestJson(for request: ImageGenRequest, modelName: String, seed: Int) -> [String: Any] {
         var json: [String: Any] = [
             "model": modelName,
@@ -222,6 +223,12 @@ final class ImageGenService: ObservableObject {
            weights.count == request.condWeightCount {
             json["cond_weights"] = weights
         }
+        // Classifier-free guidance (base klein only — `model.supportsGuidance`
+        // gates the control, so a distilled preset's 1.0 default never reaches
+        // here as anything but the omitted-field no-op).
+        if request.guidanceScale != 1.0 { json["guidance_scale"] = request.guidanceScale }
+        let negativePrompt = request.negativePrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !negativePrompt.isEmpty { json["negative_prompt"] = negativePrompt }
         // Stacked style LoRAs: several `.safetensors` adapters attach at once
         // and their effects sum (mirrors mflux's `lora_paths`/`lora_scales`).
         // Half-filled rows (no path picked yet) are dropped here rather than

--- a/app/Sources/MLXServe/Services/MediaBundle.swift
+++ b/app/Sources/MLXServe/Services/MediaBundle.swift
@@ -463,8 +463,9 @@ extension ImageModelPreset {
             return .krea(repo: repo, displayName: name, sizeGB: Double(approxDownloadGB))
         case .mageFlowTurbo, .mageFlowEditTurbo:
             return .mageFlow(repo: repo, displayName: name, sizeGB: Double(approxDownloadGB))
-        case .flux2Klein9B:
-            // The one MLX conversion of klein 9B ships no root config.json.
+        case .flux2Klein9B, .flux2Klein9BBase:
+            // The MLX conversions of klein 9B — distilled and base alike —
+            // ship no root config.json.
             return .flux(repo: repo, displayName: name, sizeGB: Double(approxDownloadGB), hasRootConfig: false)
         default:
             return .flux(repo: repo, displayName: name, sizeGB: Double(approxDownloadGB))

--- a/app/Sources/MLXServe/Services/MediaGen.swift
+++ b/app/Sources/MLXServe/Services/MediaGen.swift
@@ -13,8 +13,10 @@ import SwiftUI
 
 /// Industry-standard tier names. Each model defines its own concrete step
 /// count per tier, so a "Fast" on FLUX.2-klein doesn't mean the same as "Fast"
-/// on FLUX.2-dev. There is no CFG here: no image backend reads a guidance
-/// field, so carrying one only invited the UI to show a knob that does nothing.
+/// on FLUX.2-dev. CFG (`guidance_scale`/negative prompt) is a real knob only
+/// on the undistilled "base" klein checkpoint (`ImageModelPreset.supportsGuidance`)
+/// — the distilled presets have guidance baked into the weights, so the field
+/// stays hidden there rather than showing a control that does nothing.
 enum QualityPreset: String, CaseIterable, Identifiable, Codable {
     case fast = "Fast"
     case good = "Good"
@@ -131,6 +133,9 @@ enum CustomResolution: Equatable {
 enum FluxVariant: String, Hashable, Codable {
     case flux2Klein4B     // FLUX.2-klein 4B params — uses Flux2Klein, ModelConfig.flux2_klein_4b()
     case flux2Klein9B     // FLUX.2-klein 9B params — uses Flux2Klein, ModelConfig.flux2_klein_9b()
+    case flux2Klein9BBase // FLUX.2-klein-base 9B — same DiT geometry as flux2Klein9B, UNDISTILLED:
+                          // real CFG (guidance_scale + negative prompt) over 30-50 steps instead
+                          // of the 4-step guidance-baked-in distilled schedule.
     case krea2Turbo       // Krea-2-Turbo single-stream MMDiT — served by the krea image backend
     case mageFlowTurbo    // Microsoft Mage-Flow-Turbo double-stream flow DiT — served by the mage_flow backend
     case mageFlowEditTurbo // Microsoft Mage-Flow-Edit-Turbo — same arch, edit-trained; multi-reference in-context editor
@@ -235,6 +240,39 @@ struct ImageModelPreset: Identifiable, Hashable {
         ],
         defaultQuality: .good,
         description: "The bigger FLUX.2-klein — stronger prompt following and detail than the 4B, with the same fast schedule and the same instruction editing. Twice the download and memory."
+    )
+
+    /// FLUX.2-klein-base 9B 4-bit — the UNDISTILLED checkpoint distillation
+    /// started from. Same DiT geometry as `flux2Klein9B_Q4` (the engine reads
+    /// it off the checkpoint), so it shares that preset's resolution grid and
+    /// editing capability; the whole difference is the training regime: no
+    /// guidance baked into the weights, so it needs real classifier-free
+    /// guidance (`supportsGuidance`) and many more steps — 30-50 rather than
+    /// klein's 4-step schedule — but rewards it with more creative,
+    /// prompt-varied output than the distilled model's narrower distribution.
+    ///
+    /// No official MLX conversion exists yet; `AITRADER/FLUX2-klein-base-9B-mlx-4bit`
+    /// is the only one published (an mflux repack of
+    /// `black-forest-labs/FLUX.2-klein-base-9B`), same configless weight-subdir
+    /// layout as the distilled 9B.
+    static let flux2Klein9BBase_Q4 = ImageModelPreset(
+        id: "mflux/flux2-klein-9b-base-q4",
+        name: "FLUX.2-klein 9B Base 4-bit (~10 GB)",
+        variant: .flux2Klein9BBase,
+        configName: "flux2_klein_9b",
+        repo: "AITRADER/FLUX2-klein-base-9B-mlx-4bit",
+        approxDownloadGB: 10,
+        approxRAMGB: 16,
+        resolutions: fluxResolutions,
+        defaultResolution: fluxResolutions[0],
+        qualityProfiles: [
+            .fast:         .init(steps: 20),
+            .good:         .init(steps: 30),
+            .quality:      .init(steps: 40),
+            .superQuality: .init(steps: 50),
+        ],
+        defaultQuality: .good,
+        description: "The undistilled FLUX.2-klein 9B — more creative and varied than the fast distilled model, at the cost of many more steps (30+) and real guidance/negative-prompt control."
     )
 
     // Krea-2-Turbo accepts any multiple of 16 in [256, 2048]; offer a few
@@ -407,6 +445,7 @@ struct ImageModelPreset: Identifiable, Hashable {
         .flux2Klein4B_Q4,                              // 5
         .mageFlowTurbo8bit, .mageFlowEditTurbo8bit,    // 9, 10
         .flux2Klein9B_Q4,                              // 10
+        .flux2Klein9BBase_Q4,                          // 10
         .krea2Turbo,                                   // 15
     ]
 }
@@ -1780,6 +1819,12 @@ struct ImageGenRequest {
     /// DiT at runtime (sent as `lora_paths`/`lora_scales` — mirrors mflux).
     /// Empty = none. Rows with an empty `path` are dropped before sending.
     var loras: [LoraAdapter] = []
+    /// Classifier-free guidance (Advanced, `model.supportsGuidance` only):
+    /// 1.0 = off, matching the server default.
+    var guidanceScale: Double = 1.0
+    /// What to steer AWAY from — only meaningful alongside `guidanceScale`
+    /// != 1.0. Empty = the server's own unconditioning (empty-string prompt).
+    var negativePrompt: String = ""
 }
 
 extension ImageModelPreset {
@@ -1806,7 +1851,7 @@ extension ImageModelPreset {
             return ResolutionGrid(alignment: 16, minDim: 256, maxDim: 2048)
         // `clampFluxDim` — klein's /32 crop granularity, 1536 covering the
         // widest preset edge.
-        case .flux2Klein4B, .flux2Klein9B:
+        case .flux2Klein4B, .flux2Klein9B, .flux2Klein9BBase:
             return ResolutionGrid(alignment: 32, minDim: 256, maxDim: 1536)
         }
     }
@@ -1815,7 +1860,16 @@ extension ImageModelPreset {
     /// capability: FLUX.2-klein, and the Mage-Flow-Edit checkpoint. Krea and
     /// Mage-Flow Turbo (txt2img) can only do renoise variations.
     var supportsReferenceEdit: Bool {
-        variant == .flux2Klein4B || variant == .flux2Klein9B || variant == .mageFlowEditTurbo
+        variant == .flux2Klein4B || variant == .flux2Klein9B || variant == .flux2Klein9BBase || variant == .mageFlowEditTurbo
+    }
+
+    /// Real classifier-free guidance (`guidance_scale` + negative prompt) —
+    /// `gen.ImageEngine.supportsGuidance()` is FLUX-generic server-side (1.0
+    /// is a no-op there), but only the undistilled base checkpoint has an
+    /// unconditional pathway worth opposing a prompt against; distilled klein
+    /// collapsed it into the weights, so the field stays hidden for it.
+    var supportsGuidance: Bool {
+        variant == .flux2Klein9BBase
     }
 
     // ── Capability flags: what the Advanced panel is allowed to offer ──

--- a/app/Sources/MLXServe/Views/ImageGenView.swift
+++ b/app/Sources/MLXServe/Views/ImageGenView.swift
@@ -47,6 +47,12 @@ struct ImageGenView: View {
     @State private var condGain: Double = 1.0
     /// Conditioning rebalance (Advanced): per-tapped-layer weights as typed.
     @State private var condWeightsText: String = ""
+    /// Classifier-free guidance (Advanced, `model.supportsGuidance` only):
+    /// how strongly to follow the prompt over the unconditional pathway.
+    @State private var guidanceScale: Double = 1.0
+    /// What to steer away from (Advanced, CFG only). Transient like the main
+    /// prompt — not persisted.
+    @State private var negativePrompt: String = ""
     /// Style LoRAs (Advanced): stacked `.safetensors` adapters ([] = none).
     /// Several can attach at once — their effects sum, so order doesn't matter.
     @State private var loras: [LoraAdapter] = []
@@ -473,11 +479,8 @@ struct ImageGenView: View {
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
             }
-            // No CFG field and no negative prompt: NO image backend reads either
-            // one (`handleImage` parses neither, and the app never sent
-            // guidance), so both were pure decoration on every model, not just
-            // the distilled ones. Steps stay overridable even where the schedule
-            // is fixed — it's the Advanced panel, and the hint says the cost.
+            // Steps stay overridable even where the schedule is fixed — it's
+            // the Advanced panel, and the hint says the cost.
             HStack {
                 numberField("Steps", value: $steps, step: 1)
                 // -1 is the random sentinel and renders as an EMPTY box, so the
@@ -490,6 +493,27 @@ struct ImageGenView: View {
                 Text("This model is distilled for \(model.fixedSteps) steps; other values cost time without adding detail.")
                     .font(.caption2)
                     .foregroundStyle(.secondary)
+            }
+
+            // Real CFG — the undistilled base checkpoint only. Every other
+            // preset has guidance baked into its weights, so the field would
+            // be pure decoration there and stays hidden.
+            if model.supportsGuidance {
+                Divider()
+                Text("Classifier-free guidance").font(.caption.weight(.semibold))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Guidance scale").font(.caption)
+                    Stepper(value: $guidanceScale, in: 1...20, step: 0.5) {
+                        Text(String(format: "%.1f", guidanceScale))
+                    }
+                    .onChange(of: guidanceScale) { _, _ in guard !hydrating else { return }; persist() }
+                }
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Negative prompt").font(.caption)
+                    TextField("", text: $negativePrompt, prompt: Text("what to steer away from (optional)"))
+                        .textFieldStyle(.roundedBorder)
+                        .font(.caption)
+                }
             }
             Toggle("Keep model loaded after generating", isOn: $keepResident)
                 .font(.caption)
@@ -812,6 +836,7 @@ struct ImageGenView: View {
         editMode = s.editMode
         condGain = s.condGain
         condWeightsText = s.condWeightsText
+        guidanceScale = s.guidanceScale
         loras = s.loras
         customWidthText = String(s.customWidth)
         customHeightText = String(s.customHeight)
@@ -837,6 +862,7 @@ struct ImageGenView: View {
         s.editMode = editMode
         s.condGain = condGain
         s.condWeightsText = condWeightsText
+        s.guidanceScale = guidanceScale
         s.loras = loras
         s.save()
     }
@@ -876,7 +902,9 @@ struct ImageGenView: View {
             refImagePaths: effectiveEditMode ? refImageURLs.map(\.path) : [],
             condGain: condGain,
             condWeightsText: condWeightsText,
-            loras: loras
+            loras: loras,
+            guidanceScale: model.supportsGuidance ? guidanceScale : 1.0,
+            negativePrompt: model.supportsGuidance ? negativePrompt : ""
         )
         persist()  // final capture — the agent's generate_image reuses these
 

--- a/app/Tests/MLXCoreTests/MediaGenServiceTests.swift
+++ b/app/Tests/MLXCoreTests/MediaGenServiceTests.swift
@@ -1206,6 +1206,38 @@ final class MediaGenServiceTests: XCTestCase {
         XCTAssertEqual(json["lora_scales"] as? [Double], [0.9])
     }
 
+    func testImageRequestJsonOmitsGuidanceFieldsAtDefaults() {
+        let req = ImageGenRequest(model: .flux2Klein9BBase_Q4, prompt: "x", width: 1024, height: 1024, steps: 30)
+        let json = ImageGenService.requestJson(for: req, modelName: "m", seed: 1)
+        XCTAssertNil(json["guidance_scale"])
+        XCTAssertNil(json["negative_prompt"])
+    }
+
+    func testImageRequestJsonIncludesGuidanceScaleAndTrimmedNegativePrompt() {
+        var req = ImageGenRequest(model: .flux2Klein9BBase_Q4, prompt: "x", width: 1024, height: 1024, steps: 30)
+        req.guidanceScale = 3.5
+        req.negativePrompt = "  blurry, low quality  "
+        let json = ImageGenService.requestJson(for: req, modelName: "m", seed: 1)
+        XCTAssertEqual(json["guidance_scale"] as? Double, 3.5)
+        XCTAssertEqual(json["negative_prompt"] as? String, "blurry, low quality")
+    }
+
+    func testImageRequestJsonOmitsBlankNegativePromptEvenWithGuidanceSet() {
+        var req = ImageGenRequest(model: .flux2Klein9BBase_Q4, prompt: "x", width: 1024, height: 1024, steps: 30)
+        req.guidanceScale = 3.5
+        req.negativePrompt = "   "
+        let json = ImageGenService.requestJson(for: req, modelName: "m", seed: 1)
+        XCTAssertEqual(json["guidance_scale"] as? Double, 3.5)
+        XCTAssertNil(json["negative_prompt"])
+    }
+
+    func testOnlyTheBaseKleinPresetDeclaresGuidanceSupport() {
+        XCTAssertTrue(ImageModelPreset.flux2Klein9BBase_Q4.supportsGuidance)
+        XCTAssertFalse(ImageModelPreset.flux2Klein4B_Q4.supportsGuidance)
+        XCTAssertFalse(ImageModelPreset.flux2Klein9B_Q4.supportsGuidance)
+        XCTAssertFalse(ImageModelPreset.krea2Turbo.supportsGuidance)
+    }
+
     func testParseCondWeightsAcceptsCommasAndSpacesRejectsGarbage() {
         XCTAssertEqual(ImageGenRequest.parseCondWeights("1,2,3"), [1, 2, 3])
         XCTAssertEqual(ImageGenRequest.parseCondWeights(" 0.5  1\t-2 "), [0.5, 1, -2])

--- a/src/flux.zig
+++ b/src/flux.zig
@@ -1979,6 +1979,46 @@ test "flux applyCondRebalance scales tap thirds and global gain" {
     try testing.expectError(error.InvalidCondWeights, applyCondRebalance(enc, 1.0, &bad, s));
 }
 
+test "flux CFG blend is uncond + guidance_scale * (cond - uncond)" {
+    const s = mlx.mlx_default_gpu_stream_new();
+    defer _ = mlx.mlx_stream_free(s);
+    const cond_v = [_]f32{ 1, 2, 3, 4 };
+    const uncond_v = [_]f32{ 0, 0, 1, 2 };
+    const sh = [_]c_int{ 1, 1, 4 };
+    const cond = mlx.mlx_array_new_data(&cond_v, &sh, 3, .float32);
+    defer _ = mlx.mlx_array_free(cond);
+    const uncond = mlx.mlx_array_new_data(&uncond_v, &sh, 3, .float32);
+    defer _ = mlx.mlx_array_free(uncond);
+    const guidance_scale: f32 = 3.5;
+
+    const diff = try subA(cond, uncond, s); defer _ = mlx.mlx_array_free(diff);
+    const scale_a = mlx.mlx_array_new_float(guidance_scale); defer _ = mlx.mlx_array_free(scale_a);
+    const scaled = try mulA(diff, scale_a, s); defer _ = mlx.mlx_array_free(scaled);
+    const blended = try addA(uncond, scaled, s); defer _ = mlx.mlx_array_free(blended);
+    _ = mlx.mlx_array_eval(blended);
+    const d = mlx.mlx_array_data_float32(blended) orelse return error.NoData;
+    // manual: uncond + 3.5*(cond-uncond)
+    for (cond_v, uncond_v, 0..) |c, u, i| {
+        const expect = u + guidance_scale * (c - u);
+        try testing.expectApproxEqAbs(expect, d[i], 1e-5);
+    }
+    // guidance_scale 1.0 collapses the blend to `cond` exactly — the
+    // mathematical identity `generateFromCondWithOpts` relies on to skip
+    // the unconditional forward entirely when CFG is off.
+    const scale_one = mlx.mlx_array_new_float(1.0); defer _ = mlx.mlx_array_free(scale_one);
+    const scaled_one = try mulA(diff, scale_one, s); defer _ = mlx.mlx_array_free(scaled_one);
+    const blended_one = try addA(uncond, scaled_one, s); defer _ = mlx.mlx_array_free(blended_one);
+    _ = mlx.mlx_array_eval(blended_one);
+    const d1 = mlx.mlx_array_data_float32(blended_one) orelse return error.NoData;
+    for (cond_v, 0..) |c, i| try testing.expectApproxEqAbs(c, d1[i], 1e-5);
+}
+
+test "flux GenOpts defaults keep CFG off (distilled klein pays no extra forward)" {
+    const opts = GenOpts{};
+    try testing.expectEqual(@as(f32, 1.0), opts.guidance_scale);
+    try testing.expectEqual(@as(?mlx.mlx_array, null), opts.neg_enc);
+}
+
 // ════════════════════════════════════════════════════════════════════════
 // Full text→image pipeline.
 // ════════════════════════════════════════════════════════════════════════
@@ -2080,6 +2120,14 @@ pub const GenOpts = struct {
     /// Conditioning rebalance: global gain + per-tap weights (len 3).
     cond_gain: f32 = 1.0,
     cond_weights: ?[]const f32 = null,
+    /// Classifier-free guidance (the UNDISTILLED "base" klein checkpoints —
+    /// distilled klein has guidance baked into the weights and takes neither
+    /// field: `guidance_scale` 1.0 skips the unconditional forward entirely,
+    /// byte-identical to the no-CFG path). `neg_enc` is the negative prompt's
+    /// text-encoder output, same fixed [1,FLUX_SEQ_LEN,hidden] shape as the
+    /// positive `enc` so both forwards share `img_ids`/`txt_ids`.
+    guidance_scale: f32 = 1.0,
+    neg_enc: ?mlx.mlx_array = null,
 };
 
 pub fn generate(te: *TextEncoder, dit: *Dit, vae: *Vae, ids: []const i32, mask: []const i32, seed: u64, steps: u32, height: u32, width: u32, progress: ?sse.Progress) !mlx.mlx_array {
@@ -2102,15 +2150,35 @@ pub fn encodePrompt(te: *TextEncoder, ids: []const i32, mask: []const i32, opts:
     return enc;
 }
 
+/// One DiT forward → predicted velocity [1,nlat,128], slicing off any
+/// reference-editing tokens concatenated onto `latents`. Shared by the
+/// conditional and (CFG) unconditional passes — both read the same
+/// `img_ids`/`txt_ids`/`ref_tokens`, only `enc` differs.
+fn ditVelocity(dit: *Dit, latents: mlx.mlx_array, enc: mlx.mlx_array, t: f32, img_ids: []const i32, txt_ids: []const i32, ref_tokens: mlx.mlx_array, all_ids: ?[]i32, nlat: c_int, s: S) !mlx.mlx_array {
+    if (ref_tokens.ctx != null) {
+        const input = try concat(&[_]mlx.mlx_array{ latents, ref_tokens }, 1, s);
+        defer _ = mlx.mlx_array_free(input);
+        const full = try dit.forward(input, enc, t, all_ids.?, txt_ids);
+        defer _ = mlx.mlx_array_free(full);
+        return slice3(full, 1, 0, nlat, s);
+    }
+    return dit.forward(latents, enc, t, img_ids, txt_ids);
+}
+
 pub fn generateWithOpts(te: *TextEncoder, dit: *Dit, vae: *Vae, ids: []const i32, mask: []const i32, seed: u64, steps: u32, height: u32, width: u32, opts: GenOpts, progress: ?sse.Progress) !mlx.mlx_array {
     const enc = try encodePrompt(te, ids, mask, opts);
     return generateFromCondWithOpts(dit, vae, enc, ids.len, seed, steps, height, width, opts, progress);
 }
 
 /// Stages 2+ (latents init → denoise loop → VAE decode) from a pre-computed
-/// prompt encoding. Takes ownership of `enc_owned`. `prompt_len` = token count
-/// of the encoded prompt (drives the text position ids).
+/// prompt encoding. Takes ownership of `enc_owned` AND `opts.neg_enc` (CFG).
+/// `prompt_len` = token count of the encoded prompt (drives the text position
+/// ids); the negative encoding shares the same fixed FLUX_SEQ_LEN padding, so
+/// it needs no position ids of its own.
 pub fn generateFromCondWithOpts(dit: *Dit, vae: *Vae, enc_owned: mlx.mlx_array, prompt_len: usize, seed: u64, steps: u32, height: u32, width: u32, opts: GenOpts, progress: ?sse.Progress) !mlx.mlx_array {
+    defer if (opts.neg_enc) |ne| {
+        _ = mlx.mlx_array_free(ne);
+    };
     const s = dit.s;
     const a = dit.allocator;
     const lh = height / 16;
@@ -2204,19 +2272,21 @@ pub fn generateFromCondWithOpts(dit: *Dit, vae: *Vae, enc_owned: mlx.mlx_array, 
         latents = nl;
     }
 
+    const use_cfg = opts.guidance_scale != 1.0 and opts.neg_enc != null;
     const run_steps = steps - start_step;
     for (start_step..steps) |t| {
         if (progress) |p| if (p.cancelled()) return error.Cancelled;
-        const nz = blk: {
-            if (ref_tokens.ctx != null) {
-                const input = try concat(&[_]mlx.mlx_array{ latents, ref_tokens }, 1, s);
-                defer _ = mlx.mlx_array_free(input);
-                const full = try dit.forward(input, enc, sched.ts[t], all_ids.?, txt_ids);
-                defer _ = mlx.mlx_array_free(full);
-                break :blk try slice3(full, 1, 0, @intCast(nlat), s);
-            }
-            break :blk try dit.forward(latents, enc, sched.ts[t], img_ids, txt_ids);
-        };
+        const nz_cond = try ditVelocity(dit, latents, enc, sched.ts[t], img_ids, txt_ids, ref_tokens, all_ids, @intCast(nlat), s);
+        const nz = if (use_cfg) blk: {
+            defer _ = mlx.mlx_array_free(nz_cond);
+            const nz_uncond = try ditVelocity(dit, latents, opts.neg_enc.?, sched.ts[t], img_ids, txt_ids, ref_tokens, all_ids, @intCast(nlat), s);
+            defer _ = mlx.mlx_array_free(nz_uncond);
+            // v = uncond + guidance_scale · (cond − uncond)
+            const diff = try subA(nz_cond, nz_uncond, s); defer _ = mlx.mlx_array_free(diff);
+            const scale_a = mlx.mlx_array_new_float(opts.guidance_scale); defer _ = mlx.mlx_array_free(scale_a);
+            const scaled = try mulA(diff, scale_a, s); defer _ = mlx.mlx_array_free(scaled);
+            break :blk try addA(nz_uncond, scaled, s);
+        } else nz_cond;
         defer _ = mlx.mlx_array_free(nz);
         const dt = sched.sig[t + 1] - sched.sig[t];
         const dta = mlx.mlx_array_new_float(dt); defer _ = mlx.mlx_array_free(dta);

--- a/src/gen.zig
+++ b/src/gen.zig
@@ -360,20 +360,22 @@ const FluxImpl = struct {
         self.allocator.free(self.model_dir);
     }
 
-    /// Tokenize the prompt (Qwen3 chat template) and run the FLUX pipeline →
-    /// image [1,3,H,W] f32 in [0,1] (owned mlx array; caller frees).
-    fn generateImage(self: *FluxImpl, allocator: std.mem.Allocator, prompt: []const u8, width: u32, height: u32, seed: u64, steps: u32, opts: ImageGenOpts, progress: ?sse.Progress) !mlx.mlx_array {
-        // mflux Qwen3 chat template (enable_thinking=False adds an empty <think> block).
-        const templated = try std.fmt.allocPrint(allocator, "<|im_start|>user\n{s}<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n", .{prompt});
+    /// Tokenize text with the mflux Qwen3 chat template (enable_thinking=False
+    /// adds an empty <think> block), padded/truncated to the fixed
+    /// `FLUX_SEQ_LEN` the DiT's text-position ids are built for. Shared by
+    /// the prompt and (CFG) negative-prompt encodes so both land on the same
+    /// shape.
+    fn tokenizeFixed(self: *FluxImpl, allocator: std.mem.Allocator, text: []const u8) !struct { ids: []i32, mask: []i32 } {
+        const templated = try std.fmt.allocPrint(allocator, "<|im_start|>user\n{s}<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n", .{text});
         defer allocator.free(templated);
 
         const enc = try self.tok.encode(allocator, templated);
         defer allocator.free(enc);
 
-        var ids = try allocator.alloc(i32, FLUX_SEQ_LEN);
-        defer allocator.free(ids);
-        var mask = try allocator.alloc(i32, FLUX_SEQ_LEN);
-        defer allocator.free(mask);
+        const ids = try allocator.alloc(i32, FLUX_SEQ_LEN);
+        errdefer allocator.free(ids);
+        const mask = try allocator.alloc(i32, FLUX_SEQ_LEN);
+        errdefer allocator.free(mask);
         const real = @min(enc.len, FLUX_SEQ_LEN);
         for (0..FLUX_SEQ_LEN) |i| {
             if (i < real) {
@@ -384,7 +386,18 @@ const FluxImpl = struct {
                 mask[i] = 0;
             }
         }
-        var fopts = flux.GenOpts{ .cond_gain = opts.cond_gain, .cond_weights = opts.cond_weights };
+        return .{ .ids = ids, .mask = mask };
+    }
+
+    /// Run the FLUX pipeline → image [1,3,H,W] f32 in [0,1] (owned mlx array;
+    /// caller frees).
+    fn generateImage(self: *FluxImpl, allocator: std.mem.Allocator, prompt: []const u8, width: u32, height: u32, seed: u64, steps: u32, opts: ImageGenOpts, progress: ?sse.Progress) !mlx.mlx_array {
+        const pos = try self.tokenizeFixed(allocator, prompt);
+        defer allocator.free(pos.ids);
+        defer allocator.free(pos.mask);
+        const ids = pos.ids;
+        const mask = pos.mask;
+        var fopts = flux.GenOpts{ .cond_gain = opts.cond_gain, .cond_weights = opts.cond_weights, .guidance_scale = opts.guidance_scale };
         var init_lat: ?mlx.mlx_array = null;
         defer if (init_lat) |l| {
             _ = mlx.mlx_array_free(l);
@@ -417,6 +430,15 @@ const FluxImpl = struct {
         // (pinned by tests/test_flux_lowmem.sh).
         if (self.te == null) {
             self.te = try flux.loadTextEncoder(self.io, self.allocator, self.s, self.model_dir);
+        }
+        // Classifier-free guidance (base klein): encode the negative prompt
+        // (default "" — unconditional) at the SAME fixed length, so the
+        // denoise loop's cond/uncond forwards share img_ids/txt_ids.
+        if (opts.guidance_scale != 1.0) {
+            const neg = try self.tokenizeFixed(allocator, opts.negative_prompt);
+            defer allocator.free(neg.ids);
+            defer allocator.free(neg.mask);
+            fopts.neg_enc = try flux.encodePrompt(&self.te.?, neg.ids, neg.mask, fopts);
         }
         const cond = try flux.encodePrompt(&self.te.?, ids, mask, fopts);
         if (self.low_mem) {
@@ -493,6 +515,12 @@ pub const ImageGenOpts = struct {
     /// (FLUX: 3 taps, Krea: 12 taps).
     cond_gain: f32 = 1.0,
     cond_weights: ?[]const f32 = null,
+    /// Classifier-free guidance — the undistilled "base" klein checkpoints,
+    /// gated by `ImageEngine.supportsGuidance()`. 1.0 (default) skips the
+    /// unconditional forward entirely; distilled klein has guidance baked
+    /// into the weights and is never asked to run it.
+    guidance_scale: f32 = 1.0,
+    negative_prompt: []const u8 = "",
 };
 
 /// Image modality engine. The slot on `LoadedModel` stays modality-named; the
@@ -577,6 +605,14 @@ pub const ImageEngine = struct {
     /// needs a target-size VAE resize AND a separate VLM resize per reference.
     pub fn editUsesRawBytes(self: *const ImageEngine) bool {
         return self.backend == .mage_flow;
+    }
+
+    /// True when real classifier-free guidance (`guidance_scale`/`negative_prompt`)
+    /// is wired — FLUX only. Distilled klein still accepts the fields (1.0
+    /// is a no-op, matching mflux's basic guider); Krea/Mage-Flow have no
+    /// negative-encode path.
+    pub fn supportsGuidance(self: *const ImageEngine) bool {
+        return self.backend == .flux;
     }
 
     /// Reconcile the engine's attached LoRA stack with the request: an empty
@@ -1956,6 +1992,27 @@ pub fn handleImage(allocator: std.mem.Allocator, conn: *Conn, body: []const u8, 
         log.info("[image] rebalance: gain={d:.2} weights={d}\n", .{ cond_gain, wl.len });
     }
 
+    // Classifier-free guidance (base klein, undistilled): 'guidance_scale'
+    // != 1.0 runs a second, unconditional forward per step against
+    // 'negative_prompt' (default "" — empty-string unconditioning, the
+    // standard CFG convention). 1.0 is a no-op, so distilled klein can
+    // accept both fields harmlessly; only an ACTUALLY-requested CFG run
+    // needs the capability.
+    var guidance_scale: f32 = 1.0;
+    if (extractJsonFloat(body, "guidance_scale")) |g| {
+        if (!(g >= 0.0 and g <= 20.0)) return sendError(conn, 400, "'guidance_scale' must be in [0,20]");
+        guidance_scale = @floatCast(g);
+    }
+    var negative_prompt: []const u8 = "";
+    var negative_prompt_owned: ?[]u8 = null;
+    defer if (negative_prompt_owned) |np| allocator.free(np);
+    if (extractJsonString(body, "negative_prompt")) |raw_neg| {
+        negative_prompt_owned = try jsonUnescape(allocator, raw_neg);
+        negative_prompt = negative_prompt_owned.?;
+    }
+    if (guidance_scale != 1.0 and !engine.supportsGuidance())
+        return sendError(conn, 400, "'guidance_scale' requires a FLUX.2 model");
+
     // Style LoRA(s): one or more absolute paths to .safetensors adapters,
     // each with an optional scale — mirrors mflux's `--lora-paths`/
     // `--lora-scales`. Accepts the array form (`lora_paths`/`lora_scales`)
@@ -1987,7 +2044,7 @@ pub fn handleImage(allocator: std.mem.Allocator, conn: *Conn, body: []const u8, 
     }
 
     const want_stream = sse.bodyWantsTrue(body, "stream");
-    log.info("[image] generating {d}x{d} steps={d} stream={}: {d} chars\n", .{ width, height, steps, want_stream, prompt.len });
+    log.info("[image] generating {d}x{d} steps={d} guidance={d:.1} stream={}: {d} chars\n", .{ width, height, steps, guidance_scale, want_stream, prompt.len });
     var sctx = sse.StreamCtx{ .conn = conn, .stream = want_stream };
     const prog: ?sse.Progress = sctx.progress();
     if (want_stream) try conn.writeAll(sse.headers);
@@ -1999,6 +2056,8 @@ pub fn handleImage(allocator: std.mem.Allocator, conn: *Conn, body: []const u8, 
         .edit_image_bytes = edit_byte_bufs[0..edit_byte_n],
         .cond_gain = cond_gain,
         .cond_weights = cond_weights,
+        .guidance_scale = guidance_scale,
+        .negative_prompt = negative_prompt,
     };
     const img = engine.generateImage(allocator, prompt, width, height, seed, steps, gen_opts, prog) catch |err| {
         // Client hung up mid-generation — there is nobody to answer, and


### PR DESCRIPTION
Distilled klein has guidance baked in and needs no CFG, but the undistilled "base" checkpoint requires it: encode a negative prompt at the same fixed FLUX_SEQ_LEN, run cond/uncond DiT forwards sharing img_ids/txt_ids, and blend v = uncond + guidance_scale*(cond-uncond). guidance_scale defaults to 1.0, which collapses to the no-CFG path.