### PR TITLE
feat: joycaption

### DIFF
--- a/app/Sources/MLXServe/Models/HFModels.swift
+++ b/app/Sources/MLXServe/Models/HFModels.swift
@@ -19,6 +19,7 @@ private let supportedArchitectureTagPrefixes: [String] = [
     "gemma",      // gemma, gemma2, gemma3, gemma3n, gemma4
     "qwen",       // qwen2, qwen3, qwen3_5, qwen3.5, qwen3.6
     "llama",
+    "llava",      // JoyCaption / standard HF LlavaForConditionalGeneration
     "mistral",
     "nemotron",   // nemotron_h (Mamba2 SSM hybrid)
     "lfm",        // lfm2, lfm2_vl (Liquid state-space hybrid; VL serves images)
@@ -45,6 +46,7 @@ let supportedModelTypes: Set<String> = [
     "qwen4_exp", "qwen4_exp_text", // Qwen3.8-Flash-Next (GDN + QSA + n-gram PLE MoE)
     "qwen2",
     "llama", "mistral",
+    "llava", // JoyCaption / standard HF LlavaForConditionalGeneration (Llama-3 + SigLIP)
     "lfm2", "lfm2_vl", // Liquid LFM2.5; the VL tag adds a SigLIP2-NaFlex tower
     "nemotron_h",
     "hy_v3", // Tencent Hunyuan 3 (295B-A21B MoE)

--- a/src/chat.zig
+++ b/src/chat.zig
@@ -41,7 +41,13 @@ pub const ImageData = struct {
 pub const VisionPreproc = struct {
     /// Which processor produced `ImageData.pixels`: Gemma's fixed CHW square,
     /// or one of the patch-grid towers (each with its own resize + patch order).
-    mode: enum { gemma, qwen, muse, lfm2 } = .gemma,
+    mode: enum { gemma, qwen, muse, lfm2, siglip } = .gemma,
+    /// siglip (JoyCaption): the fixed square resize target in pixels (e.g.
+    /// 384). Distinct from `.gemma`'s hardcoded 768 — JoyCaption's SigLIP
+    /// also gets proper bilinear resize + mean/std normalization at
+    /// preprocess time (see `decodeImageToPixels`), not `.gemma`'s
+    /// nearest-neighbor + defer-to-tower-forward convention.
+    fixed_size: u32 = 0,
     patch: u32 = 16,
     tps: u32 = 2,
     merge: u32 = 2,

--- a/src/joycaption_vision.zig
+++ b/src/joycaption_vision.zig
@@ -1,0 +1,446 @@
+//! JoyCaption / standard HF `LlavaForConditionalGeneration` vision tower.
+//!
+//! A FIXED-resolution `siglip_vision_model` encoder: patch_embedding (a
+//! Conv2d, implemented here as a linear layer on flattened patches — stride
+//! equals kernel size, so the two are equivalent), a learned
+//! `position_embedding` added directly (no CLS token, no interpolation —
+//! the checkpoint's position count always equals our fixed patch grid),
+//! then standard pre-norm transformer blocks (2 layernorms, biased q/k/v/out
+//! attention, biased fc1/fc2 MLP with `gelu_pytorch_tanh`, no RoPE, no
+//! gating). `vision_feature_layer` (-2 for JoyCaption) selects a
+//! hidden_states index BEFORE the final encoder layer, so that layer and
+//! `post_layernorm` are never run at all. `multi_modal_projector` (linear →
+//! erf `gelu` → linear, both biased) bridges vision_hidden → text_hidden.
+//! Reference: transformers `SiglipVisionModel` + `LlavaForConditionalGeneration`.
+
+const std = @import("std");
+const mlx = @import("mlx.zig");
+const model_mod = @import("model.zig");
+const log = @import("log.zig");
+
+const ModelConfig = model_mod.ModelConfig;
+const Weights = model_mod.Weights;
+
+const Lin = struct {
+    w: mlx.mlx_array,
+    b: mlx.mlx_array,
+};
+
+const Block = struct {
+    ln1_w: mlx.mlx_array,
+    ln1_b: mlx.mlx_array,
+    ln2_w: mlx.mlx_array,
+    ln2_b: mlx.mlx_array,
+    q: Lin,
+    k: Lin,
+    v: Lin,
+    out: Lin,
+    fc1: Lin,
+    fc2: Lin,
+};
+
+/// Weight lookup under the checkpoint's fixed nesting. Handles are BORROWED
+/// from the weights map (owned by `Weights`, freed there).
+const NameCtx = struct {
+    weights: *const Weights,
+    prefix: []const u8,
+    buf: *[200]u8,
+
+    fn key(self: NameCtx, comptime fmt: []const u8, args: anytype) []const u8 {
+        const body = std.fmt.bufPrint(self.buf[100..], fmt, args) catch unreachable;
+        return std.fmt.bufPrint(self.buf[0..100], "{s}{s}", .{ self.prefix, body }) catch unreachable;
+    }
+
+    fn opt(self: NameCtx, comptime fmt: []const u8, args: anytype) ?mlx.mlx_array {
+        return self.weights.get(self.key(fmt, args));
+    }
+
+    fn must(self: NameCtx, comptime fmt: []const u8, args: anytype) !mlx.mlx_array {
+        return self.opt(fmt, args) orelse {
+            log.warn("MISSING JOYCAPTION VISION WEIGHT: {s}\n", .{self.key(fmt, args)});
+            return error.MissingVisionWeights;
+        };
+    }
+
+    fn lin(self: NameCtx, comptime fmt: []const u8, args: anytype) !Lin {
+        return .{
+            .w = try self.must(fmt ++ ".weight", args),
+            .b = try self.must(fmt ++ ".bias", args),
+        };
+    }
+};
+
+pub const JoycaptionVision = struct {
+    allocator: std.mem.Allocator,
+    s: mlx.mlx_stream,
+
+    hidden: u32,
+    heads: u32,
+    head_dim: u32,
+    patch: u32,
+    ln_eps: f32,
+    out_hidden: u32,
+
+    // Conv2d [hidden, 3, ps, ps] weight, pre-transposed + flattened to
+    // [hidden, ps*ps*3] to match `patchify`'s (py, px, c) feature order —
+    // an owned array (everything else below is borrowed from `weights`).
+    patch_w: mlx.mlx_array,
+    patch_b: mlx.mlx_array,
+    pos_emb: mlx.mlx_array, // [num_positions, hidden]
+
+    // Only `run_layers` of the checkpoint's `vision_num_layers` blocks ever
+    // run — see the module doc comment on `vision_feature_layer`.
+    blocks: []Block,
+
+    proj1: Lin, // multi_modal_projector.linear_1: vision_hidden -> text_hidden
+    proj2: Lin, // multi_modal_projector.linear_2: text_hidden -> text_hidden
+
+    pub fn init(allocator: std.mem.Allocator, config: ModelConfig, weights: *const Weights) !JoycaptionVision {
+        const s = mlx.mlx_default_gpu_stream_new();
+        var tbuf: [200]u8 = undefined;
+        var pbuf: [200]u8 = undefined;
+        const ctx = NameCtx{ .weights = weights, .prefix = "vision_tower.vision_model.", .buf = &tbuf };
+        const pctx = NameCtx{ .weights = weights, .prefix = "multi_modal_projector.", .buf = &pbuf };
+
+        const hidden = config.vision_hidden_size;
+        const patch = config.vision_patch_size;
+
+        const patch_w_raw = try ctx.must("embeddings.patch_embedding.weight", .{});
+        const patch_b = try ctx.must("embeddings.patch_embedding.bias", .{});
+        const pos_emb = try ctx.must("embeddings.position_embedding.weight", .{});
+
+        // [hidden, 3, ps, ps] -> [hidden, ps, ps, 3] -> [hidden, ps*ps*3],
+        // matching `patchify`'s (py, px, c) flatten order below.
+        var patch_w = mlx.mlx_array_new();
+        {
+            const perm = [_]c_int{ 0, 2, 3, 1 };
+            var wt = mlx.mlx_array_new();
+            defer _ = mlx.mlx_array_free(wt);
+            try mlx.check(mlx.mlx_transpose_axes(&wt, patch_w_raw, &perm, 4, s));
+            const flat_shape = [_]c_int{ @intCast(hidden), @intCast(3 * patch * patch) };
+            try mlx.check(mlx.mlx_reshape(&patch_w, wt, &flat_shape, 2, s));
+        }
+
+        const num_layers = config.vision_num_layers;
+        // hidden_states[k] = the state after k encoder layers (index 0 = the
+        // raw embeddings); `vision_feature_layer` indexes that HF list.
+        const target_idx: i32 = if (config.vision_feature_layer < 0)
+            @as(i32, @intCast(num_layers)) + 1 + config.vision_feature_layer
+        else
+            config.vision_feature_layer;
+        if (target_idx < 0 or target_idx > @as(i32, @intCast(num_layers))) return error.MissingVisionWeights;
+        const run_layers: u32 = @intCast(target_idx);
+
+        var blocks = try allocator.alloc(Block, run_layers);
+        errdefer allocator.free(blocks);
+        for (0..run_layers) |i| {
+            blocks[i] = .{
+                .ln1_w = try ctx.must("encoder.layers.{d}.layer_norm1.weight", .{i}),
+                .ln1_b = try ctx.must("encoder.layers.{d}.layer_norm1.bias", .{i}),
+                .ln2_w = try ctx.must("encoder.layers.{d}.layer_norm2.weight", .{i}),
+                .ln2_b = try ctx.must("encoder.layers.{d}.layer_norm2.bias", .{i}),
+                .q = try ctx.lin("encoder.layers.{d}.self_attn.q_proj", .{i}),
+                .k = try ctx.lin("encoder.layers.{d}.self_attn.k_proj", .{i}),
+                .v = try ctx.lin("encoder.layers.{d}.self_attn.v_proj", .{i}),
+                .out = try ctx.lin("encoder.layers.{d}.self_attn.out_proj", .{i}),
+                .fc1 = try ctx.lin("encoder.layers.{d}.mlp.fc1", .{i}),
+                .fc2 = try ctx.lin("encoder.layers.{d}.mlp.fc2", .{i}),
+            };
+        }
+
+        const proj1 = try pctx.lin("linear_1", .{});
+        const proj2 = try pctx.lin("linear_2", .{});
+
+        // Batch-eval everything once.
+        {
+            var eval_list = std.ArrayList(mlx.mlx_array).empty;
+            defer eval_list.deinit(allocator);
+            const heads = [_]mlx.mlx_array{ patch_w, patch_b, pos_emb, proj1.w, proj1.b, proj2.w, proj2.b };
+            try eval_list.appendSlice(allocator, &heads);
+            for (blocks) |b| {
+                const arrs = [_]mlx.mlx_array{
+                    b.ln1_w, b.ln1_b, b.ln2_w, b.ln2_b,
+                    b.q.w,   b.q.b,   b.k.w,    b.k.b,
+                    b.v.w,   b.v.b,   b.out.w,  b.out.b,
+                    b.fc1.w, b.fc1.b, b.fc2.w,  b.fc2.b,
+                };
+                try eval_list.appendSlice(allocator, &arrs);
+            }
+            const vec = mlx.mlx_vector_array_new_data(eval_list.items.ptr, eval_list.items.len);
+            defer _ = mlx.mlx_vector_array_free(vec);
+            _ = mlx.mlx_eval(vec);
+        }
+
+        log.info("Vision encoder: JoyCaption SigLIP ({d}/{d} layers run, hidden={d}, heads={d}, patch={d}, image_size={d})\n", .{
+            run_layers, num_layers, hidden, config.vision_num_heads, patch, config.vision_image_size,
+        });
+
+        return .{
+            .allocator = allocator,
+            .s = s,
+            .hidden = hidden,
+            .heads = config.vision_num_heads,
+            .head_dim = hidden / config.vision_num_heads,
+            .patch = patch,
+            .ln_eps = config.vision_layer_norm_eps,
+            .out_hidden = config.hidden_size,
+            .patch_w = patch_w,
+            .patch_b = patch_b,
+            .pos_emb = pos_emb,
+            .blocks = blocks,
+            .proj1 = proj1,
+            .proj2 = proj2,
+        };
+    }
+
+    pub fn deinit(self: *JoycaptionVision) void {
+        _ = mlx.mlx_array_free(self.patch_w);
+        self.allocator.free(self.blocks);
+        _ = mlx.mlx_stream_free(self.s);
+    }
+
+    /// Encode one image. `pixels` is `[1, 3, H, W]` float32 (H == W ==
+    /// `config.vision_image_size`, the fixed SigLIP resize target) →
+    /// `[1, tokens, text_hidden]`, ready to splice at image-token positions.
+    pub fn forward(self: *JoycaptionVision, pixels: mlx.mlx_array) !mlx.mlx_array {
+        const pix_shape = mlx.getShape(pixels);
+        const batch = pix_shape[0];
+        if (batch != 1) return error.UnsupportedBatchSize;
+        const height = pix_shape[2];
+        const width = pix_shape[3];
+        const ps: c_int = @intCast(self.patch);
+        const gh = @divExact(height, ps);
+        const gw = @divExact(width, ps);
+        const n: c_int = gh * gw;
+
+        const patches_raw = try self.patchify(pixels, batch, gh, gw, ps);
+        defer _ = mlx.mlx_array_free(patches_raw);
+        var x = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_astype(&x, patches_raw, .bfloat16, self.s));
+        {
+            // [1, N, patch_dim] -> [N, patch_dim]: every block below works in 2D.
+            const shape = [_]c_int{ n, @intCast(3 * self.patch * self.patch) };
+            var r = mlx.mlx_array_new();
+            try mlx.check(mlx.mlx_reshape(&r, x, &shape, 2, self.s));
+            replace(&x, r);
+        }
+
+        replace(&x, try self.linear(x, self.patch_w, self.patch_b));
+        {
+            var summed = mlx.mlx_array_new();
+            try mlx.check(mlx.mlx_add(&summed, x, self.pos_emb, self.s));
+            replace(&x, summed);
+        }
+
+        var dt = mlx.DtypeTrace.begin("joycaption-vision", x, if (self.blocks.len > 0) self.blocks[0].ln1_w else null);
+        for (self.blocks, 0..) |blk, i| {
+            {
+                const normed = try self.layerNorm(x, blk.ln1_w, blk.ln1_b);
+                defer _ = mlx.mlx_array_free(normed);
+                const attn = try self.attention(normed, blk, n);
+                defer _ = mlx.mlx_array_free(attn);
+                var h = mlx.mlx_array_new();
+                try mlx.check(mlx.mlx_add(&h, x, attn, self.s));
+                replace(&x, h);
+            }
+            {
+                const normed = try self.layerNorm(x, blk.ln2_w, blk.ln2_b);
+                defer _ = mlx.mlx_array_free(normed);
+                const up = try self.linear(normed, blk.fc1.w, blk.fc1.b);
+                defer _ = mlx.mlx_array_free(up);
+                // The encoder MLP is `gelu_pytorch_tanh`; the projector below is
+                // plain erf `gelu` — two acts, one checkpoint.
+                const act = try self.geluTanh(up);
+                defer _ = mlx.mlx_array_free(act);
+                const down = try self.linear(act, blk.fc2.w, blk.fc2.b);
+                defer _ = mlx.mlx_array_free(down);
+                var h = mlx.mlx_array_new();
+                try mlx.check(mlx.mlx_add(&h, x, down, self.s));
+                replace(&x, h);
+            }
+            dt.layer(x, i);
+        }
+        dt.end(x);
+        // No post_layernorm: `vision_feature_layer` selected a hidden state
+        // before the final encoder layer, which was never run either.
+
+        return self.project(x, n);
+    }
+
+    /// `LlavaMultiModalProjector`: Linear -> erf GELU -> Linear.
+    /// [N, vision_hidden] -> [1, N, text_hidden].
+    fn project(self: *JoycaptionVision, hidden: mlx.mlx_array, n: c_int) !mlx.mlx_array {
+        var x = try self.linear(hidden, self.proj1.w, self.proj1.b);
+        replace(&x, try self.geluExact(x));
+        replace(&x, try self.linear(x, self.proj2.w, self.proj2.b));
+
+        var out = mlx.mlx_array_new();
+        const oshape = [_]c_int{ 1, n, @intCast(self.out_hidden) };
+        try mlx.check(mlx.mlx_reshape(&out, x, &oshape, 3, self.s));
+        _ = mlx.mlx_array_free(x);
+        return out;
+    }
+
+    fn attention(self: *JoycaptionVision, x: mlx.mlx_array, blk: Block, n: c_int) !mlx.mlx_array {
+        const hd: c_int = @intCast(self.head_dim);
+        const heads: c_int = @intCast(self.heads);
+
+        // [N, D] -> [1, heads, N, hd] for the fused SDPA. No mask: one image
+        // per call, full bidirectional attention (SigLIP has no CLS/packing).
+        var bhnd: [3]mlx.mlx_array = undefined;
+        var built: usize = 0;
+        errdefer for (bhnd[0..built]) |arr| {
+            _ = mlx.mlx_array_free(arr);
+        };
+        inline for (.{ blk.q, blk.k, blk.v }, 0..) |l, i| {
+            const flat = try self.linear(x, l.w, l.b);
+            defer _ = mlx.mlx_array_free(flat);
+            const shape = [_]c_int{ n, heads, hd };
+            var r = mlx.mlx_array_new();
+            defer _ = mlx.mlx_array_free(r);
+            try mlx.check(mlx.mlx_reshape(&r, flat, &shape, 3, self.s));
+            const perm = [_]c_int{ 1, 0, 2 };
+            var t = mlx.mlx_array_new();
+            defer _ = mlx.mlx_array_free(t);
+            try mlx.check(mlx.mlx_transpose_axes(&t, r, &perm, 3, self.s));
+            var b = mlx.mlx_array_new();
+            try mlx.check(mlx.mlx_reshape(&b, t, &[_]c_int{ 1, heads, n, hd }, 4, self.s));
+            bhnd[i] = b;
+            built += 1;
+        }
+        defer for (bhnd) |arr| {
+            _ = mlx.mlx_array_free(arr);
+        };
+
+        const scale = 1.0 / @sqrt(@as(f32, @floatFromInt(self.head_dim)));
+        const none = mlx.mlx_array{ .ctx = null };
+        var ctx_out = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(ctx_out);
+        try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&ctx_out, bhnd[0], bhnd[1], bhnd[2], scale, "", none, none, false, self.s));
+
+        const back = [_]c_int{ 0, 2, 1, 3 };
+        var t = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(t);
+        try mlx.check(mlx.mlx_transpose_axes(&t, ctx_out, &back, 4, self.s));
+        var flat = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(flat);
+        try mlx.check(mlx.mlx_reshape(&flat, t, &[_]c_int{ n, @intCast(self.hidden) }, 2, self.s));
+        return self.linear(flat, blk.out.w, blk.out.b);
+    }
+
+    /// `[B,3,H,W]` -> `[B, gh*gw, ps*ps*3]`, feature order (py, px, c).
+    fn patchify(self: *JoycaptionVision, pixels: mlx.mlx_array, batch: c_int, gh: c_int, gw: c_int, ps: c_int) !mlx.mlx_array {
+        const reshape6 = [_]c_int{ batch, 3, gh, ps, gw, ps };
+        var r1 = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(r1);
+        try mlx.check(mlx.mlx_reshape(&r1, pixels, &reshape6, 6, self.s));
+        const perm = [_]c_int{ 0, 2, 4, 3, 5, 1 };
+        var r2 = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(r2);
+        try mlx.check(mlx.mlx_transpose_axes(&r2, r1, &perm, 6, self.s));
+        const num_patches = gh * gw;
+        const patch_dim = 3 * ps * ps;
+        const reshape3 = [_]c_int{ batch, num_patches, patch_dim };
+        var out = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_reshape(&out, r2, &reshape3, 3, self.s));
+        return out;
+    }
+
+    /// y = x · Wᵀ + b. W is [out, in] bf16 dense (this tower never ships quantized).
+    fn linear(self: *JoycaptionVision, x: mlx.mlx_array, w: mlx.mlx_array, b: mlx.mlx_array) !mlx.mlx_array {
+        var wt = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(wt);
+        try mlx.check(mlx.mlx_transpose(&wt, w, self.s));
+        var out = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_matmul(&out, x, wt, self.s));
+        var biased = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_add(&biased, out, b, self.s));
+        _ = mlx.mlx_array_free(out);
+        return biased;
+    }
+
+    fn layerNorm(self: *JoycaptionVision, x: mlx.mlx_array, w: mlx.mlx_array, b: mlx.mlx_array) !mlx.mlx_array {
+        var out = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_fast_layer_norm(&out, x, w, b, self.ln_eps, self.s));
+        return out;
+    }
+
+    /// `gelu_pytorch_tanh`: 0.5x(1+tanh(sqrt(2/pi)(x+0.044715x^3))). SigLIP's
+    /// own MLP activation.
+    fn geluTanh(self: *JoycaptionVision, x: mlx.mlx_array) !mlx.mlx_array {
+        const c_coeff = bf16Scalar(0.7978845608028654, self.s);
+        defer _ = mlx.mlx_array_free(c_coeff);
+        const c_inner = bf16Scalar(0.044715, self.s);
+        defer _ = mlx.mlx_array_free(c_inner);
+        const c_three = bf16Scalar(3.0, self.s);
+        defer _ = mlx.mlx_array_free(c_three);
+        const c_one = bf16Scalar(1.0, self.s);
+        defer _ = mlx.mlx_array_free(c_one);
+        const c_half = bf16Scalar(0.5, self.s);
+        defer _ = mlx.mlx_array_free(c_half);
+
+        var x3 = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(x3);
+        try mlx.check(mlx.mlx_power(&x3, x, c_three, self.s));
+        var inner = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(inner);
+        try mlx.check(mlx.mlx_multiply(&inner, c_inner, x3, self.s));
+        var sum = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(sum);
+        try mlx.check(mlx.mlx_add(&sum, x, inner, self.s));
+        var scaled = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(scaled);
+        try mlx.check(mlx.mlx_multiply(&scaled, c_coeff, sum, self.s));
+        var th = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(th);
+        try mlx.check(mlx.mlx_tanh(&th, scaled, self.s));
+        var onep = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(onep);
+        try mlx.check(mlx.mlx_add(&onep, c_one, th, self.s));
+        var xt = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(xt);
+        try mlx.check(mlx.mlx_multiply(&xt, x, onep, self.s));
+        var out = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_multiply(&out, xt, c_half, self.s));
+        return out;
+    }
+
+    /// nn.GELU() exact: 0.5·x·(1+erf(x/√2)). `multi_modal_projector`'s
+    /// `projector_hidden_act: "gelu"`.
+    fn geluExact(self: *JoycaptionVision, x: mlx.mlx_array) !mlx.mlx_array {
+        const inv_sqrt2 = bf16Scalar(0.7071067811865476, self.s);
+        defer _ = mlx.mlx_array_free(inv_sqrt2);
+        const c_one = bf16Scalar(1.0, self.s);
+        defer _ = mlx.mlx_array_free(c_one);
+        const c_half = bf16Scalar(0.5, self.s);
+        defer _ = mlx.mlx_array_free(c_half);
+        var t = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(t);
+        try mlx.check(mlx.mlx_multiply(&t, x, inv_sqrt2, self.s));
+        var e = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(e);
+        try mlx.check(mlx.mlx_erf(&e, t, self.s));
+        var onep = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(onep);
+        try mlx.check(mlx.mlx_add(&onep, c_one, e, self.s));
+        var xt = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(xt);
+        try mlx.check(mlx.mlx_multiply(&xt, x, onep, self.s));
+        var out = mlx.mlx_array_new();
+        try mlx.check(mlx.mlx_multiply(&out, xt, c_half, self.s));
+        return out;
+    }
+};
+
+fn replace(dst: *mlx.mlx_array, next: mlx.mlx_array) void {
+    _ = mlx.mlx_array_free(dst.*);
+    dst.* = next;
+}
+
+fn bf16Scalar(v: f32, s: mlx.mlx_stream) mlx.mlx_array {
+    const f = mlx.mlx_array_new_float(v);
+    defer _ = mlx.mlx_array_free(f);
+    var out = mlx.mlx_array_new();
+    _ = mlx.mlx_astype(&out, f, .bfloat16, s);
+    return out;
+}

--- a/src/model.zig
+++ b/src/model.zig
@@ -144,6 +144,16 @@ pub const ModelConfig = struct {
     rope_scaling_factor: f32 = 1.0,
     rope_proportional: bool = false, // Gemma 4: full attention uses proportional RoPE
     rope_proportional_factor: f32 = 1.0,
+    // Llama-3.1/3.2 "llama3" rope_scaling: a piecewise wavelength blend
+    // (low/high freq factors around original_max_position_embeddings), NOT
+    // a uniform `rope_scaling_factor` division. Reuses the SAME
+    // `rope_freqs_global` custom-frequencies mechanism as Gemma 4's
+    // proportional RoPE (mutually exclusive with `rope_proportional`).
+    rope_llama3: bool = false,
+    rope_llama3_factor: f32 = 8.0,
+    rope_llama3_low_freq_factor: f32 = 1.0,
+    rope_llama3_high_freq_factor: f32 = 4.0,
+    rope_llama3_orig_max_pos: u32 = 8192,
 
     // Sliding window attention
     has_sliding_window: bool = true,
@@ -477,6 +487,20 @@ pub const ModelConfig = struct {
     image_token_id: u32 = 0, // 0 = no image token
     boi_token_id: u32 = 0, // beginning of image
     eoi_token_id: u32 = 0, // end of image
+
+    // JoyCaption / standard HF LLaVA (src/joycaption_vision.zig): a plain,
+    // fixed-resolution SigLIP tower (siglip_vision_model, NO CLS token,
+    // NO RoPE, NO gating — 2 layernorms + fc1/fc2 MLP, everything biased)
+    // bridged to the text trunk by a 2-layer MLP `multi_modal_projector`.
+    // Distinct from the Gemma fields above, which are a different SigLIP
+    // variant (2D RoPE, clipped linears, sandwich norms, gated MLP).
+    joycaption_vision: bool = false,
+    vision_image_size: u32 = 384, // fixed square resize target (image_size in vision_config)
+    vision_layer_norm_eps: f32 = 1e-6,
+    // HF `hidden_states` index (Python-negative allowed): which vision layer's
+    // OUTPUT to splice. -2 (JoyCaption's value) means "skip the LAST encoder
+    // layer and post_layernorm entirely" — see joycaption_vision.zig.
+    vision_feature_layer: i32 = -2,
 
     // Gemma 4 12B "unified" (encoder-free) multimodal. Instead of the SigLIP
     // transformer tower, vision is a single patch embedder
@@ -1720,6 +1744,12 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
             if (vc.get("patch_size")) |v| {
                 if (v == .integer) config.vision_patch_size = @intCast(v.integer);
             }
+            if (vc.get("image_size")) |v| {
+                if (v == .integer) config.vision_image_size = @intCast(v.integer);
+            }
+            if (vc.get("layer_norm_eps")) |v| {
+                config.vision_layer_norm_eps = jsonFloat(v);
+            }
             if (vc.get("pooling_kernel_size")) |v| {
                 if (v == .integer) config.vision_pooling_kernel = @intCast(v.integer);
             }
@@ -1792,6 +1822,14 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
     }
     if (root.get("image_token_index")) |v| {
         if (v == .integer and config.image_token_id == 0) config.image_token_id = @intCast(v.integer);
+    }
+    // JoyCaption/LLaVA: a FIXED per-image token count (no dynamic resolution),
+    // same role as Gemma's `default_output_length`/`num_soft_tokens` above.
+    if (root.get("image_seq_length")) |v| {
+        if (v == .integer) config.vision_soft_tokens = @intCast(v.integer);
+    }
+    if (root.get("vision_feature_layer")) |v| {
+        if (v == .integer) config.vision_feature_layer = @intCast(v.integer);
     }
     if (root.get("boi_token_id")) |v| {
         if (v == .integer) config.boi_token_id = @intCast(v.integer);
@@ -3120,6 +3158,15 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
             config.model_type = "llama";
         } else if (std.mem.eql(u8, model_type, "mistral")) {
             config.model_type = "mistral";
+        } else if (std.mem.eql(u8, model_type, "llava")) {
+            // JoyCaption (fancyfeast/llama-joycaption-beta-one-hf-llava) and
+            // any standard HF LlavaForConditionalGeneration checkpoint: a
+            // plain Llama text backbone (`text_config`, already `cfg_obj`
+            // above) + a standard SigLIP vision tower (`vision_config`,
+            // parsed generically above) bridged by `multi_modal_projector`.
+            config.model_type = "llava";
+            config.weight_prefix = "language_model.model";
+            config.joycaption_vision = true;
         } else {
             config.model_type = "unknown";
         }
@@ -3155,6 +3202,31 @@ pub fn parseConfigFromJson(allocator: std.mem.Allocator, content: []const u8) !M
 
         if (std.mem.eql(u8, model_type, "qwen3")) {
             config.has_qk_norm = true;
+        }
+
+        // Llama-3.1/3.2 "llama3" rope_scaling: a piecewise wavelength blend,
+        // NOT the uniform `rope_scaling_factor` division the generic reader
+        // above already applied (harmless once `rope_llama3` is set — the
+        // custom-freqs path in transformer.zig ignores `rope_scaling_factor`).
+        if (std.mem.eql(u8, model_type, "llava")) {
+            if (cfg_obj.get("rope_scaling")) |rs_val| {
+                if (rs_val == .object) {
+                    const rs = rs_val.object;
+                    const is_llama3 = if (rs.get("rope_type")) |v|
+                        (v == .string and std.mem.eql(u8, v.string, "llama3"))
+                    else
+                        false;
+                    if (is_llama3) {
+                        config.rope_llama3 = true;
+                        if (rs.get("factor")) |v| config.rope_llama3_factor = jsonFloat(v);
+                        if (rs.get("low_freq_factor")) |v| config.rope_llama3_low_freq_factor = jsonFloat(v);
+                        if (rs.get("high_freq_factor")) |v| config.rope_llama3_high_freq_factor = jsonFloat(v);
+                        if (rs.get("original_max_position_embeddings")) |v| {
+                            if (v == .integer) config.rope_llama3_orig_max_pos = @intCast(v.integer);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/model_discovery.zig
+++ b/src/model_discovery.zig
@@ -41,6 +41,7 @@ const supported_model_types = [_][]const u8{
     "qwen3_moe_text",   "qwen3_next",
     "qwen4_exp",        "qwen4_exp_text", // Qwen3.8-Flash-Next (GDN + QSA + n-gram PLE MoE)
     "llama",            "mistral",
+    "llava", // JoyCaption / standard HF LlavaForConditionalGeneration (Llama-3 + SigLIP)
     "lfm2", // also matches any "lfm2*" prefix (lfm2_vl etc. when added)
     "nemotron_h",
     "bert",

--- a/src/server.zig
+++ b/src/server.zig
@@ -9978,6 +9978,9 @@ fn parseAudioContent(allocator: std.mem.Allocator, data: []const u8) ?chat_mod.A
 /// Returns null on any decode failure (caller treats as missing image).
 /// Derive per-request image preprocessing params from the loaded model config.
 fn visionPreprocFromConfig(config: *const model_mod.ModelConfig) chat_mod.VisionPreproc {
+    if (config.joycaption_vision) {
+        return .{ .mode = .siglip, .fixed_size = config.vision_image_size };
+    }
     if (config.lfm2_vision) {
         // NaFlex: no temporal axis and no merge-block patch order — the
         // projector unshuffles AFTER the tower, so the grid stays plain
@@ -10451,6 +10454,35 @@ fn decodeImageToPixels(allocator: std.mem.Allocator, encoded: []const u8, vp: ch
     const px = src.rgb.ptr;
     const src_w: u32 = src.w;
     const src_h: u32 = src.h;
+
+    // JoyCaption SigLIP: FIXED square resize (no smart-resize — the tower's
+    // patch grid, and therefore `image_seq_length`, is constant), bilinear-
+    // family resample + proper (x/255−0.5)/0.5 normalization at preprocess
+    // time (unlike `.gemma`, whose (x−0.5)/0.5 happens inside the tower
+    // forward). `grid_h` stays 0 — this is CHW pixels, routed to
+    // `VisionEncoder.forward` like Gemma's, not `forwardPatches`.
+    if (vp.mode == .siglip) {
+        const siglip_target = if (vp.fixed_size > 0) vp.fixed_size else 384;
+        const out_size = 3 * siglip_target * siglip_target;
+        const out_buf = allocator.alloc(u8, out_size * 4) catch return null;
+        const chw: [*]f32 = @ptrCast(@alignCast(out_buf.ptr));
+        const source_len: usize = @as(usize, src_h) * src_w * 3;
+        qwen_vision.resizeRgbNormalizedChw(
+            allocator,
+            chw[0..out_size],
+            px[0..source_len],
+            src_h,
+            src_w,
+            siglip_target,
+            siglip_target,
+            resampleFilterFor(vp),
+        ) catch {
+            allocator.free(out_buf);
+            return null;
+        };
+        log.info("  Decoded {d}x{d} image → siglip {d}x{d} float32 CHW\n", .{ src_w, src_h, siglip_target, siglip_target });
+        return .{ .pixels = out_buf, .width = siglip_target, .height = siglip_target };
+    }
 
     // Patch-grid towers: smart-resize to a multiple of patch·merge, normalize
     // (x/255−0.5)/0.5 (both processors use mean/std 0.5), then emit that

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -6734,6 +6734,39 @@ pub const Transformer = struct {
             rope_freqs_global = freqs_arr;
         }
 
+        // Llama-3.1/3.2 "llama3" rope_scaling: a piecewise wavelength blend
+        // (transformers `_compute_llama3_parameters`), NOT Gemma's uniform
+        // proportional scaling above — mutually exclusive with it, but reuses
+        // the SAME `rope_freqs_global` custom-frequencies mechanism (every
+        // layer is "global" for a plain Llama trunk, so `forwardStandardWith`
+        // picks it up with zero forward-pass changes).
+        if (config.rope_llama3) {
+            const half = config.head_dim / 2;
+            const freqs_f64 = try allocator.alloc(f64, half);
+            defer allocator.free(freqs_f64);
+            computeLlama3RopeFreqs(
+                freqs_f64,
+                config.head_dim,
+                config.rope_theta,
+                config.rope_llama3_factor,
+                config.rope_llama3_low_freq_factor,
+                config.rope_llama3_high_freq_factor,
+                config.rope_llama3_orig_max_pos,
+            );
+            const freqs_f32 = try allocator.alloc(f32, half);
+            defer allocator.free(freqs_f32);
+            for (freqs_f64, 0..) |v, i| freqs_f32[i] = @floatCast(v);
+            const fshape = [_]c_int{@intCast(half)};
+            const arr = mlx.mlx_array_new_data(freqs_f32.ptr, &fshape, 1, .float32);
+            {
+                const eval_vec = mlx.mlx_vector_array_new();
+                defer _ = mlx.mlx_vector_array_free(eval_vec);
+                _ = mlx.mlx_vector_array_append_value(eval_vec, arr);
+                try mlx.check(mlx.mlx_eval(eval_vec));
+            }
+            rope_freqs_global = arr;
+        }
+
         // Laguna YaRN (full-attention layers): precompute the mlx_fast_rope
         // denominator array + the mscale vector (attention_factor on rotated
         // dims, 1.0 on the pass-through tail). Sliding layers use default RoPE.
@@ -19859,6 +19892,40 @@ fn computeYarnFreqs(
         const extrapolation_factor = 1.0 - ramp;
         const inv_freq = inv_interpolation * (1.0 - extrapolation_factor) + inv_extrapolation * extrapolation_factor;
         out[i] = 1.0 / inv_freq;
+    }
+}
+
+/// Llama-3.1/3.2 "llama3" `rope_scaling`: transformers'
+/// `_compute_llama3_parameters` — a piecewise blend between the standard
+/// (extrapolated) frequency and a uniformly-scaled (interpolated) one, keyed
+/// on each dimension's wavelength relative to `original_max_position_embeddings`.
+/// `out[i] = 1/inv_freq_llama3[i]` (same "reciprocal of inv_freq" convention
+/// as `computeYarnFreqs` — see the `mlx_fast_rope` `freqs` doc comment there).
+fn computeLlama3RopeFreqs(
+    out: []f64,
+    head_dim: u32,
+    base: f64,
+    factor: f64,
+    low_freq_factor: f64,
+    high_freq_factor: f64,
+    orig_max: u32,
+) void {
+    const dim: f64 = @floatFromInt(head_dim);
+    const n = out.len; // dim/2
+    const mp: f64 = @floatFromInt(orig_max);
+    const low_freq_wavelen = mp / low_freq_factor;
+    const high_freq_wavelen = mp / high_freq_factor;
+
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        const inv_freq = 1.0 / std.math.pow(f64, base, @as(f64, @floatFromInt(2 * i)) / dim);
+        const wavelen = 2.0 * std.math.pi / inv_freq;
+        var inv_freq_llama = if (wavelen > low_freq_wavelen) inv_freq / factor else inv_freq;
+        const smooth = (mp / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor);
+        const smoothed_inv_freq = (1.0 - smooth) / factor * inv_freq_llama + smooth * inv_freq_llama;
+        const is_medium_freq = wavelen >= high_freq_wavelen and wavelen <= low_freq_wavelen;
+        if (is_medium_freq) inv_freq_llama = smoothed_inv_freq;
+        out[i] = 1.0 / inv_freq_llama;
     }
 }
 

--- a/src/vision.zig
+++ b/src/vision.zig
@@ -5,6 +5,7 @@ const log = @import("log.zig");
 const qwen_vision = @import("qwen_vision.zig");
 const muse_vision = @import("muse_vision.zig");
 const lfm2_vision = @import("lfm2_vision.zig");
+const joycaption_vision = @import("joycaption_vision.zig");
 
 const ModelConfig = model_mod.ModelConfig;
 const Weights = model_mod.Weights;
@@ -123,12 +124,14 @@ pub const VisionEncoder = struct {
     qwen: ?qwen_vision.QwenVision = null,
     muse: ?muse_vision.MuseVision = null,
     lfm2: ?lfm2_vision.Lfm2Vision = null,
+    joycaption: ?joycaption_vision.JoycaptionVision = null,
 
     pub fn init(allocator: std.mem.Allocator, config: ModelConfig, weights: *const Weights) !VisionEncoder {
         if (config.is_gemma4_unified) return initUnified(allocator, config, weights);
         if (config.qwen_vision) return initQwen(allocator, config, weights);
         if (config.muse_vision) return initMuse(allocator, config, weights);
         if (config.lfm2_vision) return initLfm2(allocator, config, weights);
+        if (config.joycaption_vision) return initJoycaption(allocator, config, weights);
         const s = mlx.mlx_default_gpu_stream_new();
 
         var name_buf: [256]u8 = undefined;
@@ -253,6 +256,7 @@ pub const VisionEncoder = struct {
         if (self.qwen) |*q| q.deinit();
         if (self.muse) |*m| m.deinit();
         if (self.lfm2) |*l| l.deinit();
+        if (self.joycaption) |*j| j.deinit();
         self.allocator.free(self.layers);
         _ = mlx.mlx_stream_free(self.s);
     }
@@ -417,6 +421,34 @@ pub const VisionEncoder = struct {
             .half = bf16Scalar(0.5, s),
             .one = bf16Scalar(1.0, s),
             .lfm2 = lv,
+        };
+    }
+
+    /// Build a VisionEncoder wrapping the JoyCaption/LLaVA fixed-resolution
+    /// SigLIP tower. Same sentinel shape as `initQwen`; `joycaption` drives
+    /// `forward` (NOT `forwardPatches` — this tower takes CHW pixels like the
+    /// Gemma path, not pre-patchified merge-order rows).
+    fn initJoycaption(allocator: std.mem.Allocator, config: ModelConfig, weights: *const Weights) !VisionEncoder {
+        const s = mlx.mlx_default_gpu_stream_new();
+        const jv = try joycaption_vision.JoycaptionVision.init(allocator, config, weights);
+        return .{
+            .config = config,
+            .s = s,
+            .allocator = allocator,
+            .patch_proj_w = mlx.mlx_array_new(),
+            .position_embedding = mlx.mlx_array_new(),
+            .layers = &.{},
+            .proj_w = mlx.mlx_array_new(),
+            .proj_s = mlx.mlx_array_new(),
+            .proj_b = mlx.mlx_array_new(),
+            .proj_quant_bits = 4,
+            .proj_quant_group_size = config.quant_group_size,
+            .std_scale = null,
+            .std_bias = null,
+            .rms_eps = 1e-6,
+            .half = bf16Scalar(0.5, s),
+            .one = bf16Scalar(1.0, s),
+            .joycaption = jv,
         };
     }
 
@@ -618,6 +650,7 @@ pub const VisionEncoder = struct {
     /// The caller must cycle these to fill the expected image_seq_length (280) token positions.
     pub fn forward(self: *VisionEncoder, pixels: mlx.mlx_array) !mlx.mlx_array {
         if (self.unified) |u| return self.forwardUnified(&u, pixels);
+        if (self.joycaption) |*jv| return jv.forward(pixels);
         // A patch-grid tower's SigLIP fields are null sentinels, so a gridless
         // (Gemma-shaped) buffer reaching here is a client/preprocessing
         // mismatch, not something to dereference. Backstop for the parse-level


### PR DESCRIPTION
This pull request adds support for HuggingFace LLaVA (JoyCaption) models with a fixed-resolution SigLIP vision tower, and implements Llama-3.1/3.2's new RoPE scaling method. The changes include model discovery and config parsing updates, image preprocessing, and vision encoder integration for JoyCaption, as well as the implementation of Llama-3's piecewise RoPE scaling.

**LLaVA (JoyCaption) / SigLIP Vision Tower Support:**

* Added `"llava"` to supported architecture prefixes and model types, enabling discovery and loading of HuggingFace LLaVA/JoyCaption models. [[1]](diffhunk://#diff-7cd7542704941b56eac1445cd997cdb1c4aa1e255aeba0189225def1382e14bfR22) [[2]](diffhunk://#diff-7cd7542704941b56eac1445cd997cdb1c4aa1e255aeba0189225def1382e14bfR49) [[3]](diffhunk://#diff-90465a5d5c0cbc291aab0223a8a5d9207eb5ab5de2d58068c41d0da742635f33R44)
* Extended model config and JSON parsing to recognize JoyCaption-specific fields (e.g., `joycaption_vision`, `vision_image_size`, `vision_layer_norm_eps`, `vision_feature_layer`, and `image_seq_length`). [[1]](diffhunk://#diff-f80f4ad4d66eed3b0d576e4b68fe34c6117eaaf6939e6fc3bf26c67e8d427dbbR491-R504) [[2]](diffhunk://#diff-f80f4ad4d66eed3b0d576e4b68fe34c6117eaaf6939e6fc3bf26c67e8d427dbbR1747-R1752) [[3]](diffhunk://#diff-f80f4ad4d66eed3b0d576e4b68fe34c6117eaaf6939e6fc3bf26c67e8d427dbbR1826-R1833) [[4]](diffhunk://#diff-f80f4ad4d66eed3b0d576e4b68fe34c6117eaaf6939e6fc3bf26c67e8d427dbbR3161-R3169)
* Integrated JoyCaption vision encoder (`joycaption_vision.zig`) into the main vision pipeline, including initialization, forward pass, and deinitialization. [[1]](diffhunk://#diff-da6b91c9fe3537e458f9b1ee2840c967a8963c6201953494939af85247b7f7f3R8) [[2]](diffhunk://#diff-da6b91c9fe3537e458f9b1ee2840c967a8963c6201953494939af85247b7f7f3R127-R134) [[3]](diffhunk://#diff-da6b91c9fe3537e458f9b1ee2840c967a8963c6201953494939af85247b7f7f3R259) [[4]](diffhunk://#diff-da6b91c9fe3537e458f9b1ee2840c967a8963c6201953494939af85247b7f7f3R427-R454) [[5]](diffhunk://#diff-da6b91c9fe3537e458f9b1ee2840c967a8963c6201953494939af85247b7f7f3R653)
* Updated image preprocessing to handle JoyCaption's fixed-size, bilinear-resized, and properly normalized SigLIP input. [[1]](diffhunk://#diff-34160b161d0764062b8c07db4a03e2278f8215ac8a0b1eaa86b2aa8937c16661L44-R50) [[2]](diffhunk://#diff-0544ae00a95db6e9b66ccadc64b2b9a963d15e9274b7e56b9ca1b7513f64c8c1R9981-R9983) [[3]](diffhunk://#diff-0544ae00a95db6e9b66ccadc64b2b9a963d15e9274b7e56b9ca1b7513f64c8c1R10458-R10486)

**Llama-3.1/3.2 RoPE Scaling Support:**

* Implemented Llama-3's piecewise RoPE scaling ("llama3" mode), including config fields, JSON parsing, and the new `computeLlama3RopeFreqs` function for frequency calculation. [[1]](diffhunk://#diff-f80f4ad4d66eed3b0d576e4b68fe34c6117eaaf6939e6fc3bf26c67e8d427dbbR147-R156) [[2]](diffhunk://#diff-f80f4ad4d66eed3b0d576e4b68fe34c6117eaaf6939e6fc3bf26c67e8d427dbbR3206-R3230) [[3]](diffhunk://#diff-aee7b6912acdf717debec07b3e6f0cb97ff57427a2cdf2c87b4e8d7432fb6896R6737-R6769) [[4]](diffhunk://#diff-aee7b6912acdf717debec07b3e6f0cb97ff57427a2cdf2c87b4e8d7432fb6896R19898-R19931)

These changes collectively enable support for new multimodal models and improve compatibility with the latest HuggingFace and Llama model variants.