### PR TITLE
perf: let NAX own q=9 causal verify

### DIFF
--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -2825,9 +2825,10 @@ fn sdpaSplitEnabled() bool {
 var sdpa_split_logged: [4]bool = .{ false, false, false, false };
 
 /// Width-wall query split for dense causal spec-verify blocks (B==1, hd 256,
-/// q_len 6..9). MLX's sdpa has no full-kernel arm at hd 256 and its vector
-/// kernel serves q_len * gqa <= 32, so a 6..9-row verify block otherwise runs
-/// the slow internal fallback on every machine. Splitting the queries at row
+/// q_len 6..9). MLX's vector kernel serves q_len * gqa <= 32. On NAX the
+/// stock full-attention kernel owns q_len 9; the split owns q_len 6..8.
+/// Off NAX it owns q_len 6..9, avoiding the slow internal fallback. Splitting
+/// the queries at row
 /// 5 keeps both halves on the vector path with windows byte-identical to two
 /// consecutive <= 5-row rounds at the same offsets (bottom-right causal
 /// alignment): chunk A (rows 0..<5) over keys[0 .. kL-(qL-5)], chunk B
@@ -2853,6 +2854,9 @@ pub fn splitCausalSdpa(
     if (ks[2] < qs[2] or ks[2] != vs[2] or ks[1] != vs[1]) return null;
 
     const qL = qs[2];
+    // Keep the explicit test/benchmark override authoritative so the old
+    // split path remains forceable while production Q=9 yields to stock NAX.
+    if (qL == 9 and sdpa_split_override == null and naxSdpaPreferred()) return null;
     const kL = ks[2];
     const split: c_int = 5;
     const k_split: c_int = kL - (qL - split);
@@ -14070,8 +14074,8 @@ pub const Transformer = struct {
                 _ = mlx.mlx_array_free(attn_out);
                 attn_out = fused;
             } else if (try splitCausalSdpa(self.s, q_rope, full_k, full_v, attn_scale)) |split_out| {
-                // Verify-width (6..9) dense blocks: two vector-path halves
-                // beat MLX's internal hd-256 fallback.
+                // Dense verify widths still owned by the split use two
+                // vector-path halves; NAX qL=9 declines to the arm below.
                 _ = mlx.mlx_array_free(attn_out);
                 attn_out = split_out;
             } else {
@@ -34209,6 +34213,60 @@ test "splitCausalSdpa: declines outside its envelope" {
     // Kill switch -> null even for a conforming call.
     sdpa_split_override = false;
     try std.testing.expect((try splitCausalSdpa(s, q7, k, k, 1.0)) == null);
+}
+
+test "splitCausalSdpa: NAX owns q 9 unless split is explicitly forced" {
+    const old_split_override = sdpa_split_override;
+    const old_split_env = sdpa_split_env_cached;
+    const old_nax_override = nax_sdpa_override;
+    defer {
+        sdpa_split_override = old_split_override;
+        sdpa_split_env_cached = old_split_env;
+        nax_sdpa_override = old_nax_override;
+    }
+
+    // Pin the production split switch on without activating its force seam.
+    sdpa_split_override = null;
+    sdpa_split_env_cached = true;
+    nax_sdpa_override = true;
+
+    const s = mlx.gpuStream();
+    var prng = std.Random.DefaultPrng.init(0x5D9B);
+    const rnd = prng.random();
+    const kv_shape = [_]c_int{ 1, 1, 64, 256 };
+    const k = try attn256RandBf16(rnd, &kv_shape, s);
+    defer _ = mlx.mlx_array_free(k);
+    const v = try attn256RandBf16(rnd, &kv_shape, s);
+    defer _ = mlx.mlx_array_free(v);
+    const q8_shape = [_]c_int{ 1, 6, 8, 256 };
+    const q8 = try attn256RandBf16(rnd, &q8_shape, s);
+    defer _ = mlx.mlx_array_free(q8);
+    const q9_shape = [_]c_int{ 1, 6, 9, 256 };
+    const q9 = try attn256RandBf16(rnd, &q9_shape, s);
+    defer _ = mlx.mlx_array_free(q9);
+
+    // NAX still leaves width 8 on the split-vector path.
+    {
+        const out = (try splitCausalSdpa(s, q8, k, v, 1.0)) orelse return error.SplitDeclined;
+        defer _ = mlx.mlx_array_free(out);
+    }
+    // Width 9 yields to the caller's stock force_fused NAX arm.
+    try std.testing.expect((try splitCausalSdpa(s, q9, k, v, 1.0)) == null);
+
+    // The explicit seam can force the control path for parity/A-B work.
+    sdpa_split_override = true;
+    {
+        const out = (try splitCausalSdpa(s, q9, k, v, 1.0)) orelse return error.SplitDeclined;
+        defer _ = mlx.mlx_array_free(out);
+    }
+
+    // Without NAX, width 9 remains on the split path by default.
+    sdpa_split_override = null;
+    nax_sdpa_override = false;
+    {
+        const out = (try splitCausalSdpa(s, q9, k, v, 1.0)) orelse return error.SplitDeclined;
+        defer _ = mlx.mlx_array_free(out);
+    }
 }
 
 // ── KV cache growth policy (issue #110) ──────────────────────────────────────


### PR DESCRIPTION
This PR changes width-9 SDPA routing on NAX hardware. The September 13 rerun confirms the intended routing difference, but **does not establish a speedup**. This replaces the earlier unsupported performance interpretation.

The PR was closed by the maintainer on September 12 and remains closed. The follow-up evidence is committed to the source branch at `438d02d48ef516b31705ed6548659362bf37d922`; the links below point to that immutable revision.

### Rerun protocol and checks

- Qwen3.8 pack: `AutomatosX/AX-Qwen3.8-27B-MLX-AXQ-6bit-MTP`, pinned snapshot `6a052d93a4618c8a559f402a16e8a190a48f209e`. Its actual tensors use a mixed 4/6/8-bit trunk and BF16 MTP sidecar, so this is not a uniformly 6-bit checkpoint.
- A = original parent `6787142`; B = original PR head `1032fba`. Both freshly rebuilt ReleaseFast with the same pinned compiler and MLX libraries.
- `MLX_SERVE_MTP_FORCE_DEPTH=8`, `MLX_SERVE_MTP_TRACE=1`, and `--log-level debug` on both arms, with identical discarded warmups.
- One boot and session, AC power, full-blast fans throughout. **A B B A A B B A**, four reports per arm.
- `npx --yes llmprobe@0.6.7 localhost:11234 --bench-only --rungs 2k,8k,16k,32k --no-save --no-color --save <report.json>`.
- All **32/32 context rungs succeeded**. All four controls logged a width-9 split; all four PR runs logged none. Every run had positive depth-8 MTP traces. Artifact/model/library hashes matched after the session.

### Engagement excerpts

Control A, 01-A (equivalent width-9 engagement present in every A log):

```text
[sdpa-split] engaged: qL=9 kL=2369 Hq=24 Hkv=4 (MLX_SERVE_SDPA_SPLIT=0 restores the single dispatch)
```

PR B, 02-B (zero width-9 split entries across all B logs):

```text
[nax-sdpa] engaged: stock fused sdpa (force_fused) serves hd-256 causal prefill and verify blocks > 8 rows; msv_attn_p256 causal arm declined (MLX_SERVE_NAX_SDPA=0 restores)
  [mtp-trace] rounds=32 avg_ms draft=2.93 sync=0.00 ext=0.00 verify=2.49 corr=0.00 eval=89.54 hist=0.15 commit=0.08 predraft=40.26 gap=0.05 total=135.50 | m_avg=8.00 acc_avg=2.44 ext_rate=0.00 acc_idx=0.72/0.50/0.38/0.28/0.22/0.13/0.13/0.09
```

### Results and limits

Novel speculative throughput medians were **20.0 tok/s A vs 19.6 tok/s B**. Context-rung median changes were −5.0%, −7.0%, −4.9%, and −14.7% at 2K/8K/16K/32K. Ranges overlap at every rung. Prefill also moved substantially, despite the change only affecting verify routing.

**Concurrent host work was observed**, and 05-A was flagged degraded (−12.4%). Every report is retained, including adverse results and the faster B 32K sample. This was not an exclusive-host experiment: the measured slowdowns cannot be attributed solely to the PR. A causal performance claim still needs a quiet-host comparison.

### Evidence

[Full report](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/README.md) · [Per-run values and engagement counts](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/summary.md) · [Complete evidence ZIP](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/evidence.zip) · [ZIP SHA-256](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/evidence.zip.sha256)

The ZIP contains all raw JSONs, full server/console/probe logs, discarded warmup responses, manifests, hashes, and fan/host observations. Individual raw llmprobe reports:

- [01-A.llmprobe.json](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/01-A.llmprobe.json)
- [02-B.llmprobe.json](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/02-B.llmprobe.json)
- [03-B.llmprobe.json](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/03-B.llmprobe.json)
- [04-A.llmprobe.json](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/04-A.llmprobe.json)
- [05-A.llmprobe.json](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/05-A.llmprobe.json)
- [06-B.llmprobe.json](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/06-B.llmprobe.json)
- [07-B.llmprobe.json](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/07-B.llmprobe.json)
- [08-A.llmprobe.json](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/session-01/08-A.llmprobe.json)

Validation: both ReleaseFast builds passed; focused SDPA routing/parity tests exited 0; five harness tests passed. The harness rejects the older missing-2K/failed-32K reports. [Build/test receipt](https://github.com/PhilipJohnBasile/mlx-serve/blob/438d02d48ef516b31705ed6548659362bf37d922/benchmarks/pr302/2026-09-13/build/validation.json).
