### PR TITLE
fix(prefix-cache): keep bounded SSM checkpoints spread, not oldest-first

### DIFF
--- a/src/prefix_cache.zig
+++ b/src/prefix_cache.zig
@@ -739,15 +739,43 @@ pub const HotPrefixCache = struct {
                 self.allocator.free(old);
                 self.allocator.free(new);
                 // The merged list spans BOTH turns, so the per-prefill cap in
-                // generate.zig no longer bounds it. Re-apply it here, dropping
-                // oldest-first exactly as the capture path does: the newest
-                // positions sit closest to end-of-prompt, which is where warm
-                // multi-turn requests match.
+                // generate.zig no longer bounds it. Re-apply it here — but not
+                // oldest-first. Within one prefill that is fine; across turns it
+                // collapses the survivors onto the end of the prompt, and then a
+                // request that diverges early finds no checkpoint at or below its
+                // match and pays a FULL cold prefill:
+                //     [hot-cache] hybrid miss (no checkpoint <= 16382 of 178509)
+                // That one cost 415 s. Oldest-first is also the expensive choice:
+                // a checkpoint costs roughly a constant plus a term linear in its
+                // position, so it discards the cheap early ones and keeps the
+                // large late ones.
+                //
+                // Thin the interior instead, always keeping the first and the
+                // newest: drop whichever checkpoint sits between the closest pair
+                // of neighbours, i.e. the one whose removal widens the coverage
+                // gap least. The result is a spread over the whole prompt at the
+                // same count and LESS memory. `n` is at most ssm_checkpoint_max,
+                // so the quadratic scan is trivial.
                 while (self.ssm_checkpoint_max > 0 and
                     merged.items.len > self.ssm_checkpoint_max)
                 {
-                    var oldest = merged.orderedRemove(0);
-                    oldest.deinit(self.allocator);
+                    // Under three there is no interior to thin; honour the cap by
+                    // dropping the oldest, which is also the cheapest to redo.
+                    const drop = if (merged.items.len < 3) 0 else blk2: {
+                        var best_at: usize = 1;
+                        var best_span: usize = std.math.maxInt(usize);
+                        var k: usize = 1;
+                        while (k + 1 < merged.items.len) : (k += 1) {
+                            const span = merged.items[k + 1].pos - merged.items[k - 1].pos;
+                            if (span < best_span) {
+                                best_span = span;
+                                best_at = k;
+                            }
+                        }
+                        break :blk2 best_at;
+                    };
+                    var dropped = merged.orderedRemove(drop);
+                    dropped.deinit(self.allocator);
                 }
                 break :blk try merged.toOwnedSlice(self.allocator);
             };
@@ -1723,56 +1751,69 @@ test "HotPrefixCache: hybrid RAM match at least as good as disk skips the SSD re
 }
 
 // Regression: an entry that is EXTENDED in place must not accumulate SSM
-// checkpoints without bound. `generate.zig` caps what a single prefill
+// checkpoints without bound, and bounding them must not collapse the survivors
+// onto the end of the prompt. `generate.zig` caps what a single prefill
 // captures, but the replace path merges the previous entry's checkpoints with
-// this turn's, and nothing re-applied the cap to the merged list — so an agent
+// this turn's, and nothing re-applied a cap to the merged list — so an agent
 // conversation gained one checkpoint per turn forever. Observed on
 // Qwen3.8-Flash-Next (36 GDN layers): 31237 MB of SSM state in ONE entry under
 // `--ssm-checkpoint-max 8`, which starved the prompt-admission check.
-test "HotPrefixCache: replace path re-applies ssm_checkpoint_max across turns" {
+//
+// Capping oldest-first fixes the size but leaves every survivor near the end,
+// and a request diverging earlier then pays a full cold prefill
+// ("hybrid miss (no checkpoint <= 16382 of 178509)", 415 s). So the cap thins
+// the interior and keeps a spread.
+test "HotPrefixCache: replace path bounds SSM checkpoints and keeps them spread" {
     const s = mlx.gpuStream();
 
-    var tokens: [600]u32 = undefined;
+    var tokens: [900]u32 = undefined;
     for (&tokens, 0..) |*t, i| t.* = @intCast(i + 3);
 
     var hc = HotPrefixCache.initWithMem(testing.allocator, 4, 0);
-    hc.ssm_checkpoint_max = 2;
+    hc.ssm_checkpoint_max = 4;
     defer hc.deinit();
 
-    // Turn 1: a 300-token entry carrying two checkpoints.
+    var srcs: [8][3]SSMCacheEntry = undefined;
+    for (&srcs, 0..) |*e, i| {
+        const f: f64 = @floatFromInt(i + 1);
+        e.* = pcBuildHybrid(s, 100.0 * f, 500.0 * f);
+    }
+    defer {
+        for (&srcs) |*e| pcFreeHybrid(e);
+    }
+
+    // Turn 1: four checkpoints at 100..400 over a 450-token prefix.
     var c1 = try KVCache.init(testing.allocator, 3);
     defer c1.deinit();
-    try testFillCache(&c1, s, 3, 300);
-    var a = pcBuildHybrid(s, 100.0, 500.0);
-    defer pcFreeHybrid(&a);
-    var b = pcBuildHybrid(s, 300.0, 700.0);
-    defer pcFreeHybrid(&b);
-    const cps1 = try testing.allocator.alloc(SSMCheckpoint, 2);
-    cps1[0] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &a, 100, s);
-    cps1[1] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &b, 200, s);
-    try hc.commitWithSsm(&c1, tokens[0..300], false, cps1, null, null);
-    try testing.expectEqual(@as(usize, 2), hc.entries.items[0].ssm_checkpoints.?.len);
+    try testFillCache(&c1, s, 3, 450);
+    const cps1 = try testing.allocator.alloc(SSMCheckpoint, 4);
+    for (cps1, 0..) |*c, i| {
+        c.* = try transformer_mod.captureSsmCheckpoint(testing.allocator, &srcs[i], (i + 1) * 100, s);
+    }
+    try hc.commitWithSsm(&c1, tokens[0..450], false, cps1, null, null);
+    try testing.expectEqual(@as(usize, 4), hc.entries.items[0].ssm_checkpoints.?.len);
 
-    // Turn 2 extends that exact prefix — the replace path — and brings two more.
-    // Merged that is four; the cap must bring it back to two.
+    // Turn 2 extends that exact prefix and brings four more at 500..800.
+    // Merged that is eight against a cap of four.
     var c2 = try KVCache.init(testing.allocator, 3);
     defer c2.deinit();
-    try testFillCache(&c2, s, 3, 600);
-    var c = pcBuildHybrid(s, 500.0, 900.0);
-    defer pcFreeHybrid(&c);
-    var d = pcBuildHybrid(s, 700.0, 1100.0);
-    defer pcFreeHybrid(&d);
-    const cps2 = try testing.allocator.alloc(SSMCheckpoint, 2);
-    cps2[0] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &c, 400, s);
-    cps2[1] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &d, 500, s);
-    try hc.commitWithSsm(&c2, tokens[0..600], false, cps2, null, null);
+    try testFillCache(&c2, s, 3, 900);
+    const cps2 = try testing.allocator.alloc(SSMCheckpoint, 4);
+    for (cps2, 0..) |*c, i| {
+        c.* = try transformer_mod.captureSsmCheckpoint(testing.allocator, &srcs[i + 4], (i + 5) * 100, s);
+    }
+    try hc.commitWithSsm(&c2, tokens[0..900], false, cps2, null, null);
 
-    // Extended, not appended: still one entry.
+    // Extended, not appended: still one entry, and the cap holds.
     try testing.expectEqual(@as(usize, 1), hc.entries.items.len);
     const kept = hc.entries.items[0].ssm_checkpoints.?;
-    try testing.expectEqual(@as(usize, 2), kept.len);
-    // Oldest-first drop, matching the capture path: the newest positions win,
-    // because they sit closest to end-of-prompt where warm requests match.
-    try testing.expectEqual(@as(usize, 400), kept[0].pos);
-    try testing.expectEqual(@as(usize, 500), kept[1].pos);
+    try testing.expectEqual(@as(usize, 4), kept.len);
+
+    // The first and the newest always survive, the interior is thinned to keep
+    // coverage. Oldest-first would have left 500/600/700/800, and a request
+    // matching at 150 would then have nothing at or below it to restore from.
+    try testing.expectEqual(@as(usize, 100), kept[0].pos);
+    try testing.expectEqual(@as(usize, 300), kept[1].pos);
+    try testing.expectEqual(@as(usize, 500), kept[2].pos);
+    try testing.expectEqual(@as(usize, 800), kept[3].pos);
 }


### PR DESCRIPTION
Follow-up to #307, which is already merged. That PR bounded the merged checkpoint list and
fixed the unbounded growth, but it drops **oldest-first**, and running the merged behaviour
against a real session showed that is the wrong policy across turns.

## What goes wrong with oldest-first

Within one prefill it is right. Across turns it collapses every survivor onto the end of the
prompt, so a request that diverges earlier finds nothing at or below its match:

```
[hot-cache] hybrid miss (no checkpoint <= 16382 of 178509); cold prefill
<- 178509+63 tokens streamed [prefill: 430.5 tok/s, decode: 28.8 tok/s]
```

178509 / 430.5 = **415 s** of cold prefill. Two of those in one session, plus a 110 s and a
61 s one. That trades a memory failure for a latency failure.

It is also the expensive choice: a checkpoint costs roughly a constant plus a term linear in
its position, so oldest-first discards the cheap early ones and keeps the large late ones.
For 8 checkpoints over a 230k-token prompt:

| retention | cost | coverage |
|---|---:|---|
| 8 newest | ~7.0 GB | last ~16k tokens |
| 8 spread | **~4.3 GB** | whole prompt |

## The change

Thin the interior instead, always keeping the first and the newest: drop whichever
checkpoint sits between the closest pair of neighbours, i.e. the one whose removal widens
the coverage gap least. `n` is at most `ssm_checkpoint_max`, so the quadratic scan is
irrelevant. One file, no new plumbing.

## Tests

Red before green — the test now asserts the spread rather than a raw count. Two turns, cap 4,
eight checkpoints merged, expecting 100/300/500/800. With oldest-first restored:

```
error: 'prefix_cache.test.HotPrefixCache: replace path bounds SSM checkpoints and keeps them spread' failed:
       expected 100, found 500
Build Summary: 7/9 steps succeeded (1 failed); 1/2 tests passed (1 failed)
```

With the change:

```
Build Summary: 9/9 steps succeeded; 1759/1905 tests passed (146 skipped)
```

## Human testing

macOS 26.6.2, Mac17,6 (M5), 128 GiB. Same model and flags as #307
(`--mtp --prefix-cache-mem 12GB --prefix-cache-disk 20GB --ssm-checkpoint-max 8 --kv-quant turbo4`),
built with `zig build -Doptimize=ReleaseFast` and served to a coding agent. 39 requests at
~66k tokens average:

```
hybrid misses 0   evictions 0   rejections 0
residency 1588.42 -> 1930.58 MB over 14 turns, i.e. +1 to +6 MB per turn
```

Modelled 1841 MB against 1930 MB measured, 5% off. The same context under the merged
oldest-first policy would hold ~2796 MB, so this is ~31% less memory with full coverage —
and no cold prefills, where the merged policy produced four.
