### PR TITLE
ui: add remaining space to model browser view in my models

### DIFF
--- a/app/Sources/MLXServe/Views/ModelBrowserMetrics.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserMetrics.swift
@@ -92,4 +92,14 @@ enum ModelBrowserMetrics {
     static var minDetailWidth: CGFloat {
         fixedWidth(for: .compact) + compactModelColumnMinWidth
     }
+
+    /// Formats a volume's available capacity for the My Models footer, or
+    /// `""` when the value couldn't be read (`resourceValues` failed). Split
+    /// out of `MyModelsPane` so the formatting is testable without a real
+    /// volume: the caller resolves `nil`/a byte count off whichever URL is
+    /// the actual download destination, this just renders it.
+    static func freeSpaceLabel(availableBytes: Int64?) -> String {
+        guard let availableBytes else { return "" }
+        return MemoryInfo.format(availableBytes)
+    }
 }

--- a/app/Sources/MLXServe/Views/ModelBrowserView.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserView.swift
@@ -714,6 +714,7 @@ private struct DiscoverPane: View {
 private struct MyModelsPane: View {
     @Binding var filter: String
     @EnvironmentObject var appState: AppState
+    @EnvironmentObject var downloads: DownloadManager
 
     @State private var freeDiskSpace: String = ""
 
@@ -806,13 +807,20 @@ private struct MyModelsPane: View {
         .onAppear {
             updateDiskSpace()
         }
+        .onChange(of: appState.localModels.count) { _, _ in
+            updateDiskSpace()
+        }
+        .onChange(of: downloads.modelsDir) { _, _ in
+            updateDiskSpace()
+        }
     }
 
     private func updateDiskSpace() {
-        guard let values = try? URL(fileURLWithPath: NSHomeDirectory())
-            .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]),
-            let freeSpace = values.volumeAvailableCapacityForImportantUsage else { return }
-        freeDiskSpace = MemoryInfo.format(freeSpace)
+        let values = try? URL(fileURLWithPath: downloads.modelsDir)
+            .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        freeDiskSpace = ModelBrowserMetrics.freeSpaceLabel(
+            availableBytes: values?.volumeAvailableCapacityForImportantUsage
+        )
     }
 }
 

--- a/app/Sources/MLXServe/Views/ModelBrowserView.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserView.swift
@@ -723,7 +723,6 @@ private struct MyModelsPane: View {
 
     private var total: Int { groups.reduce(0) { $0 + $1.models.count } }
 
-
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 6) {
@@ -805,24 +804,15 @@ private struct MyModelsPane: View {
         }
         .navigationTitle("My Models")
         .onAppear {
-             updateDiskSpace()
-         }
+            updateDiskSpace()
+        }
     }
 
-    // Internal handler to pull clean Foundation storage metrics
     private func updateDiskSpace() {
-        let fileURL = URL(fileURLWithPath: NSHomeDirectory())
-        do {
-            let values = try fileURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
-            if let freeSpace = values.volumeAvailableCapacityForImportantUsage {
-                let formatter = ByteCountFormatter()
-                formatter.allowedUnits = [.useAll]
-                formatter.countStyle = .file
-                freeDiskSpace = formatter.string(fromByteCount: freeSpace)
-            }
-        } catch {
-            print("Failed to get storage metadata: \(error.localizedDescription)")
-        }
+        guard let values = try? URL(fileURLWithPath: NSHomeDirectory())
+            .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]),
+            let freeSpace = values.volumeAvailableCapacityForImportantUsage else { return }
+        freeDiskSpace = MemoryInfo.format(freeSpace)
     }
 }
 

--- a/app/Sources/MLXServe/Views/ModelBrowserView.swift
+++ b/app/Sources/MLXServe/Views/ModelBrowserView.swift
@@ -715,11 +715,14 @@ private struct MyModelsPane: View {
     @Binding var filter: String
     @EnvironmentObject var appState: AppState
 
+    @State private var freeDiskSpace: String = ""
+
     private var groups: [LocalModelGroup] {
         ModelBrowserUse.groupedBySource(appState.localModels, filter: filter)
     }
 
     private var total: Int { groups.reduce(0) { $0 + $1.models.count } }
+
 
     var body: some View {
         VStack(spacing: 0) {
@@ -791,11 +794,35 @@ private struct MyModelsPane: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Spacer()
+                if !freeDiskSpace.isEmpty {
+                    Text("\(freeDiskSpace) available")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
         }
         .navigationTitle("My Models")
+        .onAppear {
+             updateDiskSpace()
+         }
+    }
+
+    // Internal handler to pull clean Foundation storage metrics
+    private func updateDiskSpace() {
+        let fileURL = URL(fileURLWithPath: NSHomeDirectory())
+        do {
+            let values = try fileURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+            if let freeSpace = values.volumeAvailableCapacityForImportantUsage {
+                let formatter = ByteCountFormatter()
+                formatter.allowedUnits = [.useAll]
+                formatter.countStyle = .file
+                freeDiskSpace = formatter.string(fromByteCount: freeSpace)
+            }
+        } catch {
+            print("Failed to get storage metadata: \(error.localizedDescription)")
+        }
     }
 }
 

--- a/app/Tests/MLXCoreTests/ModelBrowserMetricsTests.swift
+++ b/app/Tests/MLXCoreTests/ModelBrowserMetricsTests.swift
@@ -96,6 +96,22 @@ final class ModelBrowserMetricsTests: XCTestCase {
         XCTAssertGreaterThan(medium, compact)
     }
 
+    /// The My Models footer's free-space label: `nil` (an unreadable volume)
+    /// renders as "" so the row is hidden entirely rather than showing a
+    /// blank/zero figure, and a real byte count renders through the same
+    /// `MemoryInfo.format` every other memory readout in the app uses.
+    func testFreeSpaceLabelIsEmptyWhenUnreadable() {
+        XCTAssertEqual(ModelBrowserMetrics.freeSpaceLabel(availableBytes: nil), "")
+    }
+
+    func testFreeSpaceLabelFormatsBytesLikeMemoryInfo() {
+        let bytes: Int64 = 20 * 1024 * 1024 * 1024
+        XCTAssertEqual(
+            ModelBrowserMetrics.freeSpaceLabel(availableBytes: bytes),
+            MemoryInfo.format(bytes)
+        )
+    }
+
     /// The Model Browser window must OPEN wide enough for the full tier:
     /// sidebar ideal width + full-tier detail. The old 900×600 default gave
     /// the detail ~695pt — born squeezed, which is the "initial window seems


### PR DESCRIPTION
This pull request enhances the `MyModelsPane` view by displaying the amount of free disk space available to the user. The implementation includes tracking and formatting disk space, and updating the view when it appears.

**User Interface Improvements:**
- The available free disk space is now shown in the UI as a caption, making it easy for users to see how much storage is left.
- The disk space is refreshed when the view appears, ensuring the information is up to date.

**Follow-up fix:** the free-space label now reuses `MemoryInfo.format(_:)` (one-decimal "X.X GB", same as the rest of the pane) instead of a separate `ByteCountFormatter`, and reads the volume capacity via `try?` to match the existing pattern in `DownloadManager.swift`.

## Testing

- `cd app && swift build` — builds clean, verified with `bash app/build.sh`.
Before:

Before:

<img width="1316" height="114" alt="image" src="https://github.com/user-attachments/assets/5e121a27-2463-436d-8932-a1df596ccc92" />


After:

<img width="747" height="79" alt="image" src="https://github.com/user-attachments/assets/1972cd4c-c0a3-4754-8085-dd2b077b9d52" />
