### PR TITLE
RFC(qwen4): evaluate PLE pread worker width as a decode improvement

### DIFF
--- a/src/qwen4_exp.zig
+++ b/src/qwen4_exp.zig
@@ -179,7 +179,7 @@ pub const NgramTable = struct {
         if (8 + hlen > size) return error.NgramTableTruncated;
         var t = try parse(map, map[8 .. 8 + hlen], 8 + hlen);
         t.fd = fd;
-        if (plePrefetchEnabled()) t.pool = PrefetchPool.create() catch null;
+        if (plePrefetchEnabled()) t.pool = PrefetchPool.create(plePrefetchWorkerCount()) catch null;
         return t;
     }
 
@@ -322,7 +322,6 @@ pub const NgramTable = struct {
         };
         return std.c.pread(self.fd, dst.ptr, dst.len, @intCast(off)) == @as(isize, @intCast(dst.len));
     }
-
 };
 
 /// Persistent gather workers. Every row's three regions are one SSD read on
@@ -332,9 +331,10 @@ pub const NgramTable = struct {
 /// instead and dequantize their rows in place. Workers wake on a generation
 /// bump and count themselves down; the caller spins (the job is ~100 us).
 const PrefetchPool = struct {
-    const N = 48;
+    const MAX_WORKERS = 48;
     const MAX_ROWS = 64;
     const ROW_BUF = 512;
+    n: usize,
     mu: std.Io.Mutex = .init,
     cv: std.Io.Condition = .init,
     gen: u64 = 0,
@@ -344,18 +344,19 @@ const PrefetchPool = struct {
     bufs: [MAX_ROWS][ROW_BUF]u8 = undefined,
     pending: std.atomic.Value(u32) = .init(0),
     failed: std.atomic.Value(u32) = .init(0),
-    threads: [N]std.Thread = undefined,
+    threads: [MAX_WORKERS]std.Thread = undefined,
 
-    fn create() !*PrefetchPool {
+    fn create(n: usize) !*PrefetchPool {
+        std.debug.assert(n >= 1 and n <= MAX_WORKERS);
         const a = std.heap.page_allocator;
         const p = try a.create(PrefetchPool);
-        p.* = .{};
+        p.* = .{ .n = n };
         var started: usize = 0;
         errdefer {
             p.shutdown(started);
             a.destroy(p);
         }
-        for (0..N) |i| {
+        for (0..n) |i| {
             p.threads[i] = try std.Thread.spawn(.{ .stack_size = 64 * 1024 }, worker, .{ p, i });
             started += 1;
         }
@@ -363,7 +364,7 @@ const PrefetchPool = struct {
     }
 
     fn destroy(self: *PrefetchPool) void {
-        self.shutdown(N);
+        self.shutdown(self.n);
         std.heap.page_allocator.destroy(self);
     }
 
@@ -383,7 +384,7 @@ const PrefetchPool = struct {
         self.table = table;
         self.rows = rows;
         self.failed.store(0, .release);
-        self.pending.store(N, .release);
+        self.pending.store(@intCast(self.n), .release);
         self.gen += 1;
         self.cv.broadcast(io);
         self.mu.unlock(io);
@@ -406,13 +407,24 @@ const PrefetchPool = struct {
             const rows = self.rows;
             self.mu.unlock(io);
             var i = idx;
-            while (i < rows.len * 3) : (i += N) {
+            while (i < rows.len * 3) : (i += self.n) {
                 if (!table.preadSite(@intCast(rows[i / 3]), i % 3, &self.bufs[i / 3])) _ = self.failed.fetchAdd(1, .acq_rel);
             }
             _ = self.pending.fetchSub(1, .acq_rel);
         }
     }
 };
+
+fn parsePlePrefetchWorkers(raw: ?[]const u8) usize {
+    const text = raw orelse return PrefetchPool.MAX_WORKERS;
+    const requested = std.fmt.parseInt(usize, text, 10) catch return PrefetchPool.MAX_WORKERS;
+    return @min(PrefetchPool.MAX_WORKERS, @max(1, requested));
+}
+
+fn plePrefetchWorkerCount() usize {
+    const raw = std.c.getenv("QWEN4_PLE_PREFETCH_WORKERS");
+    return parsePlePrefetchWorkers(if (raw) |value| std.mem.span(value) else null);
+}
 
 fn plePrefetchEnabled() bool {
     const S = struct {
@@ -432,6 +444,20 @@ pub fn bf16ToF32(u: u16) f32 {
 // ── tests ──
 
 const testing = std.testing;
+
+test "qwen4 PLE prefetch workers keep the measured default for missing or invalid values" {
+    try testing.expectEqual(@as(usize, 48), parsePlePrefetchWorkers(null));
+    try testing.expectEqual(@as(usize, 48), parsePlePrefetchWorkers(""));
+    try testing.expectEqual(@as(usize, 48), parsePlePrefetchWorkers("not-a-number"));
+}
+
+test "qwen4 PLE prefetch workers clamp the construction-time override" {
+    try testing.expectEqual(@as(usize, 1), parsePlePrefetchWorkers("0"));
+    try testing.expectEqual(@as(usize, 1), parsePlePrefetchWorkers("1"));
+    try testing.expectEqual(@as(usize, 16), parsePlePrefetchWorkers("16"));
+    try testing.expectEqual(@as(usize, 48), parsePlePrefetchWorkers("48"));
+    try testing.expectEqual(@as(usize, 48), parsePlePrefetchWorkers("96"));
+}
 
 test "ngram hash reproduces the reference multipliers, primes and offsets" {
     const h = NgramHash.init(248320, 3, 8, 20_000_000, 128, 1234, 0, 248044);


### PR DESCRIPTION
## Evaluation requested from the maintainer

**This is an experimental RFC for the mlxserve author to evaluate as a possible decode improvement. It is not presented as a finished optimization or a recommended new default.**

The question is narrow: **on each supported Apple-silicon and storage configuration, can a different width for the existing PLE pread pool improve end-to-end Qwen4 decode compared with the current fixed width of 48 workers?**

Please benchmark the candidate widths against the unchanged 48-worker default, then decide whether to keep this override, redesign it, or reject it.

## What changed

- Adds QWEN4_PLE_PREFETCH_WORKERS as a construction-time override for the existing native Qwen4 PLE pread pool.
- Keeps 48 workers as the default, so ordinary behavior is unchanged.
- Bounds experimental values to 1 through 48 and falls back to 48 for missing or invalid input.
- Sizes wakeup accounting, worker stride, and shutdown from the installed pool width.
- Reads the setting once when the n-gram table constructs its pool, never inside the gather hot path.
- Adds hermetic tests for default, invalid, and clamped values.

## What mlxserve has already proven

These are measurements of the existing optimization, not results produced by this PR:

| Existing decode implementation | PLE gather latency | Meaning |
| --- | ---: | --- |
| Serial random page faults through the 32 GiB mmap | about 5.0 ms/token | Original bottleneck |
| Shipping pool: 48 persistent workers using pread | about 0.45 ms/token | About 4.55 ms/token, or 91%, less PLE gather latency |

That establishes that native pread is valuable for decode. It does **not** establish that changing the shipping worker count from 48 is faster.

## What the author still needs to evaluate

Run matched full-request comparisons with QWEN4_PLE_PREFETCH_WORKERS set to candidate widths such as 8, 16, 32, and 48. The acceptance decision should use:

1. End-to-end decode tokens per second and wall time.
2. PLE gather latency, preferably p50 and p95.
3. Unchanged generated output and Qwen4 state behavior.
4. No prefill regression.
5. Repeatability across the supported machine and SSD configurations.

No such current-pread worker-width sweep is claimed in this PR.

## Known regression risks

Previous mmap page-fault experiments showed that thread topology matters: 16 newly spawned fault threads measured about 0.70 ms/token, a parked 16-thread fault pool measured about 0.85 ms/token, and 48 mmap-fault threads measured about 1.0 to 1.4 ms/token. Those are different mechanisms from the current persistent pread pool, so they are warnings, not direct evidence for a winning pread width.

Applying the worker route to a 4096-row prefill chunk measured roughly 4% slower. The existing decode-width gate is therefore unchanged, and this PR cannot opt large prefill gathers into the worker path.

## How to verify

    ./.zig-toolchain/zig test src/qwen4_exp.zig -O ReleaseFast

The focused suite passes 14/14 locally. No full-model benchmark was performed for this RFC.

## Notable decisions and tradeoffs

- Default behavior and maximum thread allocation remain exactly 48.
- The override is construction-bound rather than a per-gather branch.
- The decode-only row limit is untouched.
- This deliberately does not add a public CLI setting or choose a new default before the maintainer evaluation.
