### PR TITLE
Load standalone Qwen4 MTP sidecars

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -11,7 +11,8 @@ Apple M4 Max, identical weights per engine. [benchmarks.md](../benchmarks.md) tr
 Four flavors, all greedy-equivalent (byte-identical at temp=0 within the first 30 tokens; mathematically exact at temp > 0 via the Leviathan probability-ratio sampler):
 
 - **Native MTP** (Qwen 3.5/3.6/3.8) — checkpoints with a trained multi-token-prediction head (sidecar or baked in, like the Qwen 3.8 27B build) draft with the model's *own* head, with a controller that self-tunes depth per request. MoE sidecars supported. Auto-loads, zero setup.
-  A standalone Qwen3.8/Qwen4 MLX MTP checkpoint can be linked at `<target-model>/mtp/model.safetensors`; its unprefixed tensor names are mapped automatically and it replaces any MTP head embedded in the target.
+  A standalone Qwen3.8/Qwen4 MLX MTP checkpoint can be linked at `<target-model>/mtp/model.safetensors`; its unprefixed tensor names are mapped automatically when the target has no embedded MTP head.
+  Dense sidecars load independently of the backbone quantization, while an embedded head keeps precedence.
   Qwen3.8 MoE targets require `--mtp` at launch or `"enable_mtp": true` on the request.
 - **DFlash draft companions** — a model folder can ship its own `drafter/` block-draft companion (the Muse-Glimmer builds do); the server loads it with the model, switching models keeps the speedup, and the draft size adapts to the Mac. About 2x on Muse-Glimmer. `--no-drafter` turns it off.
 - **PLD** (Prompt Lookup Decoding) — model-agnostic n-gram match in `prompt + generated_tokens`. Default-on, no per-model setup. Wins on agent loops, RAG and code editing, anywhere the answer echoes the prompt.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -11,6 +11,8 @@ Apple M4 Max, identical weights per engine. [benchmarks.md](../benchmarks.md) tr
 Four flavors, all greedy-equivalent (byte-identical at temp=0 within the first 30 tokens; mathematically exact at temp > 0 via the Leviathan probability-ratio sampler):
 
 - **Native MTP** (Qwen 3.5/3.6/3.8) — checkpoints with a trained multi-token-prediction head (sidecar or baked in, like the Qwen 3.8 27B build) draft with the model's *own* head, with a controller that self-tunes depth per request. MoE sidecars supported. Auto-loads, zero setup.
+  A standalone Qwen3.8/Qwen4 MLX MTP checkpoint can be linked at `<target-model>/mtp/model.safetensors`; its unprefixed tensor names are mapped automatically and it replaces any MTP head embedded in the target.
+  Qwen3.8 MoE targets require `--mtp` at launch or `"enable_mtp": true` on the request.
 - **DFlash draft companions** — a model folder can ship its own `drafter/` block-draft companion (the Muse-Glimmer builds do); the server loads it with the model, switching models keeps the speedup, and the draft size adapts to the Mac. About 2x on Muse-Glimmer. `--no-drafter` turns it off.
 - **PLD** (Prompt Lookup Decoding) — model-agnostic n-gram match in `prompt + generated_tokens`. Default-on, no per-model setup. Wins on agent loops, RAG and code editing, anywhere the answer echoes the prompt.
 - **Gemma 4 assistant drafter** — Google's small 4-layer cross-attention drafters, opt-in via `--drafter <dir>`. Cross-attends into the target's KV cache, so no weights are duplicated.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -12,7 +12,7 @@ Four flavors, all greedy-equivalent (byte-identical at temp=0 within the first 3
 
 - **Native MTP** (Qwen 3.5/3.6/3.8) — checkpoints with a trained multi-token-prediction head (sidecar or baked in, like the Qwen 3.8 27B build) draft with the model's *own* head, with a controller that self-tunes depth per request. MoE sidecars supported. Auto-loads, zero setup.
   A standalone Qwen3.8/Qwen4 MLX MTP checkpoint can be linked at `<target-model>/mtp/model.safetensors`; its unprefixed tensor names are mapped automatically when the target has no embedded MTP head.
-  Dense sidecars load independently of the backbone quantization, while an embedded head keeps precedence.
+  Dense sidecars load independently of the backbone quantization, their delta-encoded normalization weights are folded into mlx-serve's convention, and an embedded head keeps precedence.
   Qwen3.8 MoE targets require `--mtp` at launch or `"enable_mtp": true` on the request.
 - **DFlash draft companions** — a model folder can ship its own `drafter/` block-draft companion (the Muse-Glimmer builds do); the server loads it with the model, switching models keeps the speedup, and the draft size adapts to the Mac. About 2x on Muse-Glimmer. `--no-drafter` turns it off.
 - **PLD** (Prompt Lookup Decoding) — model-agnostic n-gram match in `prompt + generated_tokens`. Default-on, no per-model setup. Wins on agent loops, RAG and code editing, anywhere the answer echoes the prompt.

--- a/src/model.zig
+++ b/src/model.zig
@@ -3506,6 +3506,7 @@ fn loadWeightsFromOpenDir(io: std.Io, allocator: std.mem.Allocator, dir: std.Io.
             s,
             false,
             "language_model.mtp",
+            true,
         );
     }
 
@@ -3593,7 +3594,28 @@ pub fn loadSafetensorsFile(
     s: mlx.mlx_stream,
     load_vision: bool,
 ) !void {
-    return loadSafetensorsFileWithPrefix(allocator, weights, path, s, load_vision, null);
+    return loadSafetensorsFileWithPrefix(allocator, weights, path, s, load_vision, null, false);
+}
+
+fn qwen4MtpNormNeedsFold(key: []const u8) bool {
+    return std.mem.indexOf(u8, key, "norm") != null and std.mem.endsWith(u8, key, ".weight");
+}
+
+fn foldQwen4MtpNormPlusOne(arr: mlx.mlx_array, s: mlx.mlx_stream) !mlx.mlx_array {
+    const dtype = mlx.mlx_array_dtype(arr);
+    var float_arr = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(float_arr);
+    try mlx.check(mlx.mlx_astype(&float_arr, arr, .float32, s));
+    const one = mlx.mlx_array_new_float(1.0);
+    defer _ = mlx.mlx_array_free(one);
+    var sum = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(sum);
+    try mlx.check(mlx.mlx_add(&sum, float_arr, one, s));
+    var out = mlx.mlx_array_new();
+    errdefer _ = mlx.mlx_array_free(out);
+    try mlx.check(mlx.mlx_astype(&out, sum, dtype, s));
+    try mlx.check(mlx.mlx_array_eval(out));
+    return out;
 }
 
 fn loadSafetensorsFileWithPrefix(
@@ -3603,6 +3625,7 @@ fn loadSafetensorsFileWithPrefix(
     s: mlx.mlx_stream,
     load_vision: bool,
     key_prefix: ?[]const u8,
+    fold_qwen4_mtp_norms: bool,
 ) !void {
     var tensor_map = mlx.mlx_map_string_to_array_new();
     defer _ = mlx.mlx_map_string_to_array_free(tensor_map);
@@ -3644,6 +3667,14 @@ fn loadSafetensorsFileWithPrefix(
             _ = mlx.mlx_array_free(value);
             final_value = cast;
             if (ndim == 1) narrowed_1d += 1;
+        }
+        if (fold_qwen4_mtp_norms and qwen4MtpNormNeedsFold(key_str)) {
+            const folded = foldQwen4MtpNormPlusOne(final_value, s) catch |err| {
+                _ = mlx.mlx_array_free(final_value);
+                return err;
+            };
+            _ = mlx.mlx_array_free(final_value);
+            final_value = folded;
         }
 
         const mapped_key_owned = if (key_prefix) |prefix|
@@ -3761,8 +3792,9 @@ test "loadWeights maps a standalone Qwen4 MTP sidecar when the checkpoint has no
 
     const mtp_hdr =
         "{\"fc_hidden.weight\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,8]}," ++
-        "\"layers.0.self_attn.q_proj.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[8,12]}}";
-    var mtp_st: [8 + mtp_hdr.len + 12]u8 = undefined;
+        "\"layers.0.self_attn.q_proj.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[8,12]}," ++
+        "\"pre_fc_norm_hidden.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[12,16]}}";
+    var mtp_st: [8 + mtp_hdr.len + 16]u8 = undefined;
     std.mem.writeInt(u64, mtp_st[0..8], mtp_hdr.len, .little);
     @memcpy(mtp_st[8 .. 8 + mtp_hdr.len], mtp_hdr);
     @memset(mtp_st[8 + mtp_hdr.len ..], 0);
@@ -3773,13 +3805,18 @@ test "loadWeights maps a standalone Qwen4 MTP sidecar when the checkpoint has no
     var weights = try loadWeightsFromOpenDir(io, allocator, tmp.dir, path_buf[0..path_len], false);
     defer weights.deinit();
 
-    try testing.expectEqual(@as(u32, 3), weights.count());
+    try testing.expectEqual(@as(u32, 4), weights.count());
     try testing.expectEqual(
         @as(usize, 2),
         mlx.mlx_array_size(weights.get("language_model.mtp.fc_hidden.weight").?),
     );
     try testing.expect(weights.get("language_model.mtp.layers.0.self_attn.q_proj.weight") != null);
     try testing.expect(weights.get("fc_hidden.weight") == null);
+    const norm = weights.get("language_model.mtp.pre_fc_norm_hidden.weight").?;
+    try mlx.check(mlx.mlx_array_eval(norm));
+    var norm_value: f32 = 0;
+    try mlx.check(mlx.mlx_array_item_float32(&norm_value, norm));
+    try testing.expectApproxEqAbs(@as(f32, 1), norm_value, 0.0001);
 }
 
 test "loadWeights preserves an embedded Qwen4 MTP head over a standalone sidecar" {

--- a/src/model.zig
+++ b/src/model.zig
@@ -3377,25 +3377,6 @@ fn hasWeightsUnder(weights: *const Weights, prefix: []const u8) bool {
     return false;
 }
 
-fn removeWeightsUnder(weights: *Weights, prefix: []const u8) !u32 {
-    var keys: std.ArrayList([]const u8) = .empty;
-    defer keys.deinit(weights.allocator);
-    var it = weights.map.keyIterator();
-    while (it.next()) |key_ptr| {
-        const key = key_ptr.*;
-        if (key.len > prefix.len and key[prefix.len] == '.' and std.mem.startsWith(u8, key, prefix)) {
-            try keys.append(weights.allocator, key);
-        }
-    }
-    for (keys.items) |key| {
-        if (weights.map.fetchRemove(key)) |entry| {
-            _ = mlx.mlx_array_free(entry.value);
-            weights.allocator.free(entry.key);
-        }
-    }
-    return @intCast(keys.items.len);
-}
-
 /// Re-point `config.weight_prefix` at the nesting the CHECKPOINT actually uses.
 ///
 /// Which of the two a converter emits is not reliably declared in config.json,
@@ -3509,14 +3490,15 @@ fn loadWeightsFromOpenDir(io: std.Io, allocator: std.mem.Allocator, dir: std.Io.
     }
 
     const qwen4_mtp_path = "mtp/model.safetensors";
-    if (safetensorsHeaderHasQwen4Mtp(io, allocator, dir, qwen4_mtp_path)) {
+    if (weights.get("language_model.mtp.fc_hidden.weight") == null and
+        safetensorsHeaderHasQwen4Mtp(io, allocator, dir, qwen4_mtp_path))
+    {
         const path_slice = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ model_dir, qwen4_mtp_path });
         defer allocator.free(path_slice);
         const path = try allocator.dupeSentinel(u8, path_slice, 0);
         defer allocator.free(path);
 
-        const replaced = try removeWeightsUnder(&weights, "language_model.mtp");
-        log.info("Loading standalone Qwen4 MTP sidecar {s} (replacing {d} embedded tensors)...\n", .{ qwen4_mtp_path, replaced });
+        log.info("Loading standalone Qwen4 MTP sidecar {s}...\n", .{qwen4_mtp_path});
         try loadSafetensorsFileWithPrefix(
             allocator,
             &weights,
@@ -3762,7 +3744,45 @@ test "ModelConfig defaults" {
     try testing.expect(!config.tie_word_embeddings);
 }
 
-test "loadWeights maps a standalone Qwen4 MTP sidecar and gives it precedence" {
+test "loadWeights maps a standalone Qwen4 MTP sidecar when the checkpoint has no head" {
+    const io = std.testing.io;
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "mtp");
+
+    const main_hdr =
+        "{\"model.keep.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[0,4]}}";
+    var main_st: [8 + main_hdr.len + 4]u8 = undefined;
+    std.mem.writeInt(u64, main_st[0..8], main_hdr.len, .little);
+    @memcpy(main_st[8 .. 8 + main_hdr.len], main_hdr);
+    @memset(main_st[8 + main_hdr.len ..], 0);
+    try tmp.dir.writeFile(io, .{ .sub_path = "model.safetensors", .data = &main_st });
+
+    const mtp_hdr =
+        "{\"fc_hidden.weight\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,8]}," ++
+        "\"layers.0.self_attn.q_proj.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[8,12]}}";
+    var mtp_st: [8 + mtp_hdr.len + 12]u8 = undefined;
+    std.mem.writeInt(u64, mtp_st[0..8], mtp_hdr.len, .little);
+    @memcpy(mtp_st[8 .. 8 + mtp_hdr.len], mtp_hdr);
+    @memset(mtp_st[8 + mtp_hdr.len ..], 0);
+    try tmp.dir.writeFile(io, .{ .sub_path = "mtp/model.safetensors", .data = &mtp_st });
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path_len = try tmp.dir.realPath(io, &path_buf);
+    var weights = try loadWeightsFromOpenDir(io, allocator, tmp.dir, path_buf[0..path_len], false);
+    defer weights.deinit();
+
+    try testing.expectEqual(@as(u32, 3), weights.count());
+    try testing.expectEqual(
+        @as(usize, 2),
+        mlx.mlx_array_size(weights.get("language_model.mtp.fc_hidden.weight").?),
+    );
+    try testing.expect(weights.get("language_model.mtp.layers.0.self_attn.q_proj.weight") != null);
+    try testing.expect(weights.get("fc_hidden.weight") == null);
+}
+
+test "loadWeights preserves an embedded Qwen4 MTP head over a standalone sidecar" {
     const io = std.testing.io;
     const allocator = std.testing.allocator;
     var tmp = std.testing.tmpDir(.{ .iterate = true });
@@ -3795,12 +3815,11 @@ test "loadWeights maps a standalone Qwen4 MTP sidecar and gives it precedence" {
 
     try testing.expectEqual(@as(u32, 3), weights.count());
     try testing.expectEqual(
-        @as(usize, 2),
+        @as(usize, 1),
         mlx.mlx_array_size(weights.get("language_model.mtp.fc_hidden.weight").?),
     );
-    try testing.expect(weights.get("language_model.mtp.layers.0.self_attn.q_proj.weight") != null);
-    try testing.expect(weights.get("language_model.mtp.fc_hidden.scales") == null);
-    try testing.expect(weights.get("fc_hidden.weight") == null);
+    try testing.expect(weights.get("language_model.mtp.fc_hidden.scales") != null);
+    try testing.expect(weights.get("language_model.mtp.layers.0.self_attn.q_proj.weight") == null);
 }
 
 test "loadWeights ignores an unrelated file at the Qwen4 MTP sidecar path" {

--- a/src/model.zig
+++ b/src/model.zig
@@ -3377,6 +3377,25 @@ fn hasWeightsUnder(weights: *const Weights, prefix: []const u8) bool {
     return false;
 }
 
+fn removeWeightsUnder(weights: *Weights, prefix: []const u8) !u32 {
+    var keys: std.ArrayList([]const u8) = .empty;
+    defer keys.deinit(weights.allocator);
+    var it = weights.map.keyIterator();
+    while (it.next()) |key_ptr| {
+        const key = key_ptr.*;
+        if (key.len > prefix.len and key[prefix.len] == '.' and std.mem.startsWith(u8, key, prefix)) {
+            try keys.append(weights.allocator, key);
+        }
+    }
+    for (keys.items) |key| {
+        if (weights.map.fetchRemove(key)) |entry| {
+            _ = mlx.mlx_array_free(entry.value);
+            weights.allocator.free(entry.key);
+        }
+    }
+    return @intCast(keys.items.len);
+}
+
 /// Re-point `config.weight_prefix` at the nesting the CHECKPOINT actually uses.
 ///
 /// Which of the two a converter emits is not reliably declared in config.json,
@@ -3489,6 +3508,25 @@ fn loadWeightsFromOpenDir(io: std.Io, allocator: std.mem.Allocator, dir: std.Io.
         file_count += 1;
     }
 
+    const qwen4_mtp_path = "mtp/model.safetensors";
+    if (safetensorsHeaderHasQwen4Mtp(io, allocator, dir, qwen4_mtp_path)) {
+        const path_slice = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ model_dir, qwen4_mtp_path });
+        defer allocator.free(path_slice);
+        const path = try allocator.dupeSentinel(u8, path_slice, 0);
+        defer allocator.free(path);
+
+        const replaced = try removeWeightsUnder(&weights, "language_model.mtp");
+        log.info("Loading standalone Qwen4 MTP sidecar {s} (replacing {d} embedded tensors)...\n", .{ qwen4_mtp_path, replaced });
+        try loadSafetensorsFileWithPrefix(
+            allocator,
+            &weights,
+            path,
+            s,
+            false,
+            "language_model.mtp",
+        );
+    }
+
     // Incomplete-checkpoint guard. A dir with config/tokenizer but no (or no
     // usable) *.safetensors is the classic interrupted-download shape: the
     // small files land first, the multi-GB weight shards never finalize. Before
@@ -3573,6 +3611,17 @@ pub fn loadSafetensorsFile(
     s: mlx.mlx_stream,
     load_vision: bool,
 ) !void {
+    return loadSafetensorsFileWithPrefix(allocator, weights, path, s, load_vision, null);
+}
+
+fn loadSafetensorsFileWithPrefix(
+    allocator: std.mem.Allocator,
+    weights: *Weights,
+    path: [*:0]const u8,
+    s: mlx.mlx_stream,
+    load_vision: bool,
+    key_prefix: ?[]const u8,
+) !void {
     var tensor_map = mlx.mlx_map_string_to_array_new();
     defer _ = mlx.mlx_map_string_to_array_free(tensor_map);
 
@@ -3615,9 +3664,44 @@ pub fn loadSafetensorsFile(
             if (ndim == 1) narrowed_1d += 1;
         }
 
-        const owned_key = try allocator.dupe(u8, key_str);
-        try weights.map.put(owned_key, final_value);
+        const mapped_key_owned = if (key_prefix) |prefix|
+            try std.fmt.allocPrint(allocator, "{s}.{s}", .{ prefix, key_str })
+        else
+            null;
+        defer if (mapped_key_owned) |mapped| allocator.free(mapped);
+        const mapped_key = mapped_key_owned orelse key_str;
+
+        if (weights.map.getPtr(mapped_key)) |old_value| {
+            _ = mlx.mlx_array_free(old_value.*);
+            old_value.* = final_value;
+        } else {
+            const owned_key = try allocator.dupe(u8, mapped_key);
+            weights.map.put(owned_key, final_value) catch |err| {
+                allocator.free(owned_key);
+                _ = mlx.mlx_array_free(final_value);
+                return err;
+            };
+        }
     }
+}
+
+fn safetensorsHeaderHasQwen4Mtp(
+    io: std.Io,
+    allocator: std.mem.Allocator,
+    dir: std.Io.Dir,
+    sub_path: []const u8,
+) bool {
+    const f = dir.openFile(io, sub_path, .{}) catch return false;
+    defer f.close(io);
+    var read_buf: [8192]u8 = undefined;
+    var reader = f.reader(io, &read_buf);
+    const header_len = reader.interface.takeInt(u64, .little) catch return false;
+    if (header_len == 0 or header_len > 16 * 1024 * 1024) return false;
+    const header = allocator.alloc(u8, @intCast(header_len)) catch return false;
+    defer allocator.free(header);
+    reader.interface.readSliceAll(header) catch return false;
+    return std.mem.indexOf(u8, header, "\"fc_hidden.weight\"") != null and
+        std.mem.indexOf(u8, header, "\"layers.0.self_attn.q_proj.weight\"") != null;
 }
 
 /// True if the safetensors weight `key` should be retained for the text
@@ -3676,6 +3760,78 @@ test "ModelConfig defaults" {
     try testing.expectEqual(@as(u32, 0), config.quant_bits); // 0 = dense bf16 (no "quantization" key)
     try testing.expectEqual(@as(u32, 64), config.quant_group_size);
     try testing.expect(!config.tie_word_embeddings);
+}
+
+test "loadWeights maps a standalone Qwen4 MTP sidecar and gives it precedence" {
+    const io = std.testing.io;
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "mtp");
+
+    const main_hdr =
+        "{\"model.keep.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[0,4]}," ++
+        "\"language_model.mtp.fc_hidden.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[4,8]}," ++
+        "\"language_model.mtp.fc_hidden.scales\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[8,12]}}";
+    var main_st: [8 + main_hdr.len + 12]u8 = undefined;
+    std.mem.writeInt(u64, main_st[0..8], main_hdr.len, .little);
+    @memcpy(main_st[8 .. 8 + main_hdr.len], main_hdr);
+    @memset(main_st[8 + main_hdr.len ..], 0);
+    try tmp.dir.writeFile(io, .{ .sub_path = "model.safetensors", .data = &main_st });
+
+    const mtp_hdr =
+        "{\"fc_hidden.weight\":{\"dtype\":\"F32\",\"shape\":[2],\"data_offsets\":[0,8]}," ++
+        "\"layers.0.self_attn.q_proj.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[8,12]}}";
+    var mtp_st: [8 + mtp_hdr.len + 12]u8 = undefined;
+    std.mem.writeInt(u64, mtp_st[0..8], mtp_hdr.len, .little);
+    @memcpy(mtp_st[8 .. 8 + mtp_hdr.len], mtp_hdr);
+    @memset(mtp_st[8 + mtp_hdr.len ..], 0);
+    try tmp.dir.writeFile(io, .{ .sub_path = "mtp/model.safetensors", .data = &mtp_st });
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path_len = try tmp.dir.realPath(io, &path_buf);
+    var weights = try loadWeightsFromOpenDir(io, allocator, tmp.dir, path_buf[0..path_len], false);
+    defer weights.deinit();
+
+    try testing.expectEqual(@as(u32, 3), weights.count());
+    try testing.expectEqual(
+        @as(usize, 2),
+        mlx.mlx_array_size(weights.get("language_model.mtp.fc_hidden.weight").?),
+    );
+    try testing.expect(weights.get("language_model.mtp.layers.0.self_attn.q_proj.weight") != null);
+    try testing.expect(weights.get("language_model.mtp.fc_hidden.scales") == null);
+    try testing.expect(weights.get("fc_hidden.weight") == null);
+}
+
+test "loadWeights ignores an unrelated file at the Qwen4 MTP sidecar path" {
+    const io = std.testing.io;
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    try tmp.dir.createDirPath(io, "mtp");
+
+    const main_hdr = "{\"model.keep.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[0,4]}}";
+    var main_st: [8 + main_hdr.len + 4]u8 = undefined;
+    std.mem.writeInt(u64, main_st[0..8], main_hdr.len, .little);
+    @memcpy(main_st[8 .. 8 + main_hdr.len], main_hdr);
+    @memset(main_st[8 + main_hdr.len ..], 0);
+    try tmp.dir.writeFile(io, .{ .sub_path = "model.safetensors", .data = &main_st });
+
+    const unrelated_hdr = "{\"not_mtp.weight\":{\"dtype\":\"F32\",\"shape\":[1],\"data_offsets\":[0,4]}}";
+    var unrelated_st: [8 + unrelated_hdr.len + 4]u8 = undefined;
+    std.mem.writeInt(u64, unrelated_st[0..8], unrelated_hdr.len, .little);
+    @memcpy(unrelated_st[8 .. 8 + unrelated_hdr.len], unrelated_hdr);
+    @memset(unrelated_st[8 + unrelated_hdr.len ..], 0);
+    try tmp.dir.writeFile(io, .{ .sub_path = "mtp/model.safetensors", .data = &unrelated_st });
+
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path_len = try tmp.dir.realPath(io, &path_buf);
+    var weights = try loadWeightsFromOpenDir(io, allocator, tmp.dir, path_buf[0..path_len], false);
+    defer weights.deinit();
+
+    try testing.expectEqual(@as(u32, 1), weights.count());
+    try testing.expect(weights.get("model.keep.weight") != null);
+    try testing.expect(weights.get("language_model.mtp.not_mtp.weight") == null);
 }
 
 test "loadWeights casts f16 quant scales/biases to bf16 (mixed-dtype qmm slow-path class)" {

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -12480,15 +12480,39 @@ pub const Transformer = struct {
     }
 
     /// Load the qwen4_exp MTP head when the pack ships `mtp.*` (null otherwise).
-    fn loadQwen4Mtp(allocator: std.mem.Allocator, config: ModelConfig, weights: *const Weights, name_buf: *[256]u8, s: mlx.mlx_stream) !?Qwen4Mtp {
-        const mtp_prefix = "language_model.mtp";
-        if (weights.get(mtp_prefix ++ ".fc_hidden.weight") == null) return null;
+    fn qwen4MtpLayerConfig(config: ModelConfig, has_quant_scales: bool) ModelConfig {
         var mcfg = config;
-        mcfg.weight_prefix = mtp_prefix;
+        mcfg.weight_prefix = "language_model.mtp";
         mcfg.num_hidden_layers = 1;
         mcfg.full_attention_interval = 1; // layer 0 is the full-attention layer
         mcfg.linear_attn_tail_from = 0;
         mcfg.ple_layer_idx = -1;
+        // A standalone BF16 head has no quantization metadata of its own.
+        // Do not inherit the backbone's quantization contract and demand
+        // nonexistent `.scales`/`.biases` tensors from that dense sidecar.
+        if (!has_quant_scales) mcfg.quant_bits = 0;
+        return mcfg;
+    }
+
+    test "Qwen4 dense MTP sidecar does not inherit backbone quantization" {
+        const trunk = ModelConfig{ .quant_bits = 4, .quant_group_size = 64 };
+
+        const dense = qwen4MtpLayerConfig(trunk, false);
+        try std.testing.expectEqual(@as(u32, 0), dense.quant_bits);
+        try std.testing.expectEqualStrings("language_model.mtp", dense.weight_prefix);
+        try std.testing.expectEqual(@as(u32, 1), dense.num_hidden_layers);
+
+        const quantized = qwen4MtpLayerConfig(trunk, true);
+        try std.testing.expectEqual(@as(u32, 4), quantized.quant_bits);
+        try std.testing.expectEqual(@as(u32, 64), quantized.quant_group_size);
+    }
+
+    fn loadQwen4Mtp(allocator: std.mem.Allocator, config: ModelConfig, weights: *const Weights, name_buf: *[256]u8, s: mlx.mlx_stream) !?Qwen4Mtp {
+        const mtp_prefix = "language_model.mtp";
+        if (weights.get(mtp_prefix ++ ".fc_hidden.weight") == null) return null;
+        const has_quant_scales = weights.get(mtp_prefix ++ ".fc_hidden.scales") != null;
+        const mcfg = qwen4MtpLayerConfig(config, has_quant_scales);
+        if (!has_quant_scales) log.info("[qwen4] standalone MTP head is dense; ignoring backbone quantization metadata\n", .{});
         const ml = try initMoeLayers(allocator, mcfg, weights, name_buf, s);
         var owned: std.ArrayList(mlx.mlx_array) = .empty;
         errdefer owned.deinit(allocator);


### PR DESCRIPTION
## Summary

- discover standalone Qwen4 MTP weights at `mtp/model.safetensors`
- map the checkpoint's unprefixed tensors into `language_model.mtp.*`
- use the standalone head only when the target has no embedded MTP head
- load a dense BF16 sidecar independently of a quantized backbone's metadata
- fold the sidecar's delta-encoded normalization weights into mlx-serve's runtime convention
- document the sidecar path and Qwen3.8 MoE opt-in

## Tests

- `zig build test -Dtest-filter=standalone`
- `zig build test -Dtest-filter=unrelated`
- `zig build test -Dtest-filter=Qwen4`

- Full `zig build test --summary all`: 9/9 steps succeeded
- Signed FAST_DEV app bundle built with the ReleaseFast server
- Live REAP-288 validation: model `ready`, `mtp_loaded: true`, 24 draft rounds, 40 accepted tokens, 1.67 accepted per round

Closes #338
