### PR TITLE
perf(qwen4): MTP/QSA history rollback without copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **A prefix-cache hit no longer leaves Flash Next's draft head guessing.** The head's own history is saved with the cached prefix and restored with it.
 - **A partly-accepted speculative round is cheaper on Flash Next.** When verification keeps only some of the drafted tokens, the sparse-attention key history for the tokens that survived is now re-used where it already sits instead of being copied out and re-seeded on the next token. The saving grows with the conversation length, and the generated text is byte-identical.
 - **Flash Next's sparse-attention block scores are extended, not rebuilt.** Every four decoded tokens the model used to re-transpose and re-convert its whole block-score table; it now writes only the new columns into a table sized once for the request. The scores are byte-identical, and the saving grows with the conversation.
+- **Speculative drafting on Flash Next stopped re-deriving position tables it already had.** The draft head builds a fresh context per draft step, which made the sparse-attention rope tables miss their cache on every step and left the head's own key history without the space the trunk had reserved for it. The tables are now keyed on what they actually depend on, and are dropped when the conversation they belong to ends.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **A cached conversation survives on SSD instead of being rebuilt, on Flash Next.** With `--prefix-cache-disk`, memory keeps the model plus the active conversation and every other conversation lives on disk, written in the background as the prompt is processed; a disk hit streams back in seconds against minutes of re-prefill. On that model `--prefix-cache-mem` is now the allowance for conversations other than the one being served (`0` keeps none idle).
 - **Speculative decoding on Flash Next switches itself off where a plain step is faster, and back on when it is not.** Past some conversation length a speculative round costs more than the steps it replaces; the switch compares two measured prices per context bucket and only acts when both agree. `--max-mtp-ctx <n>` keeps speculation off past a context length you choose.
 - **A prefix-cache hit no longer leaves Flash Next's draft head guessing.** The head's own history is saved with the cached prefix and restored with it.
+- **A partly-accepted speculative round is cheaper on Flash Next.** When verification keeps only some of the drafted tokens, the sparse-attention key history for the tokens that survived is now re-used where it already sits instead of being copied out and re-seeded on the next token. The saving grows with the conversation length, and the generated text is byte-identical.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Speculative decoding on Flash Next switches itself off where a plain step is faster, and back on when it is not.** Past some conversation length a speculative round costs more than the steps it replaces; the switch compares two measured prices per context bucket and only acts when both agree. `--max-mtp-ctx <n>` keeps speculation off past a context length you choose.
 - **A prefix-cache hit no longer leaves Flash Next's draft head guessing.** The head's own history is saved with the cached prefix and restored with it.
 - **A partly-accepted speculative round is cheaper on Flash Next.** When verification keeps only some of the drafted tokens, the sparse-attention key history for the tokens that survived is now re-used where it already sits instead of being copied out and re-seeded on the next token. The saving grows with the conversation length, and the generated text is byte-identical.
+- **Flash Next's sparse-attention block scores are extended, not rebuilt.** Every four decoded tokens the model used to re-transpose and re-convert its whole block-score table; it now writes only the new columns into a table sized once for the request. The scores are byte-identical, and the saving grows with the conversation.
 
 ### Fixes
 

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -2233,7 +2233,11 @@ pub const Generator = struct {
             );
             ctx.cache.reserve(@intCast(reserved_tokens));
             // The arch's own per-request buffers reserve at the same length.
-            transformer_mod.reserveQsaHistory(ctx.ssm_entries, @intCast(reserved_tokens));
+            transformer_mod.reserveQsaHistoryWithHead(
+                ctx.ssm_entries,
+                if (xfm.qwen4_mtp) |*m| &m.entry else null,
+                @intCast(reserved_tokens),
+            );
 
             var pos: usize = 0;
             while (pos < loop_end) {
@@ -2959,6 +2963,7 @@ pub const Generator = struct {
             self.prompt_ids_owned = &.{};
             self.prompt_ids_alloc = null;
         }
+        self.xfm.markQsaPooledRopeStale();
         if (self.mtp_cache) |*mc| {
             mc.deinit();
             self.mtp_cache = null;

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -1196,6 +1196,8 @@ pub const Generator = struct {
     mtp_drafted_tokens: u64 = 0,
     /// Rounds where the confidence gate extended into chunk B.
     mtp_ext_rounds: u64 = 0,
+    /// Speculative rounds that rolled recurrent state back on a partial accept.
+    partial_rounds: u64 = 0,
     /// Extension dry-spell gate: consecutive extension-CONSIDERED rounds
     /// whose confidence gate did not clear, and the single-chunk cooldown
     /// that a full dry streak triggers (see mtpExtDryAllows).
@@ -1540,7 +1542,7 @@ pub const Generator = struct {
             else
                 0.0;
             log.info(
-                "  [spec-stats] mode=mtp attempts={d} accepts={d} avg_per_round={d:.2} per_draft_pct={d:.1}% depth={d} drafted={d} ext_rounds={d} runtime_disabled={s} reason={s} adaptive={s} serial_cell={d:.2} sync_ms={d:.2} round_ms={d:.2} two_ms_tok={d:.2} one_ms_tok={d:.2} verdict_round={d} trials={d} width_trials={d} table={s}:{s} table_drops=t{d}/c{d}/b{d} serial_drops=t{d}/c{d}/b{d}\n",
+                "  [spec-stats] mode=mtp attempts={d} accepts={d} avg_per_round={d:.2} per_draft_pct={d:.1}% depth={d} drafted={d} ext_rounds={d} partial_rounds={d} runtime_disabled={s} reason={s} adaptive={s} serial_cell={d:.2} sync_ms={d:.2} round_ms={d:.2} two_ms_tok={d:.2} one_ms_tok={d:.2} verdict_round={d} trials={d} width_trials={d} table={s}:{s} table_drops=t{d}/c{d}/b{d} serial_drops=t{d}/c{d}/b{d}\n",
                 .{
                     self.mtp_attempted,
                     self.mtp_accepted_tokens,
@@ -1549,6 +1551,7 @@ pub const Generator = struct {
                     self.mtp_depth,
                     self.mtp_drafted_tokens,
                     self.mtp_ext_rounds,
+                    self.partial_rounds,
                     if (self.spec_disabled_runtime) "true" else "false",
                     @tagName(self.spec_disable_reason),
                     @tagName(self.mtp_adaptive.arm),
@@ -1585,7 +1588,7 @@ pub const Generator = struct {
             else
                 0.0;
             log.info(
-                "  [spec-stats] mode=dflash attempts={d} accepts={d} avg_per_round={d:.2} gate_min={d:.2} per_draft_pct={d:.1}% block_size={d} runtime_disabled={s} table={s}:{s} table_drops=t{d}/c{d}/b{d} block_avg={d:.2} block_hist={s} chooser_trials={d}\n",
+                "  [spec-stats] mode=dflash attempts={d} accepts={d} avg_per_round={d:.2} gate_min={d:.2} per_draft_pct={d:.1}% block_size={d} partial_rounds={d} runtime_disabled={s} table={s}:{s} table_drops=t{d}/c{d}/b{d} block_avg={d:.2} block_hist={s} chooser_trials={d}\n",
                 .{
                     self.dflash_attempted,
                     self.dflash_accepted_tokens,
@@ -1593,6 +1596,7 @@ pub const Generator = struct {
                     self.dflash_min_accepted_per_round,
                     per_draft_pct,
                     if (self.dflash_chooser) |ch| ch.current + 1 else self.dflash_block_size,
+                    self.partial_rounds,
                     if (self.spec_disabled_runtime) "true" else "false",
                     round_cost.bucketName(self.xfm.round_cost.layout, table_bucket),
                     self.xfm.round_cost.formatBucket(table_bucket, &table_buf),
@@ -3683,6 +3687,7 @@ pub const Generator = struct {
                 const step_keep = kv_snap.step;
                 try self.ctx.cache.truncate(moe_seq_offset_snap + accepted_len, s);
                 self.ctx.cache.step = step_keep;
+                self.partial_rounds += 1;
                 for (self.ctx.ssm_entries.?) |*entry| {
                     try transformer_mod.ssmRollbackFromCapture(entry, accepted, 1 + m, s);
                 }
@@ -4676,6 +4681,7 @@ pub const Generator = struct {
                 if (self.ctx.ssm_entries) |entries| {
                     const gdn_captured = entries.len > 0 and entries[0].spec_state_seq.ctx != null;
                     if (!gdn_captured) return error.SpecRollbackUnavailable;
+                    self.partial_rounds += 1;
                     for (entries) |*entry| {
                         try transformer_mod.ssmRollbackFromCapture(entry, accepted, 1 + m, s);
                     }

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -744,6 +744,7 @@ pub const Slot = struct {
             self.allocator.destroy(runner);
             self.diffusion = null;
         }
+        if (self.model.transformer) |xfm| xfm.markQsaPooledRopeStale();
         if (self.legacy_gen) |*gen| {
             gen.deinit(self.allocator);
         }
@@ -4199,6 +4200,7 @@ fn inferenceLoop(ctx: ThreadCtx) void {
             // Second slot-end path (a decode-phase cancel never reaches finishSlot); the
             // record must not outlive the bytes `s.deinit()` frees.
             if (s.model.prefix_cache) |*hc| hc.releaseCheckout(@intFromPtr(s), "slot cleanup");
+            if (s.model.transformer) |xfm| xfm.resetQsaPooledRope();
             s.deinit();
         }
         if (vision_n > 0 or embed_n > 0) {
@@ -6633,6 +6635,34 @@ test "Generator.initWithOptions hands off checkpoints on cancel" {
     const region = source[anchor..@min(anchor + 2400, source.len)];
     try testing.expect(std.mem.indexOf(u8, region, "cancelled_checkpoint_sink") != null);
     try testing.expect(std.mem.indexOf(u8, region, "error.Cancelled") != null);
+}
+
+test "Slot.deinit does not free the pooled-rope cache (conn-thread complete/submit)" {
+    const source = @embedFile("scheduler.zig");
+    const d_start = std.mem.indexOf(u8, source, "pub fn deinit(self: *Slot)") orelse return error.MissingSlotDeinit;
+    const d_end = std.mem.indexOfPos(u8, source, d_start + 1, "pub fn deinit(self: *Scheduler)") orelse return error.MissingSchedulerDeinit;
+    const body = source[d_start..d_end];
+    if (std.mem.indexOf(u8, body, "resetQsaPooledRope") != null) return error.SlotDeinitFreesPooledRope;
+    if (std.mem.indexOf(u8, body, "mlx_array_free") != null and std.mem.indexOf(u8, body, "qsa_pooled_rope") != null)
+        return error.SlotDeinitFreesPooledRope;
+    const mark_at = std.mem.indexOf(u8, body, "markQsaPooledRopeStale") orelse return error.MissingPooledRopeStale;
+    const gen_at = std.mem.indexOf(u8, body, "legacy_gen") orelse return error.MissingLegacyGen;
+    const mp_at = std.mem.indexOf(u8, body, "mrope_pos") orelse return error.MissingMropeFree;
+    try testing.expect(mark_at < gen_at);
+    try testing.expect(mark_at < mp_at);
+
+    const drain_start = std.mem.indexOf(u8, source, "for (cleanup_batch[0..cleanup_n])") orelse return error.MissingCleanupDrain;
+    const drain = source[drain_start..@min(drain_start + 1600, source.len)];
+    const reset_at = std.mem.indexOf(u8, drain, "resetQsaPooledRope") orelse return error.DrainDoesNotResetPooledRope;
+    const deinit_at = std.mem.indexOf(u8, drain, "s.deinit();") orelse return error.MissingDeinit;
+    try testing.expect(reset_at < deinit_at);
+
+    const gen_src = @embedFile("generate.zig");
+    const g_start = std.mem.indexOf(u8, gen_src, "pub fn deinit(self: *Generator") orelse return error.MissingGenDeinit;
+    const g_end = std.mem.indexOfPos(u8, gen_src, g_start + 1, "\n    pub fn ") orelse return error.MissingGenDeinitEnd;
+    const g_body = gen_src[g_start..g_end];
+    if (std.mem.indexOf(u8, g_body, "resetQsaPooledRope") != null) return error.SlotDeinitFreesPooledRope;
+    _ = std.mem.indexOf(u8, g_body, "markQsaPooledRopeStale") orelse return error.MissingPooledRopeStale;
 }
 
 test "Slot.deinit frees unconsumed cancelled-prefill salvage" {

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -6546,6 +6546,11 @@ pub fn reserveQsaHistory(entries: ?[]SSMCacheEntry, tokens: usize) void {
     }
 }
 
+pub fn reserveQsaHistoryWithHead(entries: ?[]SSMCacheEntry, head: ?*SSMCacheEntry, tokens: usize) void {
+    reserveQsaHistory(entries, tokens);
+    if (head) |h| reserveQsaHistory(h[0..1], tokens);
+}
+
 /// Append `chunk` into a pre-grown capacity buffer along `axis` and republish `view` as the
 /// tight `count`-long prefix. The published view is dropped first: while it lives mlx copies
 /// the buffer instead of donating it.
@@ -8778,10 +8783,14 @@ const QsaPooledRope = struct {
     n: c_int = 0,
     dtype: mlx.mlx_dtype = .float32,
     mrope: bool = false,
+    mrope_pos: ?[]const i32 = null,
+    mrope_total: usize = 0,
+    mrope_delta: i32 = 0,
     cos: mlx.mlx_array = .{ .ctx = null },
     sin: mlx.mlx_array = .{ .ctx = null },
     /// Rebuild counter.
     builds: usize = 0,
+    stale: std.atomic.Value(bool) = .init(false),
 
     fn deinit(self: *QsaPooledRope) void {
         if (self.cos.ctx != null) _ = mlx.mlx_array_free(self.cos);
@@ -8789,8 +8798,36 @@ const QsaPooledRope = struct {
         self.cos = .{ .ctx = null };
         self.sin = .{ .ctx = null };
         self.ctx = null;
+        self.mrope_pos = null;
+        self.stale.store(false, .monotonic);
     }
 };
+
+fn qsaPooledTableEq(a: ?[]const i32, b: ?[]const i32) bool {
+    const aa = a orelse return b == null;
+    const bb = b orelse return false;
+    return aa.ptr == bb.ptr and aa.len == bb.len;
+}
+
+test "markQsaPooledRopeStale is an atomic flag and does not write the cache key" {
+    const source = @embedFile("transformer.zig");
+    const struct_start = std.mem.indexOf(u8, source, "const QsaPooledRope = struct {") orelse return error.MissingStruct;
+    const struct_end = std.mem.indexOfPos(u8, source, struct_start + 1, "\nfn qsaPooledTableEq") orelse return error.MissingStructEnd;
+    const body = source[struct_start..struct_end];
+    if (std.mem.indexOf(u8, body, "stale: bool") != null) return error.StaleIsNotAtomic;
+    if (std.mem.indexOf(u8, body, "std.atomic.Value(bool)") == null) return error.StaleIsNotAtomic;
+
+    const mark_start = std.mem.indexOf(u8, source, "pub fn markQsa" ++ "PooledRopeStale") orelse return error.MissingMark;
+    const mark_end = std.mem.indexOfPos(u8, source, mark_start + 1, "\n    pub fn ") orelse return error.MissingMarkEnd;
+    const mark = source[mark_start..mark_end];
+    if (std.mem.indexOf(u8, mark, "mrope_pos") != null) return error.MarkWritesMropePos;
+    if (std.mem.indexOf(u8, mark, ".store(") == null) return error.MarkNotAtomic;
+
+    const q_start = std.mem.indexOf(u8, source, "fn qsaPooled" ++ "CosSin(") orelse return error.MissingQsaPooledCosSin;
+    const q_end = std.mem.indexOfPos(u8, source, q_start + 1, "\n    fn ") orelse return error.MissingQsaPooledCosSinEnd;
+    const q = source[q_start..q_end];
+    if (std.mem.indexOf(u8, q, ".load(.acquire)") == null) return error.ConsumeNotAcquire;
+}
 
 /// Does every complete-block visibility check pass for every query row of a call starting at
 /// cache position `offset`? Block `b` is complete at `p` iff `b*ratio + ratio - 1 <= p`, so
@@ -11399,6 +11436,14 @@ pub const Transformer = struct {
         _ = mlx.mlx_stream_free(self.s);
         // The free above is a no-op on the default stream's wrapper but we keep it for symmetry
         // with the Zig copy of the mlx_stream struct that init handed us.
+    }
+
+    pub fn resetQsaPooledRope(self: *Transformer) void {
+        self.qsa_pooled_rope.deinit();
+    }
+
+    pub fn markQsaPooledRopeStale(self: *Transformer) void {
+        self.qsa_pooled_rope.stale.store(true, .release);
     }
 
     /// Re-bind `self.s` to the *current* thread's default GPU stream. Must be called from any
@@ -15296,9 +15341,13 @@ pub const Transformer = struct {
     fn qsaPooledCosSin(self: *Transformer, ctx: *ForwardCtx, rope_dims: c_int, base: c_int, step: c_int, n: c_int, dt: mlx.mlx_dtype) !MropeCosSin {
         const is_mrope = ctx.mrope_pos != null;
         const c = &self.qsa_pooled_rope;
-        if (c.cos.ctx != null and c.gen == self.fwd_gen and c.ctx == ctx and
+        if (c.stale.load(.acquire)) c.deinit();
+        if (c.cos.ctx != null and
             c.base == base and c.step == step and c.n == n and
-            c.dtype == dt and c.mrope == is_mrope) return .{ .cos = c.cos, .sin = c.sin };
+            c.dtype == dt and c.mrope == is_mrope and
+            qsaPooledTableEq(c.mrope_pos, ctx.mrope_pos) and
+            c.mrope_total == ctx.mrope_total and c.mrope_delta == ctx.mrope_delta)
+            return .{ .cos = c.cos, .sin = c.sin };
         c.deinit();
         const cs = if (is_mrope)
             try self.mropeCosSinAt(mropeContext(ctx), @intCast(base), @intCast(step), @intCast(n), dt)
@@ -15313,6 +15362,9 @@ pub const Transformer = struct {
         c.n = n;
         c.dtype = dt;
         c.mrope = is_mrope;
+        c.mrope_pos = ctx.mrope_pos;
+        c.mrope_total = ctx.mrope_total;
+        c.mrope_delta = ctx.mrope_delta;
         c.builds += 1;
         return cs;
     }
@@ -45229,6 +45281,15 @@ test "qsa key append plan: rows advance by S, capacity grows only when it must" 
     try testing.expectEqual(@as(usize, 4596), p4.new_rows);
 }
 
+test "reserveQsaHistory: the MTP head entry is reserved at the same length" {
+    var slot = [_]SSMCacheEntry{.{ .ssm_state = .{ .ctx = null }, .conv_state = .{ .ctx = null }, .initialized = false }};
+    var head: SSMCacheEntry = .{ .ssm_state = .{ .ctx = null }, .conv_state = .{ .ctx = null }, .initialized = false };
+    const tokens: usize = 8192;
+    reserveQsaHistoryWithHead(slot[0..], &head, tokens);
+    try testing.expectEqual(tokens, slot[0].qsa_reserve_rows);
+    try testing.expectEqual(tokens, head.qsa_reserve_rows);
+}
+
 test "qsa history reservation: a reserved prefill allocates its buffers ONCE (#353 follow-up)" {
     // These buffers walked the +25% ladder beside a KV cache that had been sized once; the loop
     // below allocated ~30 times before `qsa_reserve_rows`.
@@ -45553,9 +45614,9 @@ test "qsa pooled rope: one cos/sin build per forward, not one per full-attention
     // A new forward rebuilds (the M-RoPE arm's position table is not in the key).
     t.fwd_gen += 1;
     _ = try t.qsaPooledCosSin(&ctx, rope_dims, base, step, n, .bfloat16);
-    try testing.expectEqual(@as(usize, 2), t.qsa_pooled_rope.builds);
+    try testing.expectEqual(@as(usize, 1), t.qsa_pooled_rope.builds);
     _ = try t.qsaPooledCosSin(&ctx, rope_dims, base + step, step, n, .bfloat16);
-    try testing.expectEqual(@as(usize, 3), t.qsa_pooled_rope.builds);
+    try testing.expectEqual(@as(usize, 2), t.qsa_pooled_rope.builds);
 
     // The M-RoPE arm is a different table at the same (base, step, n).
     const pos = try testing.allocator.alloc(i32, 3 * 256);
@@ -45564,14 +45625,227 @@ test "qsa pooled rope: one cos/sin build per forward, not one per full-attention
     ctx.mrope_pos = pos;
     ctx.mrope_total = 256;
     const m = try t.qsaPooledCosSin(&ctx, rope_dims, base + step, step, n, .bfloat16);
-    try testing.expectEqual(@as(usize, 4), t.qsa_pooled_rope.builds);
+    try testing.expectEqual(@as(usize, 3), t.qsa_pooled_rope.builds);
     const direct = try t.mropeCosSinAt(.{ .pos = pos, .total = 256, .delta = 0 }, @intCast(base + step), @intCast(step), @intCast(n), .bfloat16);
     defer _ = mlx.mlx_array_free(direct.cos);
     defer _ = mlx.mlx_array_free(direct.sin);
     try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(m.cos, direct.cos, s));
     try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(m.sin, direct.sin, s));
     for (0..11) |_| _ = try t.qsaPooledCosSin(&ctx, rope_dims, base + step, step, n, .bfloat16);
-    try testing.expectEqual(@as(usize, 4), t.qsa_pooled_rope.builds);
+    try testing.expectEqual(@as(usize, 3), t.qsa_pooled_rope.builds);
+}
+
+test "qsa pooled rope: the cache key is block position and the table, not the ForwardCtx pointer" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+
+    var t: Transformer = undefined;
+    t.s = s;
+    t.allocator = testing.allocator;
+    t.config = .{};
+    t.config.head_dim = 256;
+    t.config.partial_rotary_factor = 0.5;
+    t.config.rope_theta = 10_000_000.0;
+    t.config.mrope_section = .{ 11, 11, 10 };
+    t.rope_freqs_yarn = null;
+    t.yarn_inv_freq = null;
+    t.fwd_gen = 0;
+    t.qsa_pooled_rope = .{};
+    defer t.qsa_pooled_rope.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 1);
+    defer cache.deinit();
+    var seq_off: usize = 0;
+    var ctx_a: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &seq_off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+    var ctx_b: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &seq_off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+
+    const rope_dims: c_int = 128;
+    const base: c_int = 96;
+    const step: c_int = 4;
+    const n: c_int = 5;
+
+    const cs = try t.qsaPooledCosSin(&ctx_a, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 1), t.qsa_pooled_rope.builds);
+    t.fwd_gen += 1;
+    const again = try t.qsaPooledCosSin(&ctx_b, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 1), t.qsa_pooled_rope.builds);
+    try testing.expect(again.cos.ctx == cs.cos.ctx and again.sin.ctx == cs.sin.ctx);
+
+    const pos = try testing.allocator.alloc(i32, 3 * 256);
+    defer testing.allocator.free(pos);
+    for (pos, 0..) |*p, i| p.* = @intCast(i % 256);
+    ctx_b.mrope_pos = pos;
+    ctx_b.mrope_total = 256;
+    const m = try t.qsaPooledCosSin(&ctx_b, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 2), t.qsa_pooled_rope.builds);
+    var ctx_c: ForwardCtx = ctx_b;
+    t.fwd_gen += 1;
+    const m2 = try t.qsaPooledCosSin(&ctx_c, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 2), t.qsa_pooled_rope.builds);
+    try testing.expect(m2.cos.ctx == m.cos.ctx and m2.sin.ctx == m.sin.ctx);
+
+    _ = try t.qsaPooledCosSin(&ctx_c, rope_dims, base + step, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 3), t.qsa_pooled_rope.builds);
+}
+
+test "qsa pooled rope: a new M-RoPE table at the same pointer does not reuse cos/sin" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+
+    var t: Transformer = undefined;
+    t.s = s;
+    t.allocator = testing.allocator;
+    t.config = .{};
+    t.config.head_dim = 256;
+    t.config.partial_rotary_factor = 0.5;
+    t.config.rope_theta = 10_000_000.0;
+    t.config.mrope_section = .{ 11, 11, 10 };
+    t.rope_freqs_yarn = null;
+    t.yarn_inv_freq = null;
+    t.fwd_gen = 0;
+    t.qsa_pooled_rope = .{};
+    defer t.qsa_pooled_rope.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 1);
+    defer cache.deinit();
+    var seq_off: usize = 0;
+    var ctx: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &seq_off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+
+    const rope_dims: c_int = 128;
+    const base: c_int = 96;
+    const step: c_int = 4;
+    const n: c_int = 5;
+    const total: usize = 256;
+
+    const pos = try testing.allocator.alloc(i32, 3 * total);
+    defer testing.allocator.free(pos);
+    for (pos, 0..) |*p, i| p.* = @intCast(i % 256);
+    ctx.mrope_pos = pos;
+    ctx.mrope_total = total;
+    ctx.mrope_delta = 0;
+
+    const cs_a = try t.qsaPooledCosSin(&ctx, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 1), t.qsa_pooled_rope.builds);
+    const direct_a = try t.mropeCosSinAt(.{ .pos = pos, .total = total, .delta = 0 }, @intCast(base), @intCast(step), @intCast(n), .bfloat16);
+    defer _ = mlx.mlx_array_free(direct_a.cos);
+    defer _ = mlx.mlx_array_free(direct_a.sin);
+    try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(cs_a.cos, direct_a.cos, s));
+
+    for (pos, 0..) |*p, i| p.* = @intCast((i * 7 + 13) % 256);
+    const direct_b = try t.mropeCosSinAt(.{ .pos = pos, .total = total, .delta = 0 }, @intCast(base), @intCast(step), @intCast(n), .bfloat16);
+    defer _ = mlx.mlx_array_free(direct_b.cos);
+    defer _ = mlx.mlx_array_free(direct_b.sin);
+    try testing.expect(try attn256MaxDiff(direct_a.cos, direct_b.cos, s) != 0);
+
+    t.resetQsaPooledRope();
+    var ctx2: ForwardCtx = ctx;
+    const cs_b = try t.qsaPooledCosSin(&ctx2, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 2), t.qsa_pooled_rope.builds);
+    try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(cs_b.cos, direct_b.cos, s));
+    try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(cs_b.sin, direct_b.sin, s));
+}
+
+test "qsa pooled rope: markQsaPooledRopeStale forces a rebuild on the next ask" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+
+    var t: Transformer = undefined;
+    t.s = s;
+    t.allocator = testing.allocator;
+    t.config = .{};
+    t.config.head_dim = 256;
+    t.config.partial_rotary_factor = 0.5;
+    t.config.rope_theta = 10_000_000.0;
+    t.config.mrope_section = .{ 11, 11, 10 };
+    t.rope_freqs_yarn = null;
+    t.yarn_inv_freq = null;
+    t.fwd_gen = 0;
+    t.qsa_pooled_rope = .{};
+    defer t.qsa_pooled_rope.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 1);
+    defer cache.deinit();
+    var seq_off: usize = 0;
+    var ctx: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &seq_off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+
+    const rope_dims: c_int = 128;
+    const base: c_int = 96;
+    const step: c_int = 4;
+    const n: c_int = 5;
+    const total: usize = 256;
+
+    const pos = try testing.allocator.alloc(i32, 3 * total);
+    defer testing.allocator.free(pos);
+    for (pos, 0..) |*p, i| p.* = @intCast(i % 256);
+    ctx.mrope_pos = pos;
+    ctx.mrope_total = total;
+    ctx.mrope_delta = 0;
+
+    _ = try t.qsaPooledCosSin(&ctx, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 1), t.qsa_pooled_rope.builds);
+
+    for (pos, 0..) |*p, i| p.* = @intCast((i * 7 + 13) % 256);
+    t.markQsaPooledRopeStale();
+    var ctx2: ForwardCtx = ctx;
+    const cs_b = try t.qsaPooledCosSin(&ctx2, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 2), t.qsa_pooled_rope.builds);
+    const direct_b = try t.mropeCosSinAt(.{ .pos = pos, .total = total, .delta = 0 }, @intCast(base), @intCast(step), @intCast(n), .bfloat16);
+    defer _ = mlx.mlx_array_free(direct_b.cos);
+    defer _ = mlx.mlx_array_free(direct_b.sin);
+    try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(cs_b.cos, direct_b.cos, s));
+    try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(cs_b.sin, direct_b.sin, s));
+
+    ctx.mrope_pos = null;
+    ctx.mrope_total = 0;
+    ctx.mrope_delta = 0;
+    _ = try t.qsaPooledCosSin(&ctx, rope_dims, base, step, n, .bfloat16);
+    const scalar_builds = t.qsa_pooled_rope.builds;
+    t.markQsaPooledRopeStale();
+    _ = try t.qsaPooledCosSin(&ctx, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(scalar_builds + 1, t.qsa_pooled_rope.builds);
+}
+
+test "qsa pooled rope: a mark from another thread is observed by the next lookup" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+
+    var t: Transformer = undefined;
+    t.s = s;
+    t.allocator = testing.allocator;
+    t.config = .{};
+    t.config.head_dim = 256;
+    t.config.partial_rotary_factor = 0.5;
+    t.config.rope_theta = 10_000_000.0;
+    t.config.mrope_section = .{ 11, 11, 10 };
+    t.rope_freqs_yarn = null;
+    t.yarn_inv_freq = null;
+    t.fwd_gen = 0;
+    t.qsa_pooled_rope = .{};
+    defer t.qsa_pooled_rope.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 1);
+    defer cache.deinit();
+    var seq_off: usize = 0;
+    var ctx: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &seq_off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+
+    const rope_dims: c_int = 128;
+    const base: c_int = 96;
+    const step: c_int = 4;
+    const n: c_int = 5;
+
+    _ = try t.qsaPooledCosSin(&ctx, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 1), t.qsa_pooled_rope.builds);
+
+    const Worker = struct {
+        fn run(xfm: *Transformer) void {
+            xfm.markQsaPooledRopeStale();
+        }
+    };
+    const th = try std.Thread.spawn(.{}, Worker.run, .{&t});
+    th.join();
+    try testing.expect(t.qsa_pooled_rope.stale.load(.acquire));
+    _ = try t.qsaPooledCosSin(&ctx, rope_dims, base, step, n, .bfloat16);
+    try testing.expectEqual(@as(usize, 2), t.qsa_pooled_rope.builds);
 }
 
 // ── The QSA all-visible identity skip at the engagement boundary ──

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -6489,6 +6489,7 @@ pub const SSMCacheEntry = struct {
     qsa_pooled_buf: mlx.mlx_array = .{ .ctx = null },
     qsa_pooled_blocks: c_int = 0,
     qsa_score_bank: mlx.mlx_array = .{ .ctx = null },
+    qsa_score_buf: mlx.mlx_array = .{ .ctx = null },
     qsa_score_blocks: c_int = 0,
     /// Rows this entry's QSA history is asked to hold up front (the counterpart of
     /// `KVCache.reserve_tokens`); the pooled bank derives its own by `ratio`. 0 = none.
@@ -6502,6 +6503,7 @@ pub fn ssmFreeQsaState(e: *SSMCacheEntry) void {
     if (e.qsa_pooled.ctx != null) _ = mlx.mlx_array_free(e.qsa_pooled);
     if (e.qsa_pooled_buf.ctx != null) _ = mlx.mlx_array_free(e.qsa_pooled_buf);
     if (e.qsa_score_bank.ctx != null) _ = mlx.mlx_array_free(e.qsa_score_bank);
+    if (e.qsa_score_buf.ctx != null) _ = mlx.mlx_array_free(e.qsa_score_buf);
     e.aux_state = .{ .ctx = null };
     e.qsa_key_buf = .{ .ctx = null };
     e.qsa_key_rows = 0;
@@ -6509,6 +6511,7 @@ pub fn ssmFreeQsaState(e: *SSMCacheEntry) void {
     e.qsa_pooled_buf = .{ .ctx = null };
     e.qsa_pooled_blocks = 0;
     e.qsa_score_bank = .{ .ctx = null };
+    e.qsa_score_buf = .{ .ctx = null };
     e.qsa_score_blocks = 0;
 }
 
@@ -6531,6 +6534,8 @@ pub var qsa_cap_buf_allocs: usize = 0;
 
 /// How many times a QSA history accelerator was re-seeded from its authority (`seedCapBuf`).
 pub var qsa_history_seeds: usize = 0;
+
+pub var qsa_score_incremental_appends: usize = 0;
 
 /// Ask every live entry's QSA history to hold `tokens` rows up front (same lever as `KVCache.reserve`).
 pub fn reserveQsaHistory(entries: ?[]SSMCacheEntry, tokens: usize) void {
@@ -6655,6 +6660,8 @@ fn qsaResliceToKeep(entry: *SSMCacheEntry, keep: c_int, s: mlx.mlx_stream) !bool
     }
     if (entry.qsa_score_bank.ctx != null) _ = mlx.mlx_array_free(entry.qsa_score_bank);
     entry.qsa_score_bank = .{ .ctx = null };
+    if (entry.qsa_score_buf.ctx != null) _ = mlx.mlx_array_free(entry.qsa_score_buf);
+    entry.qsa_score_buf = .{ .ctx = null };
     entry.qsa_score_blocks = 0;
     return true;
 }
@@ -6950,6 +6957,7 @@ test "a PLE rollback leaves no freed-but-non-null QSA handle behind" {
     try t.expect(e.qsa_key_buf.ctx == null);
     try t.expect(e.qsa_pooled_buf.ctx == null);
     try t.expect(e.qsa_score_bank.ctx == null);
+    try t.expect(e.qsa_score_buf.ctx == null);
     try t.expectEqual(@as(c_int, 0), e.qsa_key_rows);
     try t.expectEqual(@as(c_int, 0), e.qsa_pooled_blocks);
 }
@@ -15228,23 +15236,58 @@ pub const Transformer = struct {
     /// The block-score matmul's key operand: `[B, 1, hd, nb]` f32, the pooled bank transposed
     /// and up-cast, rebuilt only when a block completes (it used to be a strided copy of the
     /// whole bank on every layer of every forward). Borrowed; bit-identical to the per-forward build.
-    fn qsaScoreBank(self: *Transformer, entry: *SSMCacheEntry, batch: c_int, nb: c_int, idx_hd: c_int) !mlx.mlx_array {
-        if (entry.qsa_score_bank.ctx != null and entry.qsa_score_blocks == nb) return entry.qsa_score_bank;
-        if (entry.qsa_score_bank.ctx != null) _ = mlx.mlx_array_free(entry.qsa_score_bank);
-        entry.qsa_score_bank = .{ .ctx = null };
-        entry.qsa_score_blocks = 0;
+    fn qsaScoreCols(self: *Transformer, pooled: mlx.mlx_array, batch: c_int, n: c_int, idx_hd: c_int) !mlx.mlx_array {
         var k_rope = mlx.mlx_array_new();
         defer _ = mlx.mlx_array_free(k_rope);
-        try mlx.check(mlx.mlx_reshape(&k_rope, entry.qsa_pooled, &[_]c_int{ batch, 1, nb, idx_hd }, 4, self.s)); // [B,1,nb,hd]
+        try mlx.check(mlx.mlx_reshape(&k_rope, pooled, &[_]c_int{ batch, 1, n, idx_hd }, 4, self.s));
         const kperm = [_]c_int{ 0, 1, 3, 2 };
         var kt = mlx.mlx_array_new();
         defer _ = mlx.mlx_array_free(kt);
-        try mlx.check(mlx.mlx_transpose_axes(&kt, k_rope, &kperm, 4, self.s)); // [B,1,hd,nb]
+        try mlx.check(mlx.mlx_transpose_axes(&kt, k_rope, &kperm, 4, self.s));
         var k32 = mlx.mlx_array_new();
         errdefer _ = mlx.mlx_array_free(k32);
         try mlx.check(mlx.mlx_astype(&k32, kt, .float32, self.s));
-        entry.qsa_score_bank = k32;
-        entry.qsa_score_blocks = nb;
+        return k32;
+    }
+
+    fn qsaScoreBank(self: *Transformer, entry: *SSMCacheEntry, batch: c_int, nb: c_int, idx_hd: c_int) !mlx.mlx_array {
+        if (entry.qsa_score_bank.ctx != null and entry.qsa_score_blocks == nb) return entry.qsa_score_bank;
+        const old_nb = entry.qsa_score_blocks;
+        const ratio: usize = @max(@as(usize, @intCast(entry.qsa_ratio)), 1);
+        const reserve = entry.qsa_reserve_rows / ratio;
+        if (entry.qsa_score_buf.ctx != null and old_nb > 0 and nb > old_nb and entry.qsa_pooled.ctx != null) {
+            const psh = mlx.getShape(entry.qsa_pooled);
+            if (psh[1] >= nb) {
+                const n_new = nb - old_nb;
+                var new_pooled = mlx.mlx_array_new();
+                defer _ = mlx.mlx_array_free(new_pooled);
+                try mlx.check(mlx.mlx_slice(
+                    &new_pooled,
+                    entry.qsa_pooled,
+                    &[_]c_int{ 0, old_nb, 0 },
+                    3,
+                    &[_]c_int{ psh[0], nb, psh[2] },
+                    3,
+                    &[_]c_int{ 1, 1, 1 },
+                    3,
+                    self.s,
+                ));
+                const cols = try self.qsaScoreCols(new_pooled, batch, n_new, idx_hd);
+                defer _ = mlx.mlx_array_free(cols);
+                try capBufAppend(self.s, &entry.qsa_score_buf, &entry.qsa_score_bank, &entry.qsa_score_blocks, cols, 3, reserve);
+                self.qsa_score_bank_builds += 1;
+                qsa_score_incremental_appends += 1;
+                return entry.qsa_score_bank;
+            }
+        }
+        if (entry.qsa_score_bank.ctx != null) _ = mlx.mlx_array_free(entry.qsa_score_bank);
+        if (entry.qsa_score_buf.ctx != null) _ = mlx.mlx_array_free(entry.qsa_score_buf);
+        entry.qsa_score_bank = .{ .ctx = null };
+        entry.qsa_score_buf = .{ .ctx = null };
+        entry.qsa_score_blocks = 0;
+        const cols = try self.qsaScoreCols(entry.qsa_pooled, batch, nb, idx_hd);
+        defer _ = mlx.mlx_array_free(cols);
+        try capBufAppend(self.s, &entry.qsa_score_buf, &entry.qsa_score_bank, &entry.qsa_score_blocks, cols, 3, reserve);
         self.qsa_score_bank_builds += 1;
         return entry.qsa_score_bank;
     }
@@ -45401,6 +45444,59 @@ test "qsa pooled bank: capacity append equals the concat, and the f32 score oper
     _ = try t.qsaScoreBank(&entry, 1, nb + 1, hd);
     try testing.expectEqual(before + 2, t.qsa_score_bank_builds);
     try testing.expectEqual(nb + 1, mlx.getShape(entry.qsa_score_bank)[3]);
+}
+
+test "qsa score bank: incremental column append matches a from-scratch rebuild" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+
+    var t: Transformer = undefined;
+    t.s = s;
+    t.allocator = testing.allocator;
+    t.qsa_score_bank_builds = 0;
+
+    const hd: c_int = 16;
+    const batch: c_int = 1;
+    var prng = std.Random.DefaultPrng.init(0x5C0E_BA11);
+    const rnd = prng.random();
+
+    var scratch: SSMCacheEntry = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true };
+    defer ssmFreeQsaState(&scratch);
+    var incr: SSMCacheEntry = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true };
+    defer ssmFreeQsaState(&incr);
+
+    const before = qsa_score_incremental_appends;
+    var nb: c_int = 0;
+    var step_i: usize = 0;
+    while (step_i < 24) : (step_i += 1) {
+        const add: c_int = if (step_i == 0) 5 else 1;
+        const new3 = try attn256RandBf16(rnd, &[_]c_int{ batch, add, hd }, s);
+        defer _ = mlx.mlx_array_free(new3);
+        try t.qsaAppendPooled(&scratch, new3, nb);
+        try t.qsaAppendPooled(&incr, new3, nb);
+        nb += add;
+        _ = try t.qsaScoreBank(&incr, batch, nb, hd);
+    }
+    try testing.expectEqual(before + 23, qsa_score_incremental_appends);
+    try testing.expect(mlx.getShape(incr.qsa_score_buf)[3] > nb);
+    const bank_inc = try t.qsaScoreBank(&incr, batch, nb, hd);
+    const bank_scratch = try t.qsaScoreBank(&scratch, batch, nb, hd);
+    try testing.expectEqual(@as(c_int, hd), mlx.getShape(bank_inc)[2]);
+    try testing.expectEqual(nb, mlx.getShape(bank_inc)[3]);
+    try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(bank_inc, bank_scratch, s));
+    {
+        var k_rope = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(k_rope);
+        try mlx.check(mlx.mlx_reshape(&k_rope, scratch.qsa_pooled, &[_]c_int{ batch, 1, nb, hd }, 4, s));
+        var kt = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(kt);
+        try mlx.check(mlx.mlx_transpose_axes(&kt, k_rope, &[_]c_int{ 0, 1, 3, 2 }, 4, s));
+        var k32 = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(k32);
+        try mlx.check(mlx.mlx_astype(&k32, kt, .float32, s));
+        try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(bank_inc, k32, s));
+    }
+    try testing.expect(qsa_score_incremental_appends > before);
 }
 
 test "qsa pooled rope: one cos/sin build per forward, not one per full-attention layer" {

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -6485,7 +6485,7 @@ pub const SSMCacheEntry = struct {
     qsa_key_rows: c_int = 0,
     /// Pooled-bank accelerators, same discipline: `qsa_pooled_buf` is the capacity buffer
     /// `qsa_pooled` views; `qsa_score_bank` is the f32 `[B, 1, hd, nb]` score operand,
-    /// rebuilt only when a block completes.
+    /// a view of `qsa_score_buf`, which grows by appended columns as blocks complete.
     qsa_pooled_buf: mlx.mlx_array = .{ .ctx = null },
     qsa_pooled_blocks: c_int = 0,
     qsa_score_bank: mlx.mlx_array = .{ .ctx = null },
@@ -8771,13 +8771,15 @@ pub const PlePending = struct {
     capture: bool,
 };
 
-/// The QSA pooled-block RoPE tables for one forward: every full-attention layer ropes the
-/// same blocks at the same positions, so they are a property of the forward (qwen4_exp
-/// rebuilt them 12 times). The key carries `gen` and the `ForwardCtx` pointer because the
-/// M-RoPE arm also reads the ctx's position table.
+/// The QSA pooled-block RoPE tables, shared by every full-attention layer of a forward
+/// and across forwards while the key holds. The key is the block position (`base`,
+/// `step`, `n`, dtype) and, on the M-RoPE arm, the position table compared by pointer
+/// and length only; it is never dereferenced through the key. The table's owner slot
+/// frees it only after `markQsaPooledRopeStale`, and the one free site is scan-pinned,
+/// so a same-address table cannot hit. Connection threads write nothing here except
+/// the atomic `stale`; the inference thread frees and rebuilds. Hashing the table's
+/// contents into the key would turn this address compare into a use after free.
 const QsaPooledRope = struct {
-    gen: u64 = 0,
-    ctx: ?*const ForwardCtx = null,
     base: c_int = 0,
     step: c_int = 0,
     n: c_int = 0,
@@ -8797,7 +8799,6 @@ const QsaPooledRope = struct {
         if (self.sin.ctx != null) _ = mlx.mlx_array_free(self.sin);
         self.cos = .{ .ctx = null };
         self.sin = .{ .ctx = null };
-        self.ctx = null;
         self.mrope_pos = null;
         self.stale.store(false, .monotonic);
     }
@@ -9882,9 +9883,9 @@ pub const Transformer = struct {
     qsa_consts: QsaBlockConsts = .{},
     /// QSA pooled-block cos/sin, built once per forward (`QsaPooledRope`).
     qsa_pooled_rope: QsaPooledRope = .{},
-    /// Bumped by every forward entry that can reach QSA; part of the `qsa_pooled_rope` key.
+    /// Bumped by every forward entry that can reach QSA; keys the per-forward QSA scratch.
     fwd_gen: u64 = 0,
-    /// Test meter: how many times `qsaScoreBank` rebuilt the transposed f32 operand.
+    /// Test meter: how many times `qsaScoreBank` built or extended the transposed f32 operand.
     qsa_score_bank_builds: usize = 0,
     /// qwen4_exp MTP head (one hyper-connected QSA+MoE layer over the trunk's
     /// pre-mixer stream + next-token embedding). Loaded when the pack carries
@@ -15355,8 +15356,6 @@ pub const Transformer = struct {
             try self.ropeCosSinFromFreqs(rope_dims, try self.ropeInvFreq(rope_dims, self.config.rope_theta), @floatFromInt(base), @floatFromInt(step), n, dt);
         c.cos = cs.cos;
         c.sin = cs.sin;
-        c.gen = self.fwd_gen;
-        c.ctx = ctx;
         c.base = base;
         c.step = step;
         c.n = n;
@@ -45611,7 +45610,7 @@ test "qsa pooled rope: one cos/sin build per forward, not one per full-attention
     defer _ = mlx.mlx_array_free(per_layer);
     try testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(hoisted, per_layer, s));
 
-    // A new forward rebuilds (the M-RoPE arm's position table is not in the key).
+    // A new forward at the same position hits: the forward counter is not in the key.
     t.fwd_gen += 1;
     _ = try t.qsaPooledCosSin(&ctx, rope_dims, base, step, n, .bfloat16);
     try testing.expectEqual(@as(usize, 1), t.qsa_pooled_rope.builds);

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -6635,6 +6635,51 @@ fn capBufAppend(s: mlx.mlx_stream, buf: *mlx.mlx_array, view: *mlx.mlx_array, co
     try mlx.check(mlx.mlx_slice(view, buf.*, &start, nd, &stop, nd, &strides, nd, s));
 }
 
+fn qsaResliceToKeep(entry: *SSMCacheEntry, keep: c_int, s: mlx.mlx_stream) !bool {
+    const buf_ok = entry.qsa_key_buf.ctx != null and
+        keep <= entry.qsa_key_rows and
+        mlx.getShape(entry.qsa_key_buf)[1] >= keep;
+    if (!buf_ok) return false;
+    try capBufReslice(s, entry.qsa_key_buf, &entry.aux_state, &entry.qsa_key_rows, 1, keep);
+    const keep_blocks: c_int = @divTrunc(keep, @max(entry.qsa_ratio, 1));
+    if (entry.qsa_pooled_buf.ctx != null) {
+        if (keep_blocks > 0 and mlx.getShape(entry.qsa_pooled_buf)[1] >= keep_blocks) {
+            try capBufReslice(s, entry.qsa_pooled_buf, &entry.qsa_pooled, &entry.qsa_pooled_blocks, 1, keep_blocks);
+        } else {
+            if (entry.qsa_pooled.ctx != null) _ = mlx.mlx_array_free(entry.qsa_pooled);
+            entry.qsa_pooled = .{ .ctx = null };
+            entry.qsa_pooled_blocks = 0;
+        }
+    } else {
+        try truncatePooled(&entry.qsa_pooled, keep, entry.qsa_ratio, s, false);
+    }
+    if (entry.qsa_score_bank.ctx != null) _ = mlx.mlx_array_free(entry.qsa_score_bank);
+    entry.qsa_score_bank = .{ .ctx = null };
+    entry.qsa_score_blocks = 0;
+    return true;
+}
+
+fn capBufReslice(s: mlx.mlx_stream, buf: mlx.mlx_array, view: *mlx.mlx_array, count: *c_int, axis: usize, new_count: c_int) !void {
+    const sh = mlx.getShape(buf);
+    const nd: usize = sh.len;
+    if (view.ctx != null) _ = mlx.mlx_array_free(view.*);
+    view.* = .{ .ctx = null };
+    count.* = 0;
+    if (new_count <= 0) return;
+    var start = [_]c_int{ 0, 0, 0, 0 };
+    var stop = [_]c_int{ 0, 0, 0, 0 };
+    const strides = [_]c_int{ 1, 1, 1, 1 };
+    for (sh, 0..) |d, i| stop[i] = d;
+    stop[axis] = new_count;
+    view.* = mlx.mlx_array_new();
+    errdefer {
+        _ = mlx.mlx_array_free(view.*);
+        view.* = .{ .ctx = null };
+    }
+    try mlx.check(mlx.mlx_slice(view, buf, &start, nd, &stop, nd, &strides, nd, s));
+    count.* = new_count;
+}
+
 /// SSM snapshot value. Holds clones of conv_state and ssm_state via refcount —
 /// the underlying buffer is shared with the source entry, but the snapshot
 /// owns its own array handles and frees them on deinit. Used for
@@ -6806,20 +6851,22 @@ pub fn ssmRollbackFromCapture(entry: *SSMCacheEntry, accepted: u32, verify_len: 
     } else if (entry.aux_state.ctx != null and entry.conv_state.ctx == null) {
         const ks = mlx.getShape(entry.aux_state); // [B, rows, hd]
         const keep: c_int = ks[1] - @as(c_int, @intCast(verify_len)) + @as(c_int, @intCast(1 + accepted));
-        const start = [_]c_int{ 0, 0, 0 };
-        const stop = [_]c_int{ ks[0], keep, ks[2] };
-        const strides = [_]c_int{ 1, 1, 1 };
-        var view = mlx.mlx_array_new();
-        defer _ = mlx.mlx_array_free(view);
-        try mlx.check(mlx.mlx_slice(&view, entry.aux_state, &start, 3, &stop, 3, &strides, 3, s));
-        const owned = try materializedOwnedCopy(s, view);
-        // The pooled bank survives (truncated); only the history and its buffer are replaced.
-        const pooled = entry.qsa_pooled;
-        entry.qsa_pooled = .{ .ctx = null };
-        ssmFreeQsaState(entry);
-        entry.qsa_pooled = pooled;
-        entry.aux_state = owned;
-        try truncatePooled(&entry.qsa_pooled, keep, entry.qsa_ratio, s, true);
+        if (!try qsaResliceToKeep(entry, keep, s)) {
+            const start = [_]c_int{ 0, 0, 0 };
+            const stop = [_]c_int{ ks[0], keep, ks[2] };
+            const strides = [_]c_int{ 1, 1, 1 };
+            var view = mlx.mlx_array_new();
+            defer _ = mlx.mlx_array_free(view);
+            try mlx.check(mlx.mlx_slice(&view, entry.aux_state, &start, 3, &stop, 3, &strides, 3, s));
+            const owned = try materializedOwnedCopy(s, view);
+            // The pooled bank survives (truncated); only the history and its buffer are replaced.
+            const pooled = entry.qsa_pooled;
+            entry.qsa_pooled = .{ .ctx = null };
+            ssmFreeQsaState(entry);
+            entry.qsa_pooled = pooled;
+            entry.aux_state = owned;
+            try truncatePooled(&entry.qsa_pooled, keep, entry.qsa_ratio, s, true);
+        }
     }
     if (entry.spec_state_seq.ctx == null and entry.spec_conv_input.ctx == null) return;
 
@@ -6905,6 +6952,226 @@ test "a PLE rollback leaves no freed-but-non-null QSA handle behind" {
     try t.expect(e.qsa_score_bank.ctx == null);
     try t.expectEqual(@as(c_int, 0), e.qsa_key_rows);
     try t.expectEqual(@as(c_int, 0), e.qsa_pooled_blocks);
+}
+
+test "qsa rollback: a partial accept keeps the raw-key buffer and re-slices to keep" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const t = std.testing;
+    const s = mlx.gpuStream();
+    var xfm: Transformer = undefined;
+    xfm.s = s;
+    xfm.allocator = t.allocator;
+    xfm.qsa_score_bank_builds = 0;
+
+    var entry: SSMCacheEntry = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true };
+    defer ssmFreeQsaState(&entry);
+    entry.qsa_ratio = 4;
+    entry.qsa_reserve_rows = 64;
+
+    var prng = std.Random.DefaultPrng.init(0x51A0_B0FF);
+    const rnd = prng.random();
+    const hd: c_int = 16;
+    const prefix: c_int = 8;
+    const verify_len: c_int = 4;
+    const accepted: u32 = 1;
+    const keep: c_int = prefix + @as(c_int, @intCast(1 + accepted));
+    const keep_blocks: c_int = @divTrunc(keep, entry.qsa_ratio);
+
+    {
+        const chunk = try attn256RandBf16(rnd, &[_]c_int{ 1, prefix, hd }, s);
+        defer _ = mlx.mlx_array_free(chunk);
+        try xfm.qsaAppendKeys(&entry, chunk, 0);
+        const blocks = try attn256RandBf16(rnd, &[_]c_int{ 1, @divTrunc(prefix, entry.qsa_ratio), hd }, s);
+        defer _ = mlx.mlx_array_free(blocks);
+        try xfm.qsaAppendPooled(&entry, blocks, 0);
+    }
+    {
+        const chunk = try attn256RandBf16(rnd, &[_]c_int{ 1, verify_len, hd }, s);
+        defer _ = mlx.mlx_array_free(chunk);
+        try xfm.qsaAppendKeys(&entry, chunk, prefix);
+        const blocks = try attn256RandBf16(rnd, &[_]c_int{ 1, @divTrunc(verify_len, entry.qsa_ratio), hd }, s);
+        defer _ = mlx.mlx_array_free(blocks);
+        try xfm.qsaAppendPooled(&entry, blocks, @divTrunc(prefix, entry.qsa_ratio));
+    }
+    try t.expectEqual(prefix + verify_len, entry.qsa_key_rows);
+    try t.expect(entry.qsa_key_buf.ctx != null);
+    _ = try xfm.qsaScoreBank(&entry, 1, @divTrunc(prefix + verify_len, entry.qsa_ratio), hd);
+
+    const kept_ref = blk: {
+        const ks = mlx.getShape(entry.aux_state);
+        var view = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(view);
+        try mlx.check(mlx.mlx_slice(
+            &view,
+            entry.aux_state,
+            &[_]c_int{ 0, 0, 0 },
+            3,
+            &[_]c_int{ ks[0], keep, ks[2] },
+            3,
+            &[_]c_int{ 1, 1, 1 },
+            3,
+            s,
+        ));
+        break :blk try materializedOwnedCopy(s, view);
+    };
+    defer _ = mlx.mlx_array_free(kept_ref);
+
+    const kept_pooled = blk: {
+        const ps = mlx.getShape(entry.qsa_pooled);
+        var view = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(view);
+        try mlx.check(mlx.mlx_slice(
+            &view,
+            entry.qsa_pooled,
+            &[_]c_int{ 0, 0, 0 },
+            3,
+            &[_]c_int{ ps[0], keep_blocks, ps[2] },
+            3,
+            &[_]c_int{ 1, 1, 1 },
+            3,
+            s,
+        ));
+        break :blk try materializedOwnedCopy(s, view);
+    };
+    defer _ = mlx.mlx_array_free(kept_pooled);
+
+    const buf_before = entry.qsa_key_buf.ctx;
+    const pooled_buf_before = entry.qsa_pooled_buf.ctx;
+    try ssmRollbackFromCapture(&entry, accepted, @intCast(verify_len), s);
+
+    try t.expect(entry.qsa_key_buf.ctx == buf_before);
+    try t.expectEqual(keep, entry.qsa_key_rows);
+    try t.expectEqual(keep, mlx.getShape(entry.aux_state)[1]);
+    try t.expect(entry.qsa_pooled_buf.ctx == pooled_buf_before);
+    try t.expectEqual(keep_blocks, entry.qsa_pooled_blocks);
+    try t.expect(entry.qsa_score_bank.ctx == null);
+    try t.expectEqual(@as(c_int, 0), entry.qsa_score_blocks);
+
+    const tail = try attn256RandBf16(rnd, &[_]c_int{ 1, 2, hd }, s);
+    defer _ = mlx.mlx_array_free(tail);
+    var reference = mlx.mlx_array_new();
+    {
+        const parts = [_]mlx.mlx_array{ kept_ref, tail };
+        const vec = mlx.mlx_vector_array_new_data(&parts, 2);
+        defer _ = mlx.mlx_vector_array_free(vec);
+        try mlx.check(mlx.mlx_concatenate_axis(&reference, vec, 1, s));
+    }
+    defer _ = mlx.mlx_array_free(reference);
+
+    try xfm.qsaAppendKeys(&entry, tail, keep);
+    try t.expectEqual(keep + 2, mlx.getShape(entry.aux_state)[1]);
+    try t.expectEqual(@as(f32, 0.0), try attn256MaxDiff(entry.aux_state, reference, s));
+
+    const new_block = try attn256RandBf16(rnd, &[_]c_int{ 1, 1, hd }, s);
+    defer _ = mlx.mlx_array_free(new_block);
+    var pooled_ref = mlx.mlx_array_new();
+    {
+        const parts = [_]mlx.mlx_array{ kept_pooled, new_block };
+        const vec = mlx.mlx_vector_array_new_data(&parts, 2);
+        defer _ = mlx.mlx_vector_array_free(vec);
+        try mlx.check(mlx.mlx_concatenate_axis(&pooled_ref, vec, 1, s));
+    }
+    defer _ = mlx.mlx_array_free(pooled_ref);
+    try xfm.qsaAppendPooled(&entry, new_block, keep_blocks);
+    const bank = try xfm.qsaScoreBank(&entry, 1, keep_blocks + 1, hd);
+    {
+        var k_rope = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(k_rope);
+        try mlx.check(mlx.mlx_reshape(&k_rope, pooled_ref, &[_]c_int{ 1, 1, keep_blocks + 1, hd }, 4, s));
+        var kt = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(kt);
+        try mlx.check(mlx.mlx_transpose_axes(&kt, k_rope, &[_]c_int{ 0, 1, 3, 2 }, 4, s));
+        var k32 = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(k32);
+        try mlx.check(mlx.mlx_astype(&k32, kt, .float32, s));
+        try t.expectEqual(@as(f32, 0.0), try attn256MaxDiff(bank, k32, s));
+    }
+}
+
+test "qsa mtp truncate: a trim keeps the raw-key buffer and re-slices to keep" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const t = std.testing;
+    const s = mlx.gpuStream();
+    var xfm: Transformer = undefined;
+    xfm.s = s;
+    xfm.allocator = t.allocator;
+
+    var mtp: Qwen4Mtp = undefined;
+    const kv = try KVCache.init(t.allocator, 2);
+    mtp.cache = kv;
+    mtp.entry = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true };
+    mtp.entry.qsa_ratio = 4;
+    mtp.entry.qsa_reserve_rows = 64;
+    mtp.seq_offset = 0;
+    mtp.pos_base = 0;
+    xfm.qwen4_mtp = mtp;
+    defer {
+        ssmFreeQsaState(&xfm.qwen4_mtp.?.entry);
+        xfm.qwen4_mtp.?.cache.deinit();
+    }
+
+    var prng = std.Random.DefaultPrng.init(0x71A0_B0FF);
+    const rnd = prng.random();
+    const hd: c_int = 16;
+    const prefix: c_int = 8;
+    const tail_len: c_int = 4;
+    const keep: c_int = 10;
+    const entry = &xfm.qwen4_mtp.?.entry;
+
+    {
+        const chunk = try attn256RandBf16(rnd, &[_]c_int{ 1, prefix, hd }, s);
+        defer _ = mlx.mlx_array_free(chunk);
+        try xfm.qsaAppendKeys(entry, chunk, 0);
+    }
+    {
+        const chunk = try attn256RandBf16(rnd, &[_]c_int{ 1, tail_len, hd }, s);
+        defer _ = mlx.mlx_array_free(chunk);
+        try xfm.qsaAppendKeys(entry, chunk, prefix);
+    }
+    xfm.qwen4_mtp.?.seq_offset = @intCast(prefix + tail_len);
+    try t.expectEqual(prefix + tail_len, entry.qsa_key_rows);
+    try t.expect(entry.qsa_key_buf.ctx != null);
+
+    const kept_ref = blk: {
+        const ks = mlx.getShape(entry.aux_state);
+        var view = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(view);
+        try mlx.check(mlx.mlx_slice(
+            &view,
+            entry.aux_state,
+            &[_]c_int{ 0, 0, 0 },
+            3,
+            &[_]c_int{ ks[0], keep, ks[2] },
+            3,
+            &[_]c_int{ 1, 1, 1 },
+            3,
+            s,
+        ));
+        break :blk try materializedOwnedCopy(s, view);
+    };
+    defer _ = mlx.mlx_array_free(kept_ref);
+
+    const buf_before = entry.qsa_key_buf.ctx;
+    try xfm.qwen4MtpTruncate(@intCast(keep));
+
+    try t.expect(entry.qsa_key_buf.ctx == buf_before);
+    try t.expectEqual(keep, entry.qsa_key_rows);
+    try t.expectEqual(keep, mlx.getShape(entry.aux_state)[1]);
+
+    const extra = try attn256RandBf16(rnd, &[_]c_int{ 1, 2, hd }, s);
+    defer _ = mlx.mlx_array_free(extra);
+    var reference = mlx.mlx_array_new();
+    {
+        const parts = [_]mlx.mlx_array{ kept_ref, extra };
+        const vec = mlx.mlx_vector_array_new_data(&parts, 2);
+        defer _ = mlx.mlx_vector_array_free(vec);
+        try mlx.check(mlx.mlx_concatenate_axis(&reference, vec, 1, s));
+    }
+    defer _ = mlx.mlx_array_free(reference);
+
+    try xfm.qsaAppendKeys(entry, extra, keep);
+    try t.expectEqual(keep + 2, mlx.getShape(entry.aux_state)[1]);
+    try t.expectEqual(@as(f32, 0.0), try attn256MaxDiff(entry.aux_state, reference, s));
 }
 
 /// Keep the pooled-key rows that are still complete blocks of a key history
@@ -15613,20 +15880,23 @@ pub const Transformer = struct {
             if (len == 0) {
                 ssmFreeQsaState(&m.entry);
             } else {
-                const ks = mlx.getShape(m.entry.aux_state);
-                const start = [_]c_int{ 0, 0, 0 };
-                const stop = [_]c_int{ ks[0], @intCast(len), ks[2] };
-                const strides = [_]c_int{ 1, 1, 1 };
-                var view = mlx.mlx_array_new();
-                defer _ = mlx.mlx_array_free(view);
-                try mlx.check(mlx.mlx_slice(&view, m.entry.aux_state, &start, 3, &stop, 3, &strides, 3, self.s));
-                const owned = try materializedOwnedCopy(self.s, view);
-                const pooled = m.entry.qsa_pooled; // survives, truncated below
-                m.entry.qsa_pooled = .{ .ctx = null };
-                ssmFreeQsaState(&m.entry);
-                m.entry.qsa_pooled = pooled;
-                m.entry.aux_state = owned;
-                try truncatePooled(&m.entry.qsa_pooled, @intCast(len), m.entry.qsa_ratio, self.s, true);
+                const keep: c_int = @intCast(len);
+                if (!try qsaResliceToKeep(&m.entry, keep, self.s)) {
+                    const ks = mlx.getShape(m.entry.aux_state);
+                    const start = [_]c_int{ 0, 0, 0 };
+                    const stop = [_]c_int{ ks[0], @intCast(len), ks[2] };
+                    const strides = [_]c_int{ 1, 1, 1 };
+                    var view = mlx.mlx_array_new();
+                    defer _ = mlx.mlx_array_free(view);
+                    try mlx.check(mlx.mlx_slice(&view, m.entry.aux_state, &start, 3, &stop, 3, &strides, 3, self.s));
+                    const owned = try materializedOwnedCopy(self.s, view);
+                    const pooled = m.entry.qsa_pooled; // survives, truncated below
+                    m.entry.qsa_pooled = .{ .ctx = null };
+                    ssmFreeQsaState(&m.entry);
+                    m.entry.qsa_pooled = pooled;
+                    m.entry.aux_state = owned;
+                    try truncatePooled(&m.entry.qsa_pooled, @intCast(len), m.entry.qsa_ratio, self.s, true);
+                }
             }
         }
         m.seq_offset = len;


### PR DESCRIPTION
# perf(qwen4): MTP/QSA history rollback without copies

Three changes to the QSA indexer state on the qwen4_exp MTP path, from an audit of the serving path, hardened through five audit and fix rounds.

**Q1. A partial accept re-sliced, not re-copied.** A partial-accept rollback freed the QSA raw-key buffer and the pooled bank and re-copied them from the reserve on the next forward: about six prefix-sized passes per layer per round. The audit's shape microbench on this box put those copies at 8 ms per round at 8k and 45 ms at 786k, up to 45% of a round; the end-to-end sweep below does not isolate this term from the other two. The capacity buffers already hold every kept row after the verify forward, so the rollback now re-slices the row count, the way the KV truncate does, and drops only the score bank. The head's truncate got the same treatment. A test pins the same buffer handle before and after a rollback, the pooled bank and the score bank after it, and the next append's bytes.

**Q2. The score bank appends columns.** The bank was rebuilt from scratch every four decode tokens on every full-attention layer, 0.15 to 0.29 ms each at 32k to 383k. It now appends the new blocks' columns. A test compares the incremental bank with a from-scratch build byte for byte and requires the incremental path to have run.

**Q5. The head's history reserved, and a pooled-rope cache that survives slot teardown.** The MTP head's QSA history now takes the trunk's reservation. The pooled cos and sin cache was keyed on the ForwardCtx pointer and rebuilt every draft step; it is keyed on block position and table now. The audit rounds moved the correctness of that cache from a borrowed key, to a reset at request end, to a reset on every slot end, to a mark set by the slot and consumed by the inference thread, to an atomic mark. Connection threads write one atomic word and nothing else; the inference thread frees, at its drain or on the next lookup. Round five found nothing left.

Byte identity is the bar for every change and every test compares bytes. No comment or doc text was written by the external agent.

**Measured against the baseline on main (862bddf)**, one boot each, 4k to 384k incremental, auto-MTP:

| rung | prefill tok/s, main → branch | auto-MTP decode tok/s | round ms |
|---|---|---|---|
| 4k | 1503 → 1546 (+3%) | 67.8 → 68.6 (+1%) | 37.0 → 37.7 |
| 8k | 1697 → 1749 (+3%) | 71.3 → 68.1 (-4%) | 44.0 → 33.7 (-24%) |
| 16k | 1508 → 1670 (+11%) | 65.1 → 64.3 (-1%) | 37.9 → 24.8 (-35%) |
| 32k | 1331 → 1559 (+17%) | 67.8 → 70.5 (+4%) | 37.2 → 25.1 (-32%) |
| 64k | 1183 → 1445 (+22%) | 59.2 → 73.4 (+24%) | 42.5 → 35.6 (-16%) |
| 128k | 1052 → 1227 (+17%) | 52.1 → 62.6 (+20%) | 39.5 → 40.7 (+3%) |
| 256k | 870 → 973 (+12%) | 45.5 → 59.0 (+30%) | 52.4 → 44.4 (-15%) |
| 384k | 940 → 1049 (+12%) | 44.7 → 54.0 (+21%) | 52.1 → 34.4 (-34%) |

Peak memory, restored tokens, prefill chunk and PLE arms are identical on every rung. The partial-accept counter this PR adds was not yet in the build the sweep ran on, and a non-speculative cell (the serial round cost) moved 6 to 8% too, so the gain is not attributed per change. Every cell is one boot and one generation, so the evidence is the sign across eight rungs and the same-width round cost, which fell 19% to 30% in the four buckets with ten or more samples on both sides, not any single percentage. The baseline's step in round time at 256k and above is gone. Auto-mode output is not byte-reproducible across boots by design; the byte bar with `MLX_SERVE_MTP_FORCE_DEPTH` pinned is: byte-identical at 16k and 64k between main and the branch (`MLX_SERVE_MTP_FORCE_DEPTH=4`, adaptive serial off, cold, temperature 0), with identical draft, accept and attempt counts on every request, and reproducible across boots within each arm.

Suite on 627949f: 9 of 9 steps, 2169 passed, 153 skipped, 0 failed. Swift build clean. The qsa test family is 50 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
