### PR TITLE
perf(qwen4): the SSD tier writes the QSA indexer history once per entry, not once per checkpoint

### DIFF
--- a/src/kv_disk_cache.zig
+++ b/src/kv_disk_cache.zig
@@ -137,6 +137,8 @@ pub const SpaceProbeFn = *const fn (path: []const u8) ?VolumeSpace;
 
 /// Test hook, armed through `DiskTier.armTestSpace`.
 var test_space: ?VolumeSpace = null;
+var test_qsa_overlay_mismatch = false;
+var test_ssm_write_qsa_aux = false;
 
 fn testSpaceProbe(path: []const u8) ?VolumeSpace {
     _ = path;
@@ -181,6 +183,9 @@ pub const IndexEntry = struct {
     /// A background write for this entry failed: never matched, never a donor, never reported
     /// complete; the next commit reclaims its directory. Not persisted (`scan` re-validates).
     poisoned: bool = false,
+    qsa_history_bytes: u64 = 0,
+    qsa_history_rows: u32 = 0,
+    inherited_qsa: bool = false,
     /// In-process LRU stamp; seeded from meta.json mtime order at scan.
     last_used: u64,
 };
@@ -678,19 +683,56 @@ pub const DiskTier = struct {
         // state) so a corrupt/missing file fails before the cache is touched.
         var cp = try self.loadSsmFile(e.id, cp_pos, ssm_entries.len);
         defer cp.deinit(self.allocator);
-        try self.restoreKvInto(cache, e, cp_pos, s);
-        try transformer_mod.restoreSsmCheckpoint(ssm_entries, &cp);
-        // QSA history lives on the latest snap only. Intermediate files have
-        // GDN/PLE state; overlay the sliced indexer keys from the last file.
-        if (e.ssm_positions.len > 0) {
+        const want_rows = DiskTier.qsaHistoryRowsOf(&cp);
+        const snap_has_qsa = transformer_mod.checkpointHasQsaHistory(&cp);
+        var qsa_overlay: ?transformer_mod.SSMCheckpoint = null;
+        defer if (qsa_overlay) |*q| q.deinit(self.allocator);
+        if ((want_rows > 0 or e.qsa_history_rows > 0) and !snap_has_qsa) {
+            var hist = self.loadQsaHistoryFile(e.id, ssm_entries.len) catch return error.DiskCacheQsaHistoryGap;
+            const have = transformer_mod.checkpointQsaAuxRows(&hist);
+            if (have < @as(c_int, @intCast(cp_pos))) {
+                hist.deinit(self.allocator);
+                return error.DiskCacheQsaHistoryGap;
+            }
+            qsa_overlay = hist;
+        } else if (!snap_has_qsa and e.ssm_positions.len > 0) {
             const latest = e.ssm_positions[e.ssm_positions.len - 1];
             if (latest != cp_pos) {
-                if (self.loadSsmFile(e.id, latest, ssm_entries.len)) |qsa_cp_val| {
-                    var qsa_cp = qsa_cp_val;
-                    defer qsa_cp.deinit(self.allocator);
-                    transformer_mod.applyQsaHistoryAt(ssm_entries, &qsa_cp, cp_pos, s) catch {};
-                } else |_| {}
+                if (self.loadSsmFile(e.id, latest, ssm_entries.len)) |latest_cp_val| {
+                    var latest_cp = latest_cp_val;
+                    if (transformer_mod.checkpointHasQsaHistory(&latest_cp)) {
+                        const have = transformer_mod.checkpointQsaAuxRows(&latest_cp);
+                        if (have < @as(c_int, @intCast(cp_pos))) {
+                            latest_cp.deinit(self.allocator);
+                            return error.DiskCacheQsaHistoryGap;
+                        }
+                        qsa_overlay = latest_cp;
+                    } else {
+                        latest_cp.deinit(self.allocator);
+                    }
+                } else |_| return error.DiskCacheQsaHistoryGap;
             }
+        }
+        if (test_qsa_overlay_mismatch) {
+            if (qsa_overlay) |*q| q.deinit(self.allocator);
+            qsa_overlay = .{ .pos = 0, .layers = try self.allocator.alloc(transformer_mod.SSMCacheEntrySnapshot, 0) };
+        }
+        try self.restoreKvInto(cache, e, cp_pos, s);
+        errdefer cache.truncate(0, s) catch {};
+        try transformer_mod.restoreSsmCheckpoint(ssm_entries, &cp);
+        errdefer {
+            for (ssm_entries) |*ent| {
+                _ = mlx.mlx_array_free(ent.conv_state);
+                _ = mlx.mlx_array_free(ent.ssm_state);
+                ent.conv_state = mlx.mlx_array_new();
+                ent.ssm_state = mlx.mlx_array_new();
+                ent.initialized = false;
+                transformer_mod.ssmFreeQsaState(ent);
+                ent.ple_prev_valid = false;
+            }
+        }
+        if (qsa_overlay) |*qsa_cp| {
+            try transformer_mod.applyQsaHistoryAt(ssm_entries, qsa_cp, cp_pos, s);
         }
         e.last_used = self.bump();
         self.writeMeta(e.*) catch {};
@@ -847,6 +889,7 @@ pub const DiskTier = struct {
         defer _ = mlx.mlx_stream_free(cpu);
         const path = try std.fmt.allocPrint(self.allocator, "{s}/e{d}/s{d:0>7}.safetensors\x00", .{ self.root, id, pos });
         defer self.allocator.free(path);
+        if (fileSize(self.io, path[0 .. path.len - 1]) == null) return error.DiskCacheNoCheckpoint;
         var tensor_map = mlx.mlx_map_string_to_array_new();
         defer _ = mlx.mlx_map_string_to_array_free(tensor_map);
         var meta_map = mlx.mlx_map_string_to_string_new();
@@ -922,6 +965,26 @@ pub const DiskTier = struct {
         if (mlx.mlx_map_string_to_string_get(&ratio_c, meta_map, "qsa_ratio") == 0) {
             const ratio = std.fmt.parseInt(c_int, std.mem.span(ratio_c), 10) catch return error.DiskCacheCorruptSsm;
             for (layers) |*l| l.qsa_ratio = ratio;
+        }
+        var rows_c: [*:0]const u8 = undefined;
+        if (mlx.mlx_map_string_to_string_get(&rows_c, meta_map, "qsa_rows") == 0) {
+            const rows = std.fmt.parseInt(c_int, std.mem.span(rows_c), 10) catch return error.DiskCacheCorruptSsm;
+            for (layers) |*l| l.qsa_rows = rows;
+        } else {
+            for (layers) |*l| {
+                const probe: transformer_mod.SSMCacheEntry = .{
+                    .conv_state = l.conv_state,
+                    .ssm_state = l.ssm_state,
+                    .aux_state = l.aux_state,
+                    .qsa_pooled = l.qsa_pooled,
+                    .initialized = l.initialized,
+                };
+                if (!transformer_mod.ssmAuxIsQsaHistory(&probe)) continue;
+                if (l.aux_state.ctx != null) {
+                    const sh = mlx.getShape(l.aux_state);
+                    if (sh.len >= 2) l.qsa_rows = sh[1];
+                }
+            }
         }
 
         // `initialized=true` with both states null is a valid shape, so the
@@ -1144,6 +1207,9 @@ pub const DiskTier = struct {
             inherited = linked;
             keep = linked;
         }
+        var inherited_qsa = if (extend_idx) |i| self.entries.items[i].inherited_qsa else false;
+        var inherited_qsa_rows: u32 = if (extend_idx) |i| self.entries.items[i].qsa_history_rows else 0;
+        var inherited_qsa_bytes: u64 = if (extend_idx) |i| self.entries.items[i].qsa_history_bytes else 0;
         // A real check: a rewrite must never land on a link (the sync arm truncates in place).
         if (keep < inherited) {
             var root_dir = std.Io.Dir.openDirAbsolute(self.io, self.root, .{}) catch null;
@@ -1152,6 +1218,13 @@ pub const DiskTier = struct {
             log.warn("  [disk-cache] chunk share: e{d} would rewrite an inherited chunk (keep {d} < inherited {d}) — writing from {d} instead\n", .{ id, keep, inherited, keep });
             inherited = keep;
             if (chunk_sizes.items.len > keep) chunk_sizes.shrinkRetainingCapacity(keep);
+        }
+        if (donor) |d| {
+            if (inherited > 0 and self.linkInheritedQsa(d, id)) {
+                inherited_qsa = true;
+                inherited_qsa_rows = self.entries.items[d.idx].qsa_history_rows;
+                inherited_qsa_bytes = self.entries.items[d.idx].qsa_history_bytes;
+            }
         }
 
         var written_bytes: u64 = 0;
@@ -1184,6 +1257,16 @@ pub const DiskTier = struct {
             return err;
         };
         errdefer ssm_res.deinit(self.allocator);
+        const prefix_rows: u32 = if (donor) |d|
+            @intCast(@min(commonPrefixLen(self.entries.items[d.idx].tokens, tokens), @as(usize, kv_len)))
+        else
+            kv_len;
+        if (inherited_qsa) inherited_qsa_rows = @min(inherited_qsa_rows, prefix_rows);
+        const qsa_res = self.persistQsaHistory(dir_rel, ssm_checkpoints, inherited_qsa, inherited_qsa_rows, prefix_rows, s) catch |err| {
+            ssm_res.deinit(self.allocator);
+            chunk_sizes.deinit(self.allocator);
+            return err;
+        };
         const complete = chunk_complete and ssm_res.complete;
 
         // v4 spec snapshots — one sidecar file, REPLACED wholesale by every
@@ -1217,6 +1300,7 @@ pub const DiskTier = struct {
         // `bytes` is what this entry created on disk: inherited (linked) chunks bill 0.
         var non_chunk: u64 = @as(u64, record.len) * 4 + spec_res.bytes;
         for (ssm_res.bytes) |b| non_chunk += b;
+        if (!qsa_res.inherited) non_chunk += qsa_res.bytes;
         var bytes: u64 = non_chunk;
         for (chunk_sizes.items[@min(inherited, chunk_sizes.items.len)..]) |b| bytes += b;
 
@@ -1234,6 +1318,9 @@ pub const DiskTier = struct {
             .spec_bytes = spec_res.bytes,
             .spec_dflash = spec_res.dflash,
             .spec_mtp = spec_res.mtp,
+            .qsa_history_bytes = if (qsa_res.inherited) inherited_qsa_bytes else qsa_res.bytes,
+            .qsa_history_rows = if (qsa_res.inherited) inherited_qsa_rows else qsa_res.rows,
+            .inherited_qsa = qsa_res.inherited,
             .last_used = self.bump(),
         };
         errdefer {
@@ -1351,9 +1438,11 @@ pub const DiskTier = struct {
         var written_bytes: u64 = 0;
         var ssm_res = try self.persistSsmCheckpoints(e.id, dir_rel, e.kv_len, e.ssm_positions, e.ssm_bytes, ssm_checkpoints, &written_bytes, s);
         errdefer ssm_res.deinit(self.allocator);
+        const qsa_res = try self.persistQsaHistory(dir_rel, ssm_checkpoints, e.inherited_qsa, e.qsa_history_rows, e.kv_len, s);
 
         // Captured before the sidecar write overwrites it: this path bills a delta.
         const old_spec_bytes: u64 = e.spec_bytes;
+        const old_qsa_billed: u64 = if (e.inherited_qsa) 0 else e.qsa_history_bytes;
         if (specWorkPending(e, dflash_snap, mtp_snap)) {
             const spec_res: SpecSidecarResult = self.writeSpecSidecar(dir_rel, dflash_snap, mtp_snap, s) catch |err| blk: {
                 log.warn("  [disk-cache] spec persist failed: {s} — entry keeps its old spec\n", .{@errorName(err)});
@@ -1370,11 +1459,20 @@ pub const DiskTier = struct {
         var delta: i64 = @as(i64, @intCast(e.spec_bytes)) - @as(i64, @intCast(old_spec_bytes));
         for (ssm_res.bytes) |b| delta += @as(i64, @intCast(b));
         for (e.ssm_bytes) |b| delta -= @as(i64, @intCast(b));
+        const new_qsa_billed: u64 = if (qsa_res.inherited) 0 else qsa_res.bytes;
+        delta += @as(i64, @intCast(new_qsa_billed)) - @as(i64, @intCast(old_qsa_billed));
 
         self.allocator.free(e.ssm_positions);
         self.allocator.free(e.ssm_bytes);
         e.ssm_positions = ssm_res.positions;
         e.ssm_bytes = ssm_res.bytes;
+        if (qsa_res.inherited) {
+            e.inherited_qsa = true;
+        } else if (qsa_res.bytes > 0) {
+            e.qsa_history_bytes = qsa_res.bytes;
+            e.qsa_history_rows = qsa_res.rows;
+            e.inherited_qsa = false;
+        }
         e.bytes = clampAdd(e.bytes, delta);
         self.total_bytes = clampAdd(self.total_bytes, delta);
         e.last_used = self.bump();
@@ -2007,12 +2105,23 @@ pub const DiskTier = struct {
         // tensors and `l{d}.ple` = uint32 [9] (valid flag, then the 8 token
         // history slots); the compress ratio is one `qsa_ratio` metadata key.
         var ratio_buf: [16]u8 = undefined;
+        var rows_buf: [16]u8 = undefined;
         var ratio_written = false;
+        var rows_written = false;
         for (cp.layers, 0..) |l, li| {
+            const probe: transformer_mod.SSMCacheEntry = .{
+                .conv_state = l.conv_state,
+                .ssm_state = l.ssm_state,
+                .aux_state = l.aux_state,
+                .qsa_pooled = l.qsa_pooled,
+                .initialized = l.initialized,
+            };
+            const qsa_hist = transformer_mod.ssmAuxIsQsaHistory(&probe);
             const names = .{ "conv", "ssm", "aux", "pooled" };
             const arrs = .{ l.conv_state, l.ssm_state, l.aux_state, l.qsa_pooled };
             inline for (names, arrs) |name, arr| {
-                if (arr.ctx != null) {
+                const skip_qsa = qsa_hist and !test_ssm_write_qsa_aux and (comptime (std.mem.eql(u8, name, "aux") or std.mem.eql(u8, name, "pooled")));
+                if (arr.ctx != null and !skip_qsa) {
                     const key = try std.fmt.allocPrint(self.allocator, "l{d}." ++ name, .{li});
                     errdefer self.allocator.free(key);
                     // The list owns every handle it holds, so a borrowed checkpoint handle is retained first.
@@ -2033,10 +2142,15 @@ pub const DiskTier = struct {
                 errdefer self.allocator.free(key);
                 try list.append(self.allocator, .{ .key = key, .arr = ple_arr });
             }
-            if (!ratio_written and (l.aux_state.ctx != null or l.qsa_pooled.ctx != null)) {
+            if (!ratio_written and (l.qsa_rows > 0 or l.aux_state.ctx != null or l.qsa_pooled.ctx != null)) {
                 const rs = try std.fmt.bufPrint(&ratio_buf, "{d}\x00", .{l.qsa_ratio});
                 try meta.append(self.allocator, .{ .key = "qsa_ratio", .value = rs[0 .. rs.len - 1] });
                 ratio_written = true;
+            }
+            if (!rows_written and l.qsa_rows > 0) {
+                const rs = try std.fmt.bufPrint(&rows_buf, "{d}\x00", .{l.qsa_rows});
+                try meta.append(self.allocator, .{ .key = "qsa_rows", .value = rs[0 .. rs.len - 1] });
+                rows_written = true;
             }
         }
 
@@ -2071,6 +2185,204 @@ pub const DiskTier = struct {
         defer self.allocator.free(path);
         try mlx.check(mlx.mlx_save_safetensors(@ptrCast(path.ptr), tensor_map, meta_map));
         return fileSize(self.io, path[0 .. path.len - 1]) orelse 0;
+    }
+
+    fn qsaHistoryRowsOf(cp: *const transformer_mod.SSMCheckpoint) c_int {
+        var r: c_int = 0;
+        for (cp.layers) |l| {
+            if (l.qsa_rows > r) r = l.qsa_rows;
+            const probe: transformer_mod.SSMCacheEntry = .{
+                .conv_state = l.conv_state,
+                .ssm_state = l.ssm_state,
+                .aux_state = l.aux_state,
+                .qsa_pooled = l.qsa_pooled,
+                .initialized = l.initialized,
+            };
+            if (!transformer_mod.ssmAuxIsQsaHistory(&probe)) continue;
+            if (l.aux_state.ctx != null) {
+                const sh = mlx.getShape(l.aux_state);
+                if (sh.len >= 2 and sh[1] > r) r = sh[1];
+            }
+        }
+        return r;
+    }
+
+    fn newestQsaCheckpoint(cps: []const transformer_mod.SSMCheckpoint) ?*const transformer_mod.SSMCheckpoint {
+        var i = cps.len;
+        while (i > 0) {
+            i -= 1;
+            if (transformer_mod.checkpointHasQsaHistory(&cps[i])) return &cps[i];
+        }
+        return null;
+    }
+
+    const QsaHistoryResult = struct { bytes: u64 = 0, rows: u32 = 0, inherited: bool = false };
+
+    fn writeQsaHistoryFile(
+        self: *DiskTier,
+        dir_rel: []const u8,
+        cp: *const transformer_mod.SSMCheckpoint,
+        s: mlx.mlx_stream,
+    ) !u64 {
+        var list = std.ArrayList(NamedTensor).empty;
+        defer self.freeNamed(&list);
+        var meta = std.ArrayList(MetaPair).empty;
+        defer meta.deinit(self.allocator);
+        var ratio_buf: [16]u8 = undefined;
+        var rows_buf: [16]u8 = undefined;
+        var ratio_written = false;
+        const rows = DiskTier.qsaHistoryRowsOf(cp);
+        if (rows > 0) {
+            const rs = try std.fmt.bufPrint(&rows_buf, "{d}\x00", .{rows});
+            try meta.append(self.allocator, .{ .key = "qsa_rows", .value = rs[0 .. rs.len - 1] });
+        }
+        for (cp.layers, 0..) |l, li| {
+            const names = .{ "aux", "pooled" };
+            const arrs = .{ l.aux_state, l.qsa_pooled };
+            inline for (names, arrs) |name, arr| {
+                if (arr.ctx != null) {
+                    const key = try std.fmt.allocPrint(self.allocator, "l{d}." ++ name, .{li});
+                    errdefer self.allocator.free(key);
+                    var owned = mlx.mlx_array_new();
+                    errdefer _ = mlx.mlx_array_free(owned);
+                    try mlx.check(mlx.mlx_array_set(&owned, arr));
+                    try list.append(self.allocator, .{ .key = key, .arr = owned });
+                }
+            }
+            if (!ratio_written and (l.aux_state.ctx != null or l.qsa_pooled.ctx != null)) {
+                const rs = try std.fmt.bufPrint(&ratio_buf, "{d}\x00", .{l.qsa_ratio});
+                try meta.append(self.allocator, .{ .key = "qsa_ratio", .value = rs[0 .. rs.len - 1] });
+                ratio_written = true;
+            }
+        }
+        if (list.items.len == 0) return 0;
+        if (self.writer) |w| {
+            const path = try std.fmt.allocPrint(self.allocator, "{s}/qsa.safetensors", .{dir_rel});
+            const bytes = self.serializeSafetensors(list.items, meta.items, s) catch |err| {
+                self.allocator.free(path);
+                return err;
+            };
+            const n = bytes.len;
+            w.submit(path, bytes);
+            return n;
+        }
+        const tensor_map = mlx.mlx_map_string_to_array_new();
+        defer _ = mlx.mlx_map_string_to_array_free(tensor_map);
+        const meta_map = mlx.mlx_map_string_to_string_new();
+        defer _ = mlx.mlx_map_string_to_string_free(meta_map);
+        for (meta.items) |m| {
+            const kz = try std.fmt.allocPrint(self.allocator, "{s}\x00", .{m.key});
+            defer self.allocator.free(kz);
+            const vz = try std.fmt.allocPrint(self.allocator, "{s}\x00", .{m.value});
+            defer self.allocator.free(vz);
+            try mlx.check(mlx.mlx_map_string_to_string_insert(meta_map, @ptrCast(kz.ptr), @ptrCast(vz.ptr)));
+        }
+        for (list.items) |*t| {
+            const kz = try std.fmt.allocPrint(self.allocator, "{s}\x00", .{t.key});
+            defer self.allocator.free(kz);
+            try mlx.check(mlx.mlx_map_string_to_array_insert(tensor_map, @ptrCast(kz.ptr), t.arr));
+        }
+        const path = try std.fmt.allocPrint(self.allocator, "{s}/qsa.safetensors\x00", .{dir_rel});
+        defer self.allocator.free(path);
+        try mlx.check(mlx.mlx_save_safetensors(@ptrCast(path.ptr), tensor_map, meta_map));
+        return fileSize(self.io, path[0 .. path.len - 1]) orelse 0;
+    }
+
+    fn loadQsaHistoryFile(self: *DiskTier, id: u64, n_layers: usize) !transformer_mod.SSMCheckpoint {
+        const cpu = mlx.mlx_default_cpu_stream_new();
+        defer _ = mlx.mlx_stream_free(cpu);
+        const path = try std.fmt.allocPrint(self.allocator, "{s}/e{d}/qsa.safetensors\x00", .{ self.root, id });
+        defer self.allocator.free(path);
+        if (fileSize(self.io, path[0 .. path.len - 1]) == null) return error.DiskCacheNoCheckpoint;
+        var tensor_map = mlx.mlx_map_string_to_array_new();
+        defer _ = mlx.mlx_map_string_to_array_free(tensor_map);
+        var meta_map = mlx.mlx_map_string_to_string_new();
+        defer _ = mlx.mlx_map_string_to_string_free(meta_map);
+        try mlx.check(mlx.mlx_load_safetensors(&tensor_map, &meta_map, @ptrCast(path.ptr), cpu));
+
+        const layers = try self.allocator.alloc(transformer_mod.SSMCacheEntrySnapshot, n_layers);
+        for (layers) |*l| l.* = .{
+            .conv_state = mlx.mlx_array_new(),
+            .ssm_state = mlx.mlx_array_new(),
+            .initialized = false,
+        };
+        var cp: transformer_mod.SSMCheckpoint = .{ .pos = 0, .layers = layers };
+        errdefer cp.deinit(self.allocator);
+        for (layers, 0..) |*l, li| {
+            const akey = try std.fmt.allocPrint(self.allocator, "l{d}.aux\x00", .{li});
+            defer self.allocator.free(akey);
+            var aux = mlx.mlx_array_new();
+            if (mlx.mlx_map_string_to_array_get(&aux, tensor_map, @ptrCast(akey.ptr)) == 0) {
+                l.aux_state = aux;
+            } else {
+                _ = mlx.mlx_array_free(aux);
+            }
+            const pkey = try std.fmt.allocPrint(self.allocator, "l{d}.pooled\x00", .{li});
+            defer self.allocator.free(pkey);
+            var pooled = mlx.mlx_array_new();
+            if (mlx.mlx_map_string_to_array_get(&pooled, tensor_map, @ptrCast(pkey.ptr)) == 0) {
+                l.qsa_pooled = pooled;
+            } else {
+                _ = mlx.mlx_array_free(pooled);
+            }
+        }
+        var ratio_c: [*:0]const u8 = undefined;
+        if (mlx.mlx_map_string_to_string_get(&ratio_c, meta_map, "qsa_ratio") == 0) {
+            const ratio = std.fmt.parseInt(c_int, std.mem.span(ratio_c), 10) catch return error.DiskCacheCorruptSsm;
+            for (layers) |*l| l.qsa_ratio = ratio;
+        }
+        var rows_c: [*:0]const u8 = undefined;
+        if (mlx.mlx_map_string_to_string_get(&rows_c, meta_map, "qsa_rows") == 0) {
+            const rows = std.fmt.parseInt(c_int, std.mem.span(rows_c), 10) catch return error.DiskCacheCorruptSsm;
+            for (layers) |*l| l.qsa_rows = rows;
+            cp.pos = @intCast(rows);
+        } else {
+            cp.pos = @intCast(DiskTier.qsaHistoryRowsOf(&cp));
+        }
+        {
+            const vec = mlx.mlx_vector_array_new();
+            defer _ = mlx.mlx_vector_array_free(vec);
+            var count: usize = 0;
+            for (layers) |*l| {
+                inline for (.{ l.aux_state, l.qsa_pooled }) |arr| {
+                    if (arr.ctx != null) {
+                        _ = mlx.mlx_vector_array_append_value(vec, arr);
+                        count += 1;
+                    }
+                }
+            }
+            if (count > 0) try mlx.check(mlx.mlx_eval(vec));
+        }
+        if (!transformer_mod.checkpointHasQsaHistory(&cp)) return error.DiskCacheNoCheckpoint;
+        return cp;
+    }
+
+    fn persistQsaHistory(
+        self: *DiskTier,
+        dir_rel: []const u8,
+        cps_opt: ?[]const transformer_mod.SSMCheckpoint,
+        inherited: bool,
+        inherited_rows: u32,
+        prefix_rows: u32,
+        s: mlx.mlx_stream,
+    ) !QsaHistoryResult {
+        const cps = cps_opt orelse return .{ .inherited = inherited, .rows = inherited_rows, .bytes = 0 };
+        const src = DiskTier.newestQsaCheckpoint(cps) orelse {
+            if (inherited) return .{ .inherited = true, .rows = inherited_rows, .bytes = 0 };
+            return .{};
+        };
+        const rows: u32 = @intCast(DiskTier.qsaHistoryRowsOf(src));
+        if (inherited and rows > 0 and rows <= inherited_rows and rows <= prefix_rows) {
+            return .{ .inherited = true, .rows = @min(inherited_rows, prefix_rows), .bytes = 0 };
+        }
+        if (inherited) {
+            const qpath = try std.fmt.allocPrint(self.allocator, "{s}/qsa.safetensors", .{dir_rel});
+            defer self.allocator.free(qpath);
+            if (self.writer) |w| w.fence(qpath);
+            std.Io.Dir.deleteFileAbsolute(self.io, qpath) catch {};
+        }
+        const bytes = try self.writeQsaHistoryFile(dir_rel, src, s);
+        return .{ .bytes = bytes, .rows = rows, .inherited = false };
     }
 
     fn deleteSsmFile(self: *DiskTier, id: u64, pos: u32) void {
@@ -2126,7 +2438,20 @@ pub const DiskTier = struct {
         const dir_abs = std.fmt.allocPrint(self.allocator, "{s}/e{d}/", .{ self.root, e.id }) catch return e.bytes;
         defer self.allocator.free(dir_abs);
         if (self.writer) |w| w.fence(dir_abs);
-        var freed: u64 = nonChunkBytes(e);
+        var freed: u64 = @as(u64, e.tokens.len) * 4 + e.spec_bytes;
+        for (e.ssm_bytes) |b| freed += b;
+        if (e.qsa_history_bytes > 0) {
+            if (std.fmt.allocPrint(self.allocator, "{s}qsa.safetensors", .{dir_abs})) |qp| {
+                defer self.allocator.free(qp);
+                if (statFile(self.io, qp)) |st| {
+                    if (st.nlink <= 1) freed += st.size;
+                } else if (!e.inherited_qsa) {
+                    freed += e.qsa_history_bytes;
+                }
+            } else |_| {
+                if (!e.inherited_qsa) freed += e.qsa_history_bytes;
+            }
+        }
         for (e.chunk_bytes, 0..) |cb, i| {
             const cp = std.fmt.allocPrint(self.allocator, "{s}c{d:0>6}.safetensors", .{ dir_abs, i }) catch {
                 freed += cb;
@@ -2194,6 +2519,26 @@ pub const DiskTier = struct {
         mb /= 1024.0 * 1024.0;
         log.info("  [disk-cache] chunk share: e{d} inherits {d} chunks ({d:.1} MB) from e{d} by hard link\n", .{ id, linked, mb, d.id });
         return linked;
+    }
+
+    fn linkInheritedQsa(self: *DiskTier, d: ChunkDonor, id: u64) bool {
+        const donor = &self.entries.items[d.idx];
+        if (donor.qsa_history_bytes == 0 or donor.qsa_history_rows == 0) return false;
+        const old_abs = std.fmt.allocPrint(self.allocator, "{s}/e{d}/qsa.safetensors", .{ self.root, d.id }) catch return false;
+        defer self.allocator.free(old_abs);
+        if (!self.chunkLanded(old_abs, donor.qsa_history_bytes)) return false;
+        var root_dir = std.Io.Dir.openDirAbsolute(self.io, self.root, .{}) catch return false;
+        defer root_dir.close(self.io);
+        const old_sub = std.fmt.allocPrint(self.allocator, "e{d}/qsa.safetensors", .{d.id}) catch return false;
+        defer self.allocator.free(old_sub);
+        const new_sub = std.fmt.allocPrint(self.allocator, "e{d}/qsa.safetensors", .{id}) catch return false;
+        defer self.allocator.free(new_sub);
+        std.Io.Dir.hardLink(root_dir, old_sub, root_dir, new_sub, self.io, .{}) catch |err| {
+            log.warn("  [disk-cache] chunk share: link e{d}/qsa -> e{d} failed: {s} — writing the history instead\n", .{ d.id, id, @errorName(err) });
+            return false;
+        };
+        log.info("  [disk-cache] chunk share: e{d} inherits qsa history from e{d} by hard link\n", .{ id, d.id });
+        return true;
     }
 
     /// Has a chunk file landed: final name, recorded size, and no write to it queued or in flight?
@@ -2277,6 +2622,7 @@ pub const DiskTier = struct {
     /// claim: an older reader accepts only 2..4, so stamping v6 unconditionally made a binary
     /// downgrade discard the whole tier. v6 = inherited chunks, v5 = the MTP head's QSA half.
     fn metaVersionFor(e: IndexEntry) u8 {
+        if (e.qsa_history_rows > 0 or e.qsa_history_bytes > 0) return 7;
         if (e.inherited_chunks > 0) return 6;
         if (e.spec_mtp) |m| if (m.head != null) return 5;
         return 4;
@@ -2312,6 +2658,13 @@ pub const DiskTier = struct {
             try out.print(a, "{{\"pos\":{d},\"bytes\":{d}}}", .{ pos, sz });
         }
         try out.appendSlice(a, "]");
+        if (e.qsa_history_rows > 0 or e.qsa_history_bytes > 0) {
+            try out.print(a, ",\"qsa_history\":{{\"bytes\":{d},\"rows\":{d},\"inherited\":{}}}", .{
+                e.qsa_history_bytes,
+                e.qsa_history_rows,
+                e.inherited_qsa,
+            });
+        }
         // v4: spec snapshots (dflash context / MTP history); a size mismatch drops only the spec.
         if (e.spec_bytes > 0 and (e.spec_dflash != null or e.spec_mtp != null)) {
             try out.print(a, ",\"spec\":{{\"bytes\":{d}", .{e.spec_bytes});
@@ -2382,7 +2735,29 @@ pub const DiskTier = struct {
     /// Re-bill a scanned entry's chunk files against the inodes already counted this scan: the
     /// first entry to see an inode pays for it.
     fn billChunksOnce(self: *DiskTier, e: *IndexEntry, seen: *std.AutoHashMap(u64, void)) void {
-        var billed: u64 = nonChunkBytes(e);
+        var billed: u64 = @as(u64, e.tokens.len) * 4 + e.spec_bytes;
+        for (e.ssm_bytes) |b| billed += b;
+        if (e.qsa_history_bytes > 0) {
+            if (std.fmt.allocPrint(self.allocator, "{s}/e{d}/qsa.safetensors", .{ self.root, e.id })) |qp| {
+                defer self.allocator.free(qp);
+                if (statFile(self.io, qp)) |st| {
+                    if (st.nlink <= 1) {
+                        billed += st.size;
+                    } else {
+                        const ino: u64 = @intCast(st.inode);
+                        if (seen.getOrPut(ino)) |gop| {
+                            if (!gop.found_existing) billed += st.size;
+                        } else |_| {
+                            billed += st.size;
+                        }
+                    }
+                } else if (!e.inherited_qsa) {
+                    billed += e.qsa_history_bytes;
+                }
+            } else |_| {
+                if (!e.inherited_qsa) billed += e.qsa_history_bytes;
+            }
+        }
         for (e.chunk_bytes, 0..) |cb, i| {
             const cp = std.fmt.allocPrint(self.allocator, "{s}/e{d}/c{d:0>6}.safetensors", .{ self.root, e.id, i }) catch {
                 billed += cb;
@@ -2424,7 +2799,7 @@ pub const DiskTier = struct {
         // v2 = pure-attention (no ssm field); v3 adds SSM checkpoints; v4
         // adds optional spec snapshots; v5 the qwen4_exp MTP head's QSA half; v6 inherited
         // chunks. All restore; a lower-version entry just carries none of the newer state.
-        if (version < 2 or version > 6) return null;
+        if (version < 2 or version > 7) return null;
         // v6: the leading `inherited_chunks` chunk files are hard links into a donor's.
         const inherited_rec: u64 = jsonU64(obj, "inherited_chunks") orelse 0;
         var kv_len = jsonU64(obj, "kv_len") orelse return null;
@@ -2588,6 +2963,28 @@ pub const DiskTier = struct {
             return null;
         }
 
+        var qsa_history_bytes: u64 = 0;
+        var qsa_history_rows: u32 = 0;
+        var inherited_qsa = false;
+        if (obj.get("qsa_history")) |qh_v| qh_blk: {
+            if (qh_v != .object) break :qh_blk;
+            const qo = qh_v.object;
+            const rec_bytes = jsonU64(qo, "bytes") orelse break :qh_blk;
+            const rec_rows = jsonU64(qo, "rows") orelse break :qh_blk;
+            const inh_v = qo.get("inherited");
+            inherited_qsa = inh_v != null and inh_v.? == .bool and inh_v.?.bool;
+            const qp = std.fmt.allocPrint(self.allocator, "{s}/e{d}/qsa.safetensors", .{ self.root, id }) catch break :qh_blk;
+            defer self.allocator.free(qp);
+            const have = fileSize(self.io, qp) orelse break :qh_blk;
+            if (have != rec_bytes) {
+                log.info("  [disk-cache] e{d}: qsa history size mismatch — dropping the history\n", .{id});
+                break :qh_blk;
+            }
+            qsa_history_bytes = rec_bytes;
+            qsa_history_rows = @intCast(rec_rows);
+            if (!inherited_qsa) total += rec_bytes;
+        }
+
         // v4 spec snapshots: validated by recorded file size (kill -9
         // salvage), but a bad spec drops only the SPEC — a restore then
         // starts blind, which is today's v2/v3 behavior anyway.
@@ -2627,6 +3024,9 @@ pub const DiskTier = struct {
                 .spec_bytes = spec_bytes,
                 .spec_dflash = spec_dflash,
                 .spec_mtp = spec_mtp,
+                .qsa_history_bytes = qsa_history_bytes,
+                .qsa_history_rows = qsa_history_rows,
+                .inherited_qsa = inherited_qsa,
                 .last_used = 0,
             },
             .mtime = stat.mtime.nanoseconds,
@@ -2808,6 +3208,7 @@ pub fn defaultBaseDir(allocator: std.mem.Allocator) ![]u8 {
 fn nonChunkBytes(e: *const IndexEntry) u64 {
     var n: u64 = @as(u64, e.tokens.len) * 4 + e.spec_bytes;
     for (e.ssm_bytes) |b| n += b;
+    if (!e.inherited_qsa) n += e.qsa_history_bytes;
     return n;
 }
 
@@ -3483,8 +3884,8 @@ test "DiskTier: hybrid entry round-trips SSM checkpoints (Phase 3)" {
     defer freeHybridEntries(&src256);
     // Layer 2 at 256 also carries qwen4_exp aux state: a QSA key history +
     // pooled block keys, and layer 1 the PLE token history.
-    const aux_shape = [_]c_int{ 1, 12, 4 };
-    const pooled_shape = [_]c_int{ 1, 3, 4 };
+    const aux_shape = [_]c_int{ 1, 256, 4 };
+    const pooled_shape = [_]c_int{ 1, 64, 4 };
     src256[2].aux_state = makeArange(s, &aux_shape, 700.0);
     src256[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
     src256[2].qsa_ratio = 4;
@@ -3569,6 +3970,670 @@ test "DiskTier: hybrid entry round-trips SSM checkpoints (Phase 3)" {
 
     // A position that was never checkpointed is rejected, not silently served.
     try testing.expectError(error.DiskCacheNoCheckpoint, tier2.restoreIntoHybrid(&cache3, &dst2, 0, 200, s));
+}
+
+fn stAuxPooledBytes(allocator: std.mem.Allocator, io: std.Io, path: []const u8) !struct { aux: u64, pooled: u64 } {
+    const raw = readFileAlloc(allocator, io, path, 4 * 1024 * 1024) orelse return error.TestUnexpectedResult;
+    defer allocator.free(raw);
+    if (raw.len < 8) return error.TestUnexpectedResult;
+    const hdr_len = std.mem.readInt(u64, raw[0..8], .little);
+    if (8 + hdr_len > raw.len) return error.TestUnexpectedResult;
+    const hdr = raw[8 .. 8 + hdr_len];
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, hdr, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.TestUnexpectedResult;
+    var aux: u64 = 0;
+    var pooled: u64 = 0;
+    var it = parsed.value.object.iterator();
+    while (it.next()) |e| {
+        if (std.mem.eql(u8, e.key_ptr.*, "__metadata__")) continue;
+        if (e.value_ptr.* != .object) continue;
+        const o = e.value_ptr.*.object;
+        const dtype = if (o.get("dtype")) |d| d.string else continue;
+        const shape_v = o.get("shape") orelse continue;
+        if (shape_v != .array) continue;
+        var el: u64 = 1;
+        for (shape_v.array.items) |x| {
+            if (x != .integer) continue;
+            el *= @intCast(x.integer);
+        }
+        const b: u64 = el * switch (dtype[0]) {
+            'F' => if (dtype.len > 1 and dtype[1] == '3') @as(u64, 4) else 2,
+            'B' => 2,
+            'U', 'I' => if (dtype.len > 1 and dtype[1] == '8') @as(u64, 1) else 4,
+            else => 1,
+        };
+        if (std.mem.indexOf(u8, e.key_ptr.*, ".aux") != null) aux += b;
+        if (std.mem.indexOf(u8, e.key_ptr.*, ".pooled") != null) pooled += b;
+    }
+    return .{ .aux = aux, .pooled = pooled };
+}
+
+test "DiskTier: QSA history bytes are O(rows), not O(checkpoints x rows)" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    var tier = try DiskTier.init(testing.allocator, io, base, "fp-qsa-once", 0, 128);
+    defer tier.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    var tokens: [600]u32 = undefined;
+    for (&tokens, 0..) |*t, i| t.* = @intCast(i + 7);
+
+    const aux_shape = [_]c_int{ 1, 256, 8 };
+    const pooled_shape = [_]c_int{ 1, 64, 8 };
+    var src = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&src);
+    src[2].aux_state = makeArange(s, &aux_shape, 700.0);
+    src[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
+    src[2].qsa_ratio = 4;
+    var cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 128, s),
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 256, s),
+    };
+    defer for (&cps) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&cps, &src, s);
+
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &cps, s);
+
+    const s128 = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}/s0000128.safetensors", .{ tier.root, tier.entries.items[0].id });
+    defer testing.allocator.free(s128);
+    const s256 = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}/s0000256.safetensors", .{ tier.root, tier.entries.items[0].id });
+    defer testing.allocator.free(s256);
+    const qsa_path = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}/qsa.safetensors", .{ tier.root, tier.entries.items[0].id });
+    defer testing.allocator.free(qsa_path);
+    const a128 = try stAuxPooledBytes(testing.allocator, io, s128);
+    const a256 = try stAuxPooledBytes(testing.allocator, io, s256);
+    try testing.expectEqual(@as(u64, 0), a128.aux + a128.pooled);
+    try testing.expectEqual(@as(u64, 0), a256.aux + a256.pooled);
+    const hq = try stAuxPooledBytes(testing.allocator, io, qsa_path);
+    const one: u64 = 256 * 8 * 4 + 64 * 8 * 4;
+    try testing.expectEqual(one, hq.aux + hq.pooled);
+
+    var tier2 = try DiskTier.init(testing.allocator, io, base, "fp-qsa-once", 0, 128);
+    defer tier2.deinit();
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var dst: [3]SSMCacheEntry = .{
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+    };
+    defer freeHybridEntries(&dst);
+    try testing.expectEqual(@as(u32, 128), try tier2.restoreIntoHybrid(&cache2, &dst, 0, 128, s));
+    try testing.expectEqual(@as(c_int, 128), mlx.getShape(dst[2].aux_state)[1]);
+    try testing.expectEqual(@as(c_int, 32), mlx.getShape(dst[2].qsa_pooled)[1]);
+    try testing.expectEqual(@as(f32, 700.0 + 5.0), ssmArrVal(dst[2].aux_state, 5, s));
+}
+
+test "DiskTier: a GDN-layer aux window is persisted in the checkpoint file" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    var tier = try DiskTier.init(testing.allocator, io, base, "fp-ple-aux", 0, 128);
+    defer tier.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    var tokens: [600]u32 = undefined;
+    for (&tokens, 0..) |*t, i| t.* = @intCast(i + 7);
+
+    var src = buildHybridEntries(s, 100.0, 500.0);
+    defer freeHybridEntries(&src);
+    const ple_shape = [_]c_int{ 1, 3, 8 };
+    src[0].aux_state = makeArange(s, &ple_shape, 900.0);
+    var cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 128, s),
+    };
+    defer for (&cps) |*cp| cp.deinit(testing.allocator);
+    try testing.expect(cps[0].layers[0].aux_state.ctx != null);
+    try testing.expect(!transformer_mod.checkpointHasQsaHistory(&cps[0]));
+
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &cps, s);
+    const sp = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}/s0000128.safetensors", .{ tier.root, tier.entries.items[0].id });
+    defer testing.allocator.free(sp);
+    const fam = try stAuxPooledBytes(testing.allocator, io, sp);
+    try testing.expectEqual(@as(u64, 3 * 8 * 4), fam.aux);
+
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var dst: [3]SSMCacheEntry = .{
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+    };
+    defer freeHybridEntries(&dst);
+    try testing.expectEqual(@as(u32, 128), try tier.restoreIntoHybrid(&cache2, &dst, 0, 128, s));
+    try testing.expectEqual(@as(f32, 900.0), ssmArrVal(dst[0].aux_state, 0, s));
+    try testing.expectEqual(@as(f32, 900.0 + 23.0), ssmArrVal(dst[0].aux_state, 23, s));
+}
+
+test "DiskTier: a pre-v7 interior restore overlays QSA history from the latest s* file" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    var tier = try DiskTier.init(testing.allocator, io, base, "fp-prev7", 0, 128);
+    defer tier.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    var tokens: [600]u32 = undefined;
+    for (&tokens, 0..) |*t, i| t.* = @intCast(i + 7);
+
+    var src128 = buildHybridEntries(s, 100.0, 500.0);
+    defer freeHybridEntries(&src128);
+    var src256 = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&src256);
+    const aux_shape = [_]c_int{ 1, 256, 8 };
+    const pooled_shape = [_]c_int{ 1, 64, 8 };
+    src256[2].aux_state = makeArange(s, &aux_shape, 700.0);
+    src256[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
+    src256[2].qsa_ratio = 4;
+    var cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src128, 128, s),
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src256, 256, s),
+    };
+    defer for (&cps) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&cps, &src256, s);
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &cps, s);
+
+    const id = tier.entries.items[0].id;
+    var latest = try tier.loadSsmFile(id, 256, 3);
+    defer latest.deinit(testing.allocator);
+    var qsa = try tier.loadQsaHistoryFile(id, 3);
+    defer qsa.deinit(testing.allocator);
+    for (latest.layers, qsa.layers) |*l, q| {
+        if (q.aux_state.ctx != null) {
+            if (l.aux_state.ctx != null) _ = mlx.mlx_array_free(l.aux_state);
+            l.aux_state = mlx.mlx_array_new();
+            try mlx.check(mlx.mlx_array_set(&l.aux_state, q.aux_state));
+        }
+        if (q.qsa_pooled.ctx != null) {
+            if (l.qsa_pooled.ctx != null) _ = mlx.mlx_array_free(l.qsa_pooled);
+            l.qsa_pooled = mlx.mlx_array_new();
+            try mlx.check(mlx.mlx_array_set(&l.qsa_pooled, q.qsa_pooled));
+        }
+        l.qsa_ratio = q.qsa_ratio;
+    }
+    const dir_rel = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}", .{ tier.root, id });
+    defer testing.allocator.free(dir_rel);
+    var interior = try transformer_mod.captureSsmCheckpoint(testing.allocator, &src128, 128, s);
+    defer interior.deinit(testing.allocator);
+    _ = try tier.writeSsmFile(dir_rel, &interior, s);
+    test_ssm_write_qsa_aux = true;
+    defer test_ssm_write_qsa_aux = false;
+    _ = try tier.writeSsmFile(dir_rel, &latest, s);
+    const qsa_path = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}/qsa.safetensors", .{ tier.root, id });
+    defer testing.allocator.free(qsa_path);
+    try std.Io.Dir.deleteFileAbsolute(io, qsa_path);
+    tier.entries.items[0].qsa_history_bytes = 0;
+    tier.entries.items[0].qsa_history_rows = 0;
+    tier.entries.items[0].inherited_qsa = false;
+    try tier.writeMeta(tier.entries.items[0]);
+
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var dst: [3]SSMCacheEntry = .{
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+    };
+    defer freeHybridEntries(&dst);
+    try testing.expectEqual(@as(u32, 128), try tier.restoreIntoHybrid(&cache2, &dst, 0, 128, s));
+    try testing.expect(transformer_mod.entriesHaveQsaHistory(&dst));
+    try testing.expectEqual(@as(c_int, 128), mlx.getShape(dst[2].aux_state)[1]);
+    try testing.expectEqual(@as(f32, 700.0 + 5.0), ssmArrVal(dst[2].aux_state, 5, s));
+}
+
+test "DiskTier: a pre-v7 interior restore misses when the latest s* file is gone" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    var tier = try DiskTier.init(testing.allocator, io, base, "fp-prev7-miss", 0, 128);
+    defer tier.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    var tokens: [600]u32 = undefined;
+    for (&tokens, 0..) |*t, i| t.* = @intCast(i + 7);
+
+    var src128 = buildHybridEntries(s, 100.0, 500.0);
+    defer freeHybridEntries(&src128);
+    var src256 = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&src256);
+    const aux_shape = [_]c_int{ 1, 256, 8 };
+    const pooled_shape = [_]c_int{ 1, 64, 8 };
+    src256[2].aux_state = makeArange(s, &aux_shape, 700.0);
+    src256[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
+    src256[2].qsa_ratio = 4;
+    var cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src128, 128, s),
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src256, 256, s),
+    };
+    defer for (&cps) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&cps, &src256, s);
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &cps, s);
+
+    const id = tier.entries.items[0].id;
+    var latest = try tier.loadSsmFile(id, 256, 3);
+    defer latest.deinit(testing.allocator);
+    var qsa = try tier.loadQsaHistoryFile(id, 3);
+    defer qsa.deinit(testing.allocator);
+    for (latest.layers, qsa.layers) |*l, q| {
+        if (q.aux_state.ctx != null) {
+            if (l.aux_state.ctx != null) _ = mlx.mlx_array_free(l.aux_state);
+            l.aux_state = mlx.mlx_array_new();
+            try mlx.check(mlx.mlx_array_set(&l.aux_state, q.aux_state));
+        }
+        if (q.qsa_pooled.ctx != null) {
+            if (l.qsa_pooled.ctx != null) _ = mlx.mlx_array_free(l.qsa_pooled);
+            l.qsa_pooled = mlx.mlx_array_new();
+            try mlx.check(mlx.mlx_array_set(&l.qsa_pooled, q.qsa_pooled));
+        }
+        l.qsa_ratio = q.qsa_ratio;
+    }
+    const dir_rel = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}", .{ tier.root, id });
+    defer testing.allocator.free(dir_rel);
+    var interior = try transformer_mod.captureSsmCheckpoint(testing.allocator, &src128, 128, s);
+    defer interior.deinit(testing.allocator);
+    _ = try tier.writeSsmFile(dir_rel, &interior, s);
+    test_ssm_write_qsa_aux = true;
+    defer test_ssm_write_qsa_aux = false;
+    _ = try tier.writeSsmFile(dir_rel, &latest, s);
+    const qsa_path = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}/qsa.safetensors", .{ tier.root, id });
+    defer testing.allocator.free(qsa_path);
+    try std.Io.Dir.deleteFileAbsolute(io, qsa_path);
+    const latest_path = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}/s0000256.safetensors", .{ tier.root, id });
+    defer testing.allocator.free(latest_path);
+    try std.Io.Dir.deleteFileAbsolute(io, latest_path);
+    tier.entries.items[0].qsa_history_bytes = 0;
+    tier.entries.items[0].qsa_history_rows = 0;
+    tier.entries.items[0].inherited_qsa = false;
+    try tier.writeMeta(tier.entries.items[0]);
+
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var dst: [3]SSMCacheEntry = .{
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+    };
+    defer freeHybridEntries(&dst);
+    try testing.expectError(error.DiskCacheQsaHistoryGap, tier.restoreIntoHybrid(&cache2, &dst, 0, 128, s));
+    try testing.expectEqual(@as(usize, 0), cache2.step);
+    try testing.expect(dst[2].aux_state.ctx == null);
+}
+
+test "DiskTier: a v7 entry with missing or short qsa.safetensors misses before KV/SSM adopt" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    var tokens: [600]u32 = undefined;
+    for (&tokens, 0..) |*t, i| t.* = @intCast(i + 7);
+
+    const aux_shape = [_]c_int{ 1, 256, 8 };
+    const pooled_shape = [_]c_int{ 1, 64, 8 };
+    var src = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&src);
+    src[2].aux_state = makeArange(s, &aux_shape, 700.0);
+    src[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
+    src[2].qsa_ratio = 4;
+    var cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 128, s),
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 256, s),
+    };
+    defer for (&cps) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&cps, &src, s);
+
+    {
+        var tier = try DiskTier.init(testing.allocator, io, base, "fp-qsa-gap", 0, 128);
+        defer tier.deinit();
+        _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &cps, s);
+        const id = tier.entries.items[0].id;
+        const qsa_path = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}/qsa.safetensors", .{ tier.root, id });
+        defer testing.allocator.free(qsa_path);
+        try std.Io.Dir.deleteFileAbsolute(io, qsa_path);
+
+        var cache2 = try KVCache.init(testing.allocator, 3);
+        defer cache2.deinit();
+        var dst: [3]SSMCacheEntry = .{
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        };
+        defer freeHybridEntries(&dst);
+        try testing.expectError(error.DiskCacheQsaHistoryGap, tier.restoreIntoHybrid(&cache2, &dst, 0, 128, s));
+        try testing.expectEqual(@as(usize, 0), cache2.step);
+        try testing.expect(dst[2].aux_state.ctx == null);
+    }
+
+    {
+        var tier = try DiskTier.init(testing.allocator, io, base, "fp-qsa-short", 0, 128);
+        defer tier.deinit();
+        _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &cps, s);
+        const id = tier.entries.items[0].id;
+        var src64 = buildHybridEntries(s, 200.0, 600.0);
+        defer freeHybridEntries(&src64);
+        const aux64 = [_]c_int{ 1, 64, 8 };
+        const pooled64 = [_]c_int{ 1, 16, 8 };
+        src64[2].aux_state = makeArange(s, &aux64, 700.0);
+        src64[2].qsa_pooled = makeArange(s, &pooled64, 800.0);
+        src64[2].qsa_ratio = 4;
+        var cps64 = [_]transformer_mod.SSMCheckpoint{
+            try transformer_mod.captureSsmCheckpoint(testing.allocator, &src64, 64, s),
+        };
+        defer for (&cps64) |*cp| cp.deinit(testing.allocator);
+        try transformer_mod.attachQsaHistoryToLatest(&cps64, &src64, s);
+        const dir_rel = try std.fmt.allocPrint(testing.allocator, "{s}/e{d}", .{ tier.root, id });
+        defer testing.allocator.free(dir_rel);
+        _ = try tier.writeQsaHistoryFile(dir_rel, &cps64[0], s);
+
+        var cache2 = try KVCache.init(testing.allocator, 3);
+        defer cache2.deinit();
+        var dst: [3]SSMCacheEntry = .{
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        };
+        defer freeHybridEntries(&dst);
+        try testing.expectError(error.DiskCacheQsaHistoryGap, tier.restoreIntoHybrid(&cache2, &dst, 0, 128, s));
+        try testing.expectEqual(@as(usize, 0), cache2.step);
+        try testing.expect(dst[2].aux_state.ctx == null);
+    }
+
+    {
+        var tier = try DiskTier.init(testing.allocator, io, base, "fp-qsa-wt", 0, 128);
+        defer tier.deinit();
+        var wt_cps = [_]transformer_mod.SSMCheckpoint{
+            try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 128, s),
+            try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 256, s),
+        };
+        defer for (&wt_cps) |*cp| cp.deinit(testing.allocator);
+        _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &wt_cps, s);
+        try testing.expectEqual(@as(u32, 0), tier.entries.items[0].qsa_history_rows);
+
+        var cache2 = try KVCache.init(testing.allocator, 3);
+        defer cache2.deinit();
+        var dst: [3]SSMCacheEntry = .{
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+            .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        };
+        defer freeHybridEntries(&dst);
+        try testing.expectError(error.DiskCacheQsaHistoryGap, tier.restoreIntoHybrid(&cache2, &dst, 0, 128, s));
+        try testing.expectEqual(@as(usize, 0), cache2.step);
+        try testing.expect(dst[2].aux_state.ctx == null);
+    }
+}
+
+test "DiskTier: a history tensor shorter than cp_pos is a miss, not a short hit" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    var tier = try DiskTier.init(testing.allocator, io, base, "fp-qsa-short-tensor", 0, 128);
+    defer tier.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    var tokens: [600]u32 = undefined;
+    for (&tokens, 0..) |*t, i| t.* = @intCast(i + 7);
+
+    const aux_shape = [_]c_int{ 1, 8, 8 };
+    const pooled_shape = [_]c_int{ 1, 2, 8 };
+    var src = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&src);
+    src[2].aux_state = makeArange(s, &aux_shape, 700.0);
+    src[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
+    src[2].qsa_ratio = 4;
+    var cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 16, s),
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 64, s),
+    };
+    defer for (&cps) |*cp| cp.deinit(testing.allocator);
+    try testing.expectEqual(@as(c_int, 16), cps[0].layers[2].qsa_rows);
+    try testing.expectEqual(@as(c_int, 64), cps[1].layers[2].qsa_rows);
+    try transformer_mod.attachQsaHistoryToLatest(&cps, &src, s);
+    try testing.expectEqual(@as(c_int, 8), mlx.getShape(cps[1].layers[2].aux_state)[1]);
+    try testing.expectEqual(@as(c_int, 64), cps[1].layers[2].qsa_rows);
+
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &cps, s);
+
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var dst: [3]SSMCacheEntry = .{
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+    };
+    defer freeHybridEntries(&dst);
+    try testing.expectError(error.DiskCacheQsaHistoryGap, tier.restoreIntoHybrid(&cache2, &dst, 0, 16, s));
+    try testing.expectEqual(@as(usize, 0), cache2.step);
+    try testing.expect(dst[2].aux_state.ctx == null);
+}
+
+test "DiskTier: a QSA overlay error resets the half-built restore" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    var tier = try DiskTier.init(testing.allocator, io, base, "fp-qsa-ovl", 0, 128);
+    defer tier.deinit();
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    var tokens: [600]u32 = undefined;
+    for (&tokens, 0..) |*t, i| t.* = @intCast(i + 7);
+
+    const aux_shape = [_]c_int{ 1, 256, 8 };
+    const pooled_shape = [_]c_int{ 1, 64, 8 };
+    var src = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&src);
+    src[2].aux_state = makeArange(s, &aux_shape, 700.0);
+    src[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
+    src[2].qsa_ratio = 4;
+    var cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 256, s),
+    };
+    defer for (&cps) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&cps, &src, s);
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &tokens, false, &cps, s);
+
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var dst: [3]SSMCacheEntry = .{
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+    };
+    defer freeHybridEntries(&dst);
+    test_qsa_overlay_mismatch = true;
+    defer test_qsa_overlay_mismatch = false;
+    try testing.expectError(error.SsmCheckpointLayerMismatch, tier.restoreIntoHybrid(&cache2, &dst, 0, 256, s));
+    try testing.expectEqual(@as(usize, 0), cache2.step);
+}
+
+test "DiskTier chunk share: a prefix-diverging entry hard-links qsa.safetensors" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    chunk_share_override = true;
+    defer chunk_share_override = null;
+    var tier = try DiskTier.init(testing.allocator, io, base, "fp-qsa-share", 0, 128);
+    defer tier.deinit();
+    tier.ssd_first = true;
+    tier.armTestSpace(1024 * 1024 * 1024 * 1024, 2048 * 1024 * 1024 * 1024);
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    const toks = chunkShareTokens(520);
+
+    const aux_shape = [_]c_int{ 1, 256, 8 };
+    const pooled_shape = [_]c_int{ 1, 64, 8 };
+    var src = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&src);
+    src[2].aux_state = makeArange(s, &aux_shape, 700.0);
+    src[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
+    src[2].qsa_ratio = 4;
+    var cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &src, 256, s),
+    };
+    defer for (&cps) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&cps, &src, s);
+
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &toks.a, false, &cps, s);
+    const donor_id = tier.entries.items[0].id;
+    try testing.expect(tier.entries.items[0].qsa_history_bytes > 0);
+    try testing.expectEqual(@as(u32, 256), tier.entries.items[0].qsa_history_rows);
+
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &toks.b, false, &cps, s);
+    try testing.expectEqual(@as(usize, 2), tier.entryCount());
+    const heir = &tier.entries.items[1];
+    try testing.expect(heir.inherited_qsa);
+    try testing.expectEqual(@as(u8, 7), DiskTier.metaVersionFor(heir.*));
+
+    var pbuf: [1024]u8 = undefined;
+    const dp = try std.fmt.bufPrint(&pbuf, "{s}/fp-qsa-share/e{d}/qsa.safetensors", .{ base, donor_id });
+    const dstat = statFile(io, dp).?;
+    var hbuf: [1024]u8 = undefined;
+    const hp = try std.fmt.bufPrint(&hbuf, "{s}/fp-qsa-share/e{d}/qsa.safetensors", .{ base, heir.id });
+    const hstat = statFile(io, hp).?;
+    try testing.expectEqual(dstat.inode, hstat.inode);
+    try testing.expectEqual(@as(u64, 2), @as(u64, @intCast(hstat.nlink)));
+
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var dst: [3]SSMCacheEntry = .{
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+    };
+    defer freeHybridEntries(&dst);
+    const m = tier.bestMatch(&toks.b, false, kv_quant.KVQuantConfig.dense).?;
+    try testing.expectEqual(@as(u32, 256), try tier.restoreIntoHybrid(&cache2, &dst, m.idx, 256, s));
+    try testing.expectEqual(@as(c_int, 256), mlx.getShape(dst[2].aux_state)[1]);
+    try testing.expectEqual(@as(f32, 700.0 + 5.0), ssmArrVal(dst[2].aux_state, 5, s));
+}
+
+test "DiskTier: an inherited QSA history is dropped on extend past the common prefix" {
+    const io = std.testing.io;
+    const s = mlx.gpuStream();
+    var tmp = std.testing.tmpDir(.{ .iterate = true });
+    defer tmp.cleanup();
+    var buf: [512]u8 = undefined;
+    const base = try tmpRoot(&tmp, io, &buf);
+
+    chunk_share_override = true;
+    defer chunk_share_override = null;
+    var tier = try DiskTier.init(testing.allocator, io, base, "fp-qsa-ext", 0, 128);
+    defer tier.deinit();
+    tier.ssd_first = true;
+    tier.armTestSpace(1024 * 1024 * 1024 * 1024, 2048 * 1024 * 1024 * 1024);
+
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try fillCache(&cache, s, 3, 600, 8, 0.0, .float32);
+    const toks = chunkShareTokens(520);
+
+    var donor_src = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&donor_src);
+    const donor_aux = [_]c_int{ 1, 600, 8 };
+    const donor_pooled = [_]c_int{ 1, 150, 8 };
+    donor_src[2].aux_state = makeArange(s, &donor_aux, 700.0);
+    donor_src[2].qsa_pooled = makeArange(s, &donor_pooled, 800.0);
+    donor_src[2].qsa_ratio = 4;
+    var donor_cps = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &donor_src, 600, s),
+    };
+    defer for (&donor_cps) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&donor_cps, &donor_src, s);
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &toks.a, false, &donor_cps, s);
+
+    var heir_src = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&heir_src);
+    const heir_aux1 = [_]c_int{ 1, 256, 8 };
+    const heir_pooled1 = [_]c_int{ 1, 64, 8 };
+    heir_src[2].aux_state = makeArange(s, &heir_aux1, 700.0);
+    heir_src[2].qsa_pooled = makeArange(s, &heir_pooled1, 800.0);
+    heir_src[2].qsa_ratio = 4;
+    var heir_cps1 = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &heir_src, 256, s),
+    };
+    defer for (&heir_cps1) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&heir_cps1, &heir_src, s);
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &toks.b, false, &heir_cps1, s);
+    try testing.expect(tier.entries.items[1].inherited_qsa);
+
+    var heir_src2 = buildHybridEntries(s, 200.0, 600.0);
+    defer freeHybridEntries(&heir_src2);
+    const heir_aux2 = [_]c_int{ 1, 560, 8 };
+    const heir_pooled2 = [_]c_int{ 1, 140, 8 };
+    heir_src2[2].aux_state = makeArange(s, &heir_aux2, 900.0);
+    heir_src2[2].qsa_pooled = makeArange(s, &heir_pooled2, 1000.0);
+    heir_src2[2].qsa_ratio = 4;
+    var heir_cps2 = [_]transformer_mod.SSMCheckpoint{
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &heir_src2, 256, s),
+        try transformer_mod.captureSsmCheckpoint(testing.allocator, &heir_src2, 560, s),
+    };
+    defer for (&heir_cps2) |*cp| cp.deinit(testing.allocator);
+    try transformer_mod.attachQsaHistoryToLatest(&heir_cps2, &heir_src2, s);
+    _ = try tier.appendCommit(cache.entries, cache.step, cache.config, &toks.b, false, &heir_cps2, s);
+
+    const heir = &tier.entries.items[1];
+    try testing.expect(!heir.inherited_qsa);
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var dst: [3]SSMCacheEntry = .{
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+        .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = false },
+    };
+    defer freeHybridEntries(&dst);
+    const m = tier.bestMatch(&toks.b, false, kv_quant.KVQuantConfig.dense).?;
+    try testing.expectEqual(@as(u32, 560), try tier.restoreIntoHybrid(&cache2, &dst, m.idx, 560, s));
+    try testing.expectEqual(@as(c_int, 560), mlx.getShape(dst[2].aux_state)[1]);
+    try testing.expectEqual(@as(f32, 900.0 + 5.0), ssmArrVal(dst[2].aux_state, 5, s));
 }
 
 test "DiskTier: SSM retention thins the interior, keeping both ends" {
@@ -4148,8 +5213,8 @@ test "DiskTier: an SSM checkpoint STAGES through the writer — no filesystem wr
     // A checkpoint with every optional part qwen4_exp carries.
     var src128 = buildHybridEntries(s, 100.0, 500.0);
     defer freeHybridEntries(&src128);
-    const aux_shape = [_]c_int{ 1, 12, 4 };
-    const pooled_shape = [_]c_int{ 1, 3, 4 };
+    const aux_shape = [_]c_int{ 1, 128, 4 };
+    const pooled_shape = [_]c_int{ 1, 32, 4 };
     src128[2].aux_state = makeArange(s, &aux_shape, 700.0);
     src128[2].qsa_pooled = makeArange(s, &pooled_shape, 800.0);
     src128[2].qsa_ratio = 4;
@@ -5218,6 +6283,10 @@ test "DiskTier: the manifest stamps the LOWEST version that describes the entry"
     try t.expectEqual(@as(u8, 6), DiskTier.metaVersionFor(e));
     e.spec_mtp = null;
     try t.expectEqual(@as(u8, 6), DiskTier.metaVersionFor(e));
+
+    e.qsa_history_rows = 256;
+    e.qsa_history_bytes = 4096;
+    try t.expectEqual(@as(u8, 7), DiskTier.metaVersionFor(e));
 }
 
 test "DiskTier: the per-entry checkpoint cap is gated; a legacy tier keeps 8" {

--- a/src/prefix_cache.zig
+++ b/src/prefix_cache.zig
@@ -1116,6 +1116,15 @@ pub const HotPrefixCache = struct {
             return .{ .matched = 0, .full_match = false };
         }
         // The stamp before the bump: two arms after the restore still end in `matched = 0`.
+        if (e.ssm_checkpoints) |cps| {
+            if (highestCheckpointAtOrBelow(cps, m.shared)) |cp| {
+                const src_cp = qsaHistorySource(cps, cp) orelse cp;
+                const have = transformer_mod.checkpointQsaAuxRows(src_cp);
+                if (have > 0 and have < @as(c_int, @intCast(cp.pos))) {
+                    return error.QsaHistoryGap;
+                }
+            }
+        }
         const used_before_restore = e.last_used;
         e.last_used = self.bumpCounter();
         // Identity of the entry this request runs on: evicting it frees nothing (shared buffers).
@@ -3760,6 +3769,43 @@ test "HotPrefixCache: a QSA arch restore with no indexer history is a miss, neve
             try testing.expectEqual(@as(usize, 0), moe_off);
             try testing.expect(target[0].aux_state.ctx == null);
         }
+    }
+}
+
+test "HotPrefixCache: a history tensor shorter than the checkpoint is a miss, not a short hit" {
+    const s = mlx.gpuStream();
+    var tokens: [70]u32 = undefined;
+    for (&tokens, 0..) |*t, i| t.* = @intCast(i + 1);
+    var lookup_latest: [70]u32 = tokens;
+    lookup_latest[64] = 999;
+    var lookup_interior: [70]u32 = tokens;
+    lookup_interior[16] = 999;
+
+    var hc = HotPrefixCache.initWithMem(testing.allocator, 4, 0);
+    defer hc.deinit();
+    hc.qsa_history_required = true;
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try testFillCache(&cache, s, 3, tokens.len);
+    var live = pcBuildQsaHybrid(s, 8, 100.0);
+    defer pcFreeQsaHybrid(&live);
+    const cps = try testing.allocator.alloc(SSMCheckpoint, 2);
+    cps[0] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &live, 16, s);
+    cps[1] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &live, 64, s);
+    try transformer_mod.attachQsaHistoryToLatest(cps, &live, s);
+    try testing.expectEqual(@as(c_int, 8), mlx.getShape(cps[1].layers[0].aux_state)[1]);
+    try testing.expectEqual(@as(c_int, 64), cps[1].layers[0].qsa_rows);
+    try hc.commitWithState(&cache, &tokens, false, 0, cps, null, null);
+
+    for ([_][]const u32{ &lookup_latest, &lookup_interior }) |lookup| {
+        var target_cache = try KVCache.init(testing.allocator, 3);
+        defer target_cache.deinit();
+        var target = pcEmptySsm();
+        defer pcFreeQsaHybrid(&target);
+        var moe_off: usize = 0;
+        try testing.expectError(error.QsaHistoryGap, hc.lookupAndRestore(&target_cache, &moe_off, &target, s, lookup, false, 0, null, null));
+        try testing.expectEqual(@as(usize, 0), target_cache.step);
+        try testing.expect(target[0].aux_state.ctx == null);
     }
 }
 

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -6733,6 +6733,7 @@ pub const SSMCacheEntrySnapshot = struct {
     aux_state: mlx.mlx_array = .{ .ctx = null },
     qsa_pooled: mlx.mlx_array = .{ .ctx = null },
     qsa_ratio: c_int = 4,
+    qsa_rows: c_int = 0,
     /// The (ngram_size - 1) tokens preceding this entry.
     ple_prev: [qwen4_mod.MAX_NGRAM_SIZE]u32 = @splat(0),
     ple_prev_valid: bool = false,
@@ -6777,6 +6778,7 @@ pub fn ssmSnapshot(src: *const SSMCacheEntry) SSMCacheEntrySnapshot {
         _ = mlx.mlx_array_set(&out.qsa_pooled, src.qsa_pooled);
     }
     out.qsa_ratio = src.qsa_ratio;
+    out.qsa_rows = qsaHistoryRows(src);
     out.ple_prev = src.ple_prev;
     out.ple_prev_valid = src.ple_prev_valid;
     return out;
@@ -6819,6 +6821,10 @@ pub fn ssmRestore(dst: *SSMCacheEntry, snap: *const SSMCacheEntrySnapshot) !void
     dst.qsa_ratio = snap.qsa_ratio;
     dst.ple_prev = snap.ple_prev;
     dst.ple_prev_valid = snap.ple_prev_valid;
+    if (snap.aux_state.ctx != null) {
+        const sh = mlx.getShape(dst.aux_state);
+        dst.qsa_key_rows = if (sh.len >= 2) sh[1] else 0;
+    }
 }
 
 /// Free the transient PLD spec-decode capture buffers on an SSM entry
@@ -7220,6 +7226,9 @@ pub fn captureSsmCheckpoint(
             out.aux_state = try materializedOwnedCopy(s, src.aux_state);
         }
         out.qsa_ratio = src.qsa_ratio;
+        if (ssmAuxIsQsaHistory(src)) {
+            out.qsa_rows = @intCast(pos);
+        }
         out.ple_prev = src.ple_prev;
         out.ple_prev_valid = src.ple_prev_valid;
         layers[i] = out;
@@ -7300,6 +7309,7 @@ pub fn shareSsmCheckpoint(allocator: std.mem.Allocator, cp: *const SSMCheckpoint
             _ = mlx.mlx_array_set(&out.qsa_pooled, src.qsa_pooled);
         }
         out.qsa_ratio = src.qsa_ratio;
+        out.qsa_rows = src.qsa_rows;
         out.ple_prev = src.ple_prev;
         out.ple_prev_valid = src.ple_prev_valid;
         layers[i] = out;
@@ -7328,6 +7338,18 @@ pub fn ssmCheckpointBytes(cp: *const SSMCheckpoint) u64 {
     for (cp.layers) |l| {
         inline for (.{ l.conv_state, l.ssm_state, l.aux_state, l.qsa_pooled }) |arr| {
             if (arr.ctx != null) total += @as(u64, mlx.mlx_array_size(arr)) * @as(u64, mlx.mlx_array_itemsize(arr));
+        }
+    }
+    return total;
+}
+
+pub fn qsaHistoryBytesHeld(cps: []const SSMCheckpoint) u64 {
+    var total: u64 = 0;
+    for (cps) |cp| {
+        for (cp.layers) |l| {
+            inline for (.{ l.aux_state, l.qsa_pooled }) |arr| {
+                if (arr.ctx != null) total += @as(u64, mlx.mlx_array_size(arr)) * @as(u64, mlx.mlx_array_itemsize(arr));
+            }
         }
     }
     return total;
@@ -7412,6 +7434,14 @@ pub fn ssmAuxIsQsaHistory(e: *const SSMCacheEntry) bool {
     return mlx.mlx_array_size(e.conv_state) == 0;
 }
 
+fn qsaHistoryRows(e: *const SSMCacheEntry) c_int {
+    if (!ssmAuxIsQsaHistory(e)) return 0;
+    if (e.qsa_key_rows > 0) return e.qsa_key_rows;
+    if (e.aux_state.ctx == null) return 0;
+    const sh = mlx.getShape(e.aux_state);
+    return if (sh.len >= 2) sh[1] else 0;
+}
+
 fn snapshotHasQsaHistory(l: *const SSMCacheEntrySnapshot) bool {
     if (l.aux_state.ctx == null) return false;
     if (l.qsa_pooled.ctx != null) return true;
@@ -7424,6 +7454,17 @@ pub fn checkpointHasQsaHistory(cp: *const SSMCheckpoint) bool {
         if (snapshotHasQsaHistory(l)) return true;
     }
     return false;
+}
+
+pub fn checkpointQsaAuxRows(cp: *const SSMCheckpoint) c_int {
+    var r: c_int = 0;
+    for (cp.layers) |*l| {
+        if (!snapshotHasQsaHistory(l)) continue;
+        if (l.aux_state.ctx == null) continue;
+        const sh = mlx.getShape(l.aux_state);
+        if (sh.len >= 2 and sh[1] > r) r = sh[1];
+    }
+    return r;
 }
 
 /// One QSA layer's history onto `dst_aux`/`dst_pooled`, sliced to `take` rows
@@ -7537,6 +7578,7 @@ fn attachQsaHistoryToLatestMode(cps: []SSMCheckpoint, live: []const SSMCacheEntr
         copied += 1;
     }
     if (copied == 0) return;
+    recordQsaRowsOnCheckpoints(cps, live);
     keepOnlyLatestQsaHistory(cps);
     const vec = mlx.mlx_vector_array_new();
     defer _ = mlx.mlx_vector_array_free(vec);
@@ -7551,6 +7593,18 @@ fn attachQsaHistoryToLatestMode(cps: []SSMCheckpoint, live: []const SSMCacheEntr
         }
     }
     if (n > 0) _ = mlx.mlx_eval(vec);
+}
+
+fn recordQsaRowsOnCheckpoints(cps: []SSMCheckpoint, live: []const SSMCacheEntry) void {
+    for (cps) |*cp| {
+        if (cp.layers.len != live.len) continue;
+        const pos_rows: c_int = @intCast(cp.pos);
+        for (cp.layers, live) |*dst, src| {
+            if (!ssmAuxIsQsaHistory(&src)) continue;
+            if (dst.qsa_rows == 0) dst.qsa_rows = pos_rows;
+            dst.qsa_ratio = src.qsa_ratio;
+        }
+    }
 }
 
 /// Keep the QSA history on the NEWEST snap that carries it and drop it from
@@ -7600,8 +7654,11 @@ pub fn applyQsaHistoryAt(entries: []SSMCacheEntry, src_cp: *const SSMCheckpoint,
         // A restore replaces the history behind the append accelerator's back. Shared: the
         // first append re-seeds a private buffer from it.
         ssmFreeQsaState(dst);
+        const ks = mlx.getShape(src.aux_state);
+        if (ks.len < 2 or ks[1] < keep) return error.QsaHistoryGap;
         try copyQsaHistorySliced(&dst.aux_state, &dst.qsa_pooled, src.aux_state, src.qsa_pooled, src.qsa_ratio, keep, false, s);
         dst.qsa_ratio = src.qsa_ratio;
+        dst.qsa_key_rows = keep;
     }
 }
 
@@ -7619,6 +7676,7 @@ pub fn sliceQsaHistoryOntoCheckpoint(dst: *SSMCheckpoint, src: *const SSMCheckpo
         // Materialize: the trim drops `src` next, and a view would keep its whole buffer alive.
         try copyQsaHistorySliced(&d.aux_state, &d.qsa_pooled, s_l.aux_state, s_l.qsa_pooled, s_l.qsa_ratio, keep, true, s);
         d.qsa_ratio = s_l.qsa_ratio;
+        d.qsa_rows = keep;
     }
     // Materialize now: an unevaluated copy node keeps `src`'s buffer alive.
     const vec = mlx.mlx_vector_array_new();
@@ -30949,6 +31007,186 @@ test "captureSsmCheckpoint materializes state copies (parent-buffer retention cl
 
     // Null ssm_state stays null (LFM2 gated_conv shape).
     try testing.expect(cp.layers[0].ssm_state.ctx == null);
+}
+
+test "QSA checkpoint aux+pooled bytes are O(rows + checkpoints)" {
+    const s = mlx.gpuStream();
+    const n: c_int = 64;
+    const hd: c_int = 8;
+    const ratio: c_int = 4;
+    const aux_shape = [_]c_int{ 1, n, hd };
+    const pooled_shape = [_]c_int{ 1, @divExact(n, ratio), hd };
+    var aux = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(aux);
+    {
+        var flat = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(flat);
+        try mlx.check(mlx.mlx_arange(&flat, 0.0, @floatFromInt(n * hd), 1.0, .float32, s));
+        try mlx.check(mlx.mlx_reshape(&aux, flat, &aux_shape, 3, s));
+        try mlx.check(mlx.mlx_array_eval(aux));
+    }
+    var pooled = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(pooled);
+    {
+        var flat = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(flat);
+        try mlx.check(mlx.mlx_arange(&flat, 1000.0, 1000.0 + @as(f64, @floatFromInt((n / ratio) * hd)), 1.0, .float32, s));
+        try mlx.check(mlx.mlx_reshape(&pooled, flat, &pooled_shape, 3, s));
+        try mlx.check(mlx.mlx_array_eval(pooled));
+    }
+    const live: SSMCacheEntry = .{
+        .conv_state = .{ .ctx = null },
+        .ssm_state = .{ .ctx = null },
+        .initialized = true,
+        .aux_state = aux,
+        .qsa_pooled = pooled,
+        .qsa_ratio = ratio,
+    };
+    aux = mlx.mlx_array_new();
+    pooled = mlx.mlx_array_new();
+    try mlx.check(mlx.mlx_array_set(&aux, live.aux_state));
+    try mlx.check(mlx.mlx_array_set(&pooled, live.qsa_pooled));
+    var live_arr = [_]SSMCacheEntry{live};
+    defer {
+        if (live_arr[0].aux_state.ctx != null) _ = mlx.mlx_array_free(live_arr[0].aux_state);
+        if (live_arr[0].qsa_pooled.ctx != null) _ = mlx.mlx_array_free(live_arr[0].qsa_pooled);
+    }
+
+    const positions = [_]usize{ 16, 32, 48, 64 };
+    var cps: [positions.len]SSMCheckpoint = undefined;
+    for (positions, 0..) |p, i| {
+        cps[i] = try captureSsmCheckpoint(testing.allocator, &live_arr, p, s);
+    }
+    defer for (&cps) |*c| c.deinit(testing.allocator);
+    try attachQsaHistoryToLatest(&cps, &live_arr, s);
+
+    const held = qsaHistoryBytesHeld(&cps);
+    const one: u64 = @as(u64, @intCast(n)) * @as(u64, @intCast(hd)) * 4 +
+        @as(u64, @intCast(@divExact(n, ratio))) * @as(u64, @intCast(hd)) * 4;
+    try testing.expect(held <= one + @as(u64, positions.len) * 64);
+    for (positions, 0..) |p, i| {
+        try testing.expectEqual(@as(c_int, @intCast(p)), cps[i].layers[0].qsa_rows);
+        if (i + 1 < positions.len) {
+            try testing.expect(cps[i].layers[0].aux_state.ctx == null);
+        }
+    }
+    try testing.expect(checkpointHasQsaHistory(&cps[positions.len - 1]));
+
+    var dest = [_]SSMCacheEntry{.{
+        .conv_state = .{ .ctx = null },
+        .ssm_state = .{ .ctx = null },
+        .initialized = true,
+    }};
+    defer ssmFreeQsaState(&dest[0]);
+    try applyQsaHistoryAt(&dest, &cps[positions.len - 1], 16, s);
+    try testing.expectEqual(@as(c_int, 16), mlx.getShape(dest[0].aux_state)[1]);
+    {
+        var got = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(got);
+        try mlx.check(mlx.mlx_astype(&got, dest[0].aux_state, .float32, s));
+        try mlx.check(mlx.mlx_array_eval(got));
+        const d = mlx.mlx_array_data_float32(got) orelse return error.TestUnexpectedNullData;
+        try testing.expectEqual(@as(f32, 0), d[0]);
+        try testing.expectEqual(@as(f32, 15.0 * 8.0 + 7.0), d[15 * 8 + 7]);
+    }
+
+    var t: Transformer = undefined;
+    t.s = s;
+    t.allocator = testing.allocator;
+    const extra_shape = [_]c_int{ 1, 1, hd };
+    var extra = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(extra);
+    try mlx.check(mlx.mlx_ones(&extra, &extra_shape, 3, .float32, s));
+    try t.qsaAppendKeys(&dest[0], extra, 16);
+    try mlx.check(mlx.mlx_array_eval(dest[0].aux_state));
+    try testing.expectEqual(@as(c_int, 17), mlx.getShape(dest[0].aux_state)[1]);
+    try testing.expectEqual(@as(c_int, 64), mlx.getShape(cps[positions.len - 1].layers[0].aux_state)[1]);
+    {
+        var got = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(got);
+        try mlx.check(mlx.mlx_astype(&got, cps[positions.len - 1].layers[0].aux_state, .float32, s));
+        try mlx.check(mlx.mlx_array_eval(got));
+        const d = mlx.mlx_array_data_float32(got) orelse return error.TestUnexpectedNullData;
+        try testing.expectEqual(@as(f32, 63.0 * 8.0 + 7.0), d[63 * 8 + 7]);
+    }
+}
+
+test "qsa_rows is the checkpoint position, never current live length" {
+    const s = mlx.gpuStream();
+    const hd: c_int = 8;
+    const ratio: c_int = 4;
+    const aux_shape = [_]c_int{ 1, 16, hd };
+    var aux = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(aux);
+    try mlx.check(mlx.mlx_ones(&aux, &aux_shape, 3, .float32, s));
+    var pooled = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(pooled);
+    const pooled_shape = [_]c_int{ 1, 4, hd };
+    try mlx.check(mlx.mlx_ones(&pooled, &pooled_shape, 3, .float32, s));
+    var live16 = [_]SSMCacheEntry{.{
+        .conv_state = .{ .ctx = null },
+        .ssm_state = .{ .ctx = null },
+        .initialized = true,
+        .aux_state = aux,
+        .qsa_pooled = pooled,
+        .qsa_ratio = ratio,
+    }};
+    aux = mlx.mlx_array_new();
+    pooled = mlx.mlx_array_new();
+    try mlx.check(mlx.mlx_array_set(&aux, live16[0].aux_state));
+    try mlx.check(mlx.mlx_array_set(&pooled, live16[0].qsa_pooled));
+    defer ssmFreeQsaState(&live16[0]);
+
+    var cp32 = try captureSsmCheckpoint(testing.allocator, &live16, 32, s);
+    defer cp32.deinit(testing.allocator);
+    try testing.expectEqual(@as(c_int, 32), cp32.layers[0].qsa_rows);
+
+    const aux64_shape = [_]c_int{ 1, 64, hd };
+    var aux64 = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(aux64);
+    try mlx.check(mlx.mlx_ones(&aux64, &aux64_shape, 3, .float32, s));
+    var pooled64 = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(pooled64);
+    const pooled64_shape = [_]c_int{ 1, 16, hd };
+    try mlx.check(mlx.mlx_ones(&pooled64, &pooled64_shape, 3, .float32, s));
+    var live64 = [_]SSMCacheEntry{.{
+        .conv_state = .{ .ctx = null },
+        .ssm_state = .{ .ctx = null },
+        .initialized = true,
+        .aux_state = aux64,
+        .qsa_pooled = pooled64,
+        .qsa_ratio = ratio,
+    }};
+    aux64 = mlx.mlx_array_new();
+    pooled64 = mlx.mlx_array_new();
+    try mlx.check(mlx.mlx_array_set(&aux64, live64[0].aux_state));
+    try mlx.check(mlx.mlx_array_set(&pooled64, live64[0].qsa_pooled));
+    defer ssmFreeQsaState(&live64[0]);
+    var cps = [_]SSMCheckpoint{
+        try captureSsmCheckpoint(testing.allocator, &live64, 16, s),
+        try captureSsmCheckpoint(testing.allocator, &live64, 64, s),
+    };
+    defer for (&cps) |*c| c.deinit(testing.allocator);
+    try testing.expectEqual(@as(c_int, 16), cps[0].layers[0].qsa_rows);
+    try testing.expectEqual(@as(c_int, 64), cps[1].layers[0].qsa_rows);
+
+    const aux8_shape = [_]c_int{ 1, 8, hd };
+    var aux8 = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(aux8);
+    try mlx.check(mlx.mlx_ones(&aux8, &aux8_shape, 3, .float32, s));
+    var live8 = [_]SSMCacheEntry{.{
+        .conv_state = .{ .ctx = null },
+        .ssm_state = .{ .ctx = null },
+        .initialized = true,
+        .aux_state = aux8,
+        .qsa_ratio = ratio,
+    }};
+    aux8 = mlx.mlx_array_new();
+    try mlx.check(mlx.mlx_array_set(&aux8, live8[0].aux_state));
+    defer ssmFreeQsaState(&live8[0]);
+    try attachQsaHistoryToLatest(&cps, &live8, s);
+    try testing.expectEqual(@as(c_int, 16), cps[0].layers[0].qsa_rows);
+    try testing.expectEqual(@as(c_int, 64), cps[1].layers[0].qsa_rows);
 }
 
 test "captureSsmCheckpoint does not copy QSA aux history" {


### PR DESCRIPTION
# perf(qwen4): the SSD tier writes the QSA indexer history once per entry, not once per checkpoint

**The problem.** On qwen4_exp an SSM checkpoint file on the SSD tier carried the QSA indexer history (raw keys and pooled keys, 13 indexers, bf16) as a full copy at every checkpoint position. The history is append-only within a lineage, so checkpoint k's arrays are a byte-prefix of checkpoint k+1's, and the cost was quadratic in turn count: 85.7% of checkpoint bytes were copies, 14.1 GB of unique checkpoint inodes on one 238k-token session, and a single checkpoint at 244k was 995 MB. A long agentic session pushed the tier to about 100 GB on disk.

**The change.** A checkpoint file holds the recurrent state only (GDN state, conv window, the PLE window on GDN layers). The entry's history is written once (`qsa.safetensors`, entry format v7; v2 to v6 entries still load), and a restore at checkpoint k slices it to k rows. The rows adopted are the tensor's own row count, never a recorded one, on every restore path (RAM latest snapshot, RAM interior checkpoint, disk hybrid, SSD-first checkout): a short or missing history is a named miss before any live state is adopted, never a wrong-state restore. A diverging entry hard-links the donor's history file the way KV chunks already inherit. In RAM the entry already held one history; each checkpoint now records its row count so the same slicing applies. Reachable only where an SSM entry carries QSA history; other hybrids write and read their checkpoint files byte for byte as before.

Measured on an incremental 4k to 768k session (M5 Max 128 GB, Qwen3.8-Flash-Next mixed-4-8bit, kv8). The "old format" column is what the same checkpoints would have carried, reconstructed from each checkpoint's position; the v7 columns are the bytes on disk:

| entry | checkpoints | top position | old format | v7 checkpoints | v7 history, once | saving |
|---|---|---|---|---|---|---|
| e5 | 9 | 66k | 1.9 GB | 0.49 GB | 0.23 GB | 61% |
| e6 | 16 | 131k | 5.6 GB | 0.88 GB | 0.47 GB | 76% |
| e7 | 16 | 262k | 10.5 GB | 0.88 GB | 0.94 GB | 83% |
| e8 | 16 | 393k | 15.2 GB | 0.88 GB | 1.41 GB | 85% |
| e9 | 16 | 524k | 21.2 GB | 0.88 GB | 1.87 GB | 87% |
| total, 9 entries, 81 checkpoints | | | 55.2 GB | 4.5 GB | 5.1 GB | 83% |

A checkpoint file is now 56 MB at any position; the only thing that grows with context is the one history file per entry.

Nothing on the forward or decode path changes; the incremental sweep's MLX peaks per rung are identical to main's at 4k to 384k.

Four read-only audit rounds and four fix rounds (a missing or short history file restoring as a hit, a swallowed overlay error, a mid-chunk checkpoint recording live rows instead of its position, the PLE window on GDN layers dropped from checkpoint files) closed with no finding. Suite on this tree: 9 of 9 steps, 2185 passed, 153 skipped, 0 failed. Diff: 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
