### PR TITLE
perf(qwen4): the allocator pool is cleared once between the last prefill chunk and the first decode tick

### DIFF
--- a/src/generate.zig
+++ b/src/generate.zig
@@ -960,6 +960,17 @@ pub fn shouldClearAllocatorCache(step: u32, last_clear: u32, interval: u32) bool
     return step -| last_clear >= interval;
 }
 
+/// PURE: does this request return MLX's allocator pool once, between its last
+/// prefill chunk and its first decode tick?
+///
+/// The per-chunk clear runs before the last chunks' transient is freed, so that
+/// transient parks in the pool up to the cap and the first decode tick allocates
+/// on top of it (8.1 GB parked at the first tick of a 393k prefill). Gated on
+/// `longCtxGated`: every other arch keeps its previous call pattern exactly.
+pub fn clearsPoolAtPrefillEnd(config: *const model_mod.ModelConfig) bool {
+    return config.longCtxGated();
+}
+
 /// Number of accepted draft tokens that may accompany the always-committed
 /// anchor token without crossing the request's output-token ceiling.
 pub fn capAcceptedForTokenBudget(accepted: u32, completion: u32, max_tokens: u32) u32 {
@@ -2942,6 +2953,15 @@ pub const Generator = struct {
 
         attachCp(&gen, &ssm_checkpoints, allocator);
         return gen;
+    }
+
+    /// Return the prefill's parked transients once, at the handover to decode.
+    /// Shares `advanceStep`'s clock: a clear here is a clear, so the decode
+    /// cadence measures its next interval from this point.
+    pub fn clearPoolBeforeDecode(self: *Generator) void {
+        if (!clearsPoolAtPrefillEnd(&self.xfm.config)) return;
+        _ = mlx.mlx_clear_cache();
+        self.last_cache_clear_step = self.step;
     }
 
     /// The ONE place `step` and `completion_tokens` advance — every decode path
@@ -13410,6 +13430,32 @@ test "clear cadence survives variable spec strides" {
     }
 }
 
+test "the allocator pool is returned at the prefill/decode handover, long-context gate only" {
+    // The per-chunk clear runs BEFORE the last chunks' transient is freed, so it
+    // parks in MLX's pool up to the cap and the first decode tick allocates on top
+    // of it (measured 8.1 GB parked at the first tick of a 393k prefill; a cold
+    // 524k died 0.5 GB over the plan ceiling on exactly that tick). One clear at the
+    // handover returns it. Every other arch keeps its previous call pattern.
+    const t = testing;
+    var qwen4 = model_mod.ModelConfig{ .model_type = "qwen4_exp" };
+    try t.expect(clearsPoolAtPrefillEnd(&qwen4));
+    for ([_][]const u8{
+        "qwen3_5",
+        "qwen3_5_moe",
+        "qwen3_next",
+        "lfm2",
+        "nemotron_h",
+        "bailing_hybrid",
+        "llama",
+        "gemma4",
+        "deepseek_v4",
+        "muse_glimmer",
+    }) |mt| {
+        var cfg = model_mod.ModelConfig{ .model_type = mt };
+        try t.expect(!clearsPoolAtPrefillEnd(&cfg));
+    }
+}
+
 test "no decode path advances `step` outside advanceStep" {
     // Class guard for #110. `Generator.step` is the clear cadence's clock, so a
     // path that bumps it by hand is a path that strands its round's transients
@@ -13447,6 +13493,19 @@ test "no decode path advances `step` outside advanceStep" {
     // Exactly one: the assignment inside `advanceStep`. Zero means the field was
     // renamed and this guard went vacuous — update it with the rename.
     try testing.expectEqual(@as(usize, 1), total);
+
+    // Same discipline for the clock itself: every clear the Generator makes records
+    // it, so the decode cadence measures from the last ACTUAL clear. Two writers —
+    // `advanceStep` and the prefill/decode handover — and a third that forgot the
+    // write would leave the cadence firing against a stale clock.
+    const clock = "last_cache_clear_step" ++ " =";
+    var writers: usize = 0;
+    var clock_it = std.mem.splitScalar(u8, sources[0].src, '\n');
+    while (clock_it.next()) |raw| {
+        const line = if (std.mem.indexOf(u8, raw, "//")) |c| raw[0..c] else raw;
+        if (std.mem.indexOf(u8, line, clock) != null) writers += 1;
+    }
+    try testing.expectEqual(@as(usize, 2), writers);
 }
 
 test "dsv4: nextPld on a chokepoint-disabled generator stays serial (DSV4_MINI)" {

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -5989,6 +5989,10 @@ fn runPrefill(sch: *Scheduler, slot: *Slot) !void {
     gen.logprobs_n = slot.logprobs_n;
 
     slot.legacy_gen = gen;
+    // The last chunks' transient is freed AFTER the loop's own per-chunk clear, so it
+    // parks in MLX's pool up to the cap and the first decode tick allocates on top of
+    // it. Returned once here, at the handover — long-context gate only.
+    if (slot.legacy_gen) |*g| g.clearPoolBeforeDecode();
     // The conn thread's `cached_tokens` counted against `xfm.cache` (legacy
     // global cache) which the slot doesn't use. The slot's `cached_tokens`
     // is the hot-cache match (or 0 if the hot cache missed / isn't


### PR DESCRIPTION
# perf(qwen4): the allocator pool is cleared once between the last prefill chunk and the first decode tick

This enabled 768k context with full prefix ram cache for qwen4exp. prefill ~770 tok/s and decode high 30-40.

---

On qwen4_exp the last prefill chunks' freed transient parks in MLX's allocator pool up to its cap (8 GB on the shipped default), and the first decode tick allocates on top of it. Measured with a per-phase memory line on a cold 393k request: pool 0.1 GB at the last chunk, 4.2 GB at prefill done, 8.1 GB at the first decode tick. A cold 524k prompt beside two idle 393k entries died on that tick with a Metal out-of-memory 0.5 GB over the plan ceiling; the parked pool was the difference.

One gated `mlx_clear_cache()` at the prefill-to-decode handover in `scheduler.runPrefill`, through the same clock `advanceStep` writes, behind `ModelConfig.longCtxGated()`; ungated archs return before any MLX call. The existing scan guard on the clear cadence is extended to pin the two clock writers.

Measured at the first decode tick on the same cold request: pool 8.1 GB → 0.8 GB, output bytes identical, decode and prefill unchanged within run-to-run variance on a 2k to 128k llmprobe ladder.

Suite on the rebased tree: 9 of 9 steps, 2195 passed, 153 skipped, 0 failed. Diff: 2 files, 63 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
