### PR TITLE
perf(qwen4): use cooperative NAX tiles for sparse prefill attention

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -411,3 +411,13 @@ and they are listed because they made that work possible.
 
 Model weights downloaded at runtime carry their own licenses from their
 publishers. mlx-serve does not redistribute them.
+
+--------------------------------------------------------------------------------
+Apple MLX
+https://github.com/ml-explore/mlx
+Copyright © 2023-2024 Apple Inc.
+Licensed under the MIT License (src/kernels/MLX-LICENSE).
+
+src/kernels/qsa_nax_header.metal adapts the cooperative fragment layout and
+MMA helpers from steel/attn/nax.h. qsa_nax.metal adapts the split-head-dimension
+attention algorithm to per-query sparse block selection and corrected bf16 PV.

--- a/docs/gotchas/engine-mlx.md
+++ b/docs/gotchas/engine-mlx.md
@@ -4810,3 +4810,15 @@ tables reach 1.08x (M4 Max rc3 w4/w5 and w1/w2), poisoned width-1 cells
 see every narrower sample refused against a stale wider cell. Uniform
 contamination across a bucket is invisible to any ratio; that table wants
 deleting. Guard: the #382 parse test in `round_cost.zig`.
+
+## QSA cooperative NAX prefill
+
+`gatherQsa256` can use cooperative input tensors on G17 with macOS 26.3+;
+ordinary NAX availability (26.2) is insufficient for this API. The old gather
+path serves older systems and unhandled geometries.
+
+Relaxed float32-by-bf16 MMA rounds softmax weights. Split each weight into
+three bf16 terms and accumulate all three products in float32. Sparse block
+selection and causal tails stay unchanged. Guards: `gatherQsa256 NAX` tests,
+`tests/qsa_nax_precision.cpp` (CPU float64 oracle), and
+`tests/test_qsa_nax_prefill.py` (HTTP answers plus arm engagement).

--- a/src/kernels/MLX-LICENSE
+++ b/src/kernels/MLX-LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2023 Apple Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/kernels/qsa_nax.metal
+++ b/src/kernels/qsa_nax.metal
@@ -1,0 +1,118 @@
+// Sparse QSA for bf16 D=256, GQA12, on G17.
+// Three bf16 terms retain float32 softmax precision under relaxed NAX MMA.
+// D and block IDs are contiguous; KV rows are aligned for uint4 loads.
+using namespace mlx::steel;
+constexpr int BD = 256, LD = 264, TDH = 8, TK = BK / 16;
+const int qL=q_shape[2], kL=k_shape[2], Hq=q_shape[1], Hk=k_shape[1];
+const int gqa=Hq/Hk, KB=blocks_shape[2];
+const int s=threadgroup_position_in_grid.x;
+const int hk=threadgroup_position_in_grid.y;
+const int bb=threadgroup_position_in_grid.z;
+const ushort warp=simdgroup_index_in_threadgroup;
+const ushort lane=thread_index_in_simdgroup;
+const int tid=thread_index_in_threadgroup;
+const int p=kL-qL+s, complete=(p+1)/RATIO;
+const int sel_len=min(complete,KB)*RATIO, tail_start=complete*RATIO;
+const int L=sel_len+p+1-tail_start;
+const device int* blk=blocks+(long)bb*blocks_strides[0]+(long)s*blocks_strides[1];
+const device T* Kp=k+bb*k_strides[0]+hk*k_strides[1];
+const device T* Vp=v+bb*v_strides[0]+hk*v_strides[1];
+const device T* Qp=q+bb*q_strides[0]+(long)(hk*gqa)*q_strides[1]+(long)s*q_strides[2]+warp*128;
+threadgroup T KV[BK*LD];
+threadgroup float exchange[2][512];
+using ST=NAXTile<float,1,TK>;
+using OT=NAXTile<float,1,TDH>;
+OT O; O.clear();
+NAXTile<T,1,1> Q[TDH];
+STEEL_PRAGMA_UNROLL
+for (short d=0;d<TDH;++d) Q[d].load_rows(Qp+d*16, int(q_strides[1]), short(gqa));
+const short2 coord=BaseNAXFrag::get_coord();
+float2 max_score=float2(-3e38f),sum_score=float2(0.0f);
+const float scale=scl[0]*1.44269504088896340736f;
+for(int t0=0;t0<L;t0+=BK) {
+  const int rows=min(BK,L-t0);
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for(int i=tid;i<BK*32;i+=64) {
+    int r=i>>5,c=i&31; uint4 value=uint4(0);
+    if(r<rows) {
+      int pos=msv_qsa_pos(blk,t0+r,sel_len,tail_start,RATIO);
+      value=*((const device uint4*)(Kp+(long)pos*k_strides[2])+c);
+    }
+    *((threadgroup uint4*)(KV+r*LD)+c)=value;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  ST S; S.clear();
+  STEEL_PRAGMA_UNROLL
+  for(short ik=0;ik<TK;ik+=2) {
+    STEEL_PRAGMA_UNROLL
+    for(short d=0;d<TDH;++d) {
+      NAXTile<T,2,1> K;
+      K.template load<T,LD,1>(KV+ik*16*LD+warp*128+d*16);
+      BaseNAXFrag::mma(S.frag_at(0,ik),S.frag_at(0,ik+1),Q[d].frag_at(0,0),
+        metal::false_type{},K.frag_at(0,0),K.frag_at(1,0),metal::true_type{});
+    }
+    STEEL_PRAGMA_UNROLL
+    for(short i=0;i<8;++i) {
+      exchange[warp][lane*16+i]=S.frag_at(0,ik)[i];
+      exchange[warp][lane*16+8+i]=S.frag_at(0,ik+1)[i];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    STEEL_PRAGMA_UNROLL
+    for(short i=0;i<8;++i) {
+      S.frag_at(0,ik)[i]+=exchange[1-warp][lane*16+i];
+      S.frag_at(0,ik+1)[i]+=exchange[1-warp][lane*16+8+i];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+  STEEL_PRAGMA_UNROLL
+  for(short ik=0;ik<TK;++ik) {
+    STEEL_PRAGMA_UNROLL
+    for(short i=0;i<8;++i) {
+      S.frag_at(0,ik)[i]*=scale;
+      if(ik*16+coord.x+(i%4)>=rows) S.frag_at(0,ik)[i]=-INFINITY;
+    }
+  }
+  float2 new_max=max_score;
+  S.template row_reduce<QsaMax>(new_max);
+  S.template row_bin_op<QsaExpSub>(new_max);
+  float2 factor=metal::exp2(max_score-new_max);
+  max_score=new_max;
+  sum_score*=factor;
+  S.template row_reduce<QsaSum>(sum_score);
+  O.template row_bin_op<QsaMul>(factor);
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  for(int i=tid;i<BK*32;i+=64) {
+    int r=i>>5,c=i&31; uint4 value=uint4(0);
+    if(r<rows) {
+      int pos=msv_qsa_pos(blk,t0+r,sel_len,tail_start,RATIO);
+      value=*((const device uint4*)(Vp+(long)pos*v_strides[2])+c);
+    }
+    *((threadgroup uint4*)(KV+r*LD)+c)=value;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  STEEL_PRAGMA_UNROLL
+  for(short d=0;d<TDH;d+=2) {
+    STEEL_PRAGMA_UNROLL
+    for(short ik=0;ik<TK;++ik) {
+      NAXTile<T,1,2> V;
+      V.template load<T,LD,1>(KV+ik*16*LD+warp*128+d*16);
+      NAXTile<T,1,1> Shi, Slo, Stail;
+      for(short j=0;j<8;++j) {
+        Shi.frag_at(0,0)[j]=T(S.frag_at(0,ik)[j]);
+        float residual=S.frag_at(0,ik)[j]-float(Shi.frag_at(0,0)[j]);
+        Slo.frag_at(0,0)[j]=T(residual);
+        Stail.frag_at(0,0)[j]=T(residual-float(Slo.frag_at(0,0)[j]));
+      }
+      BaseNAXFrag::mma(O.frag_at(0,d),O.frag_at(0,d+1),Shi.frag_at(0,0),
+        metal::false_type{},V.frag_at(0,0),V.frag_at(0,1),metal::false_type{});
+      BaseNAXFrag::mma(O.frag_at(0,d),O.frag_at(0,d+1),Slo.frag_at(0,0),
+        metal::false_type{},V.frag_at(0,0),V.frag_at(0,1),metal::false_type{});
+      BaseNAXFrag::mma(O.frag_at(0,d),O.frag_at(0,d+1),Stail.frag_at(0,0),
+        metal::false_type{},V.frag_at(0,0),V.frag_at(0,1),metal::false_type{});
+    }
+  }
+}
+float2 inv=1.0f/sum_score;
+O.template row_bin_op<QsaMul>(inv);
+device T* Op=out+(((long)bb*Hq+hk*gqa)*qL+s)*BD+warp*128;
+O.store_rows(Op,qL*BD,short(gqa));

--- a/src/kernels/qsa_nax_header.metal
+++ b/src/kernels/qsa_nax_header.metal
@@ -1,0 +1,159 @@
+// Copyright © 2023-2024 Apple Inc. Adapted from MLX steel/attn/nax.h.
+// Only the cooperative fragments used by sparse attention are retained.
+#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#define STEEL_PRAGMA_UNROLL _Pragma("clang loop unroll(full)")
+namespace mlx { namespace steel {
+struct BaseNAXFrag {
+  template<typename U> using dtype_frag_t = metal::vec<U,8>;
+  static short2 get_coord() {
+    ushort lane=__metal_get_thread_index_in_simdgroup(ushort());
+    short qid=lane>>2;
+    return short2(((qid&2)|(lane&1))*4, (qid&4)|((lane>>1)&3));
+  }
+  template <
+      typename CType,
+      typename AType,
+      typename BType,
+      bool transpose_a = false,
+      bool transpose_b = false>
+  inline static constexpr void mma(
+      thread dtype_frag_t<CType>& Cn0,
+      thread dtype_frag_t<CType>& Cn1,
+      const thread dtype_frag_t<AType>& A,
+      metal::bool_constant<transpose_a>,
+      const thread dtype_frag_t<BType>& Bn0,
+      const thread dtype_frag_t<BType>& Bn1,
+      metal::bool_constant<transpose_b>) {
+    constexpr auto desc = mpp::tensor_ops::matmul2d_descriptor(
+        16,
+        32,
+        16,
+        transpose_a,
+        transpose_b,
+        true,
+        mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate);
+
+    mpp::tensor_ops::matmul2d<desc, metal::execution_simdgroup> gemm_op;
+
+    auto ct_a =
+        gemm_op
+            .template get_left_input_cooperative_tensor<AType, BType, CType>();
+    auto ct_b =
+        gemm_op
+            .template get_right_input_cooperative_tensor<AType, BType, CType>();
+
+    auto ct_c = gemm_op.template get_destination_cooperative_tensor<
+        metal::remove_addrspace_t<decltype(ct_a)>,
+        metal::remove_addrspace_t<decltype(ct_b)>,
+        CType>();
+
+    _Pragma("clang loop unroll(full)")
+    for (short i = 0; i < 8; i++) {
+      ct_a[i] = A[i];
+    }
+
+    _Pragma("clang loop unroll(full)")
+    for (short i = 0; i < 8; i++) {
+      ct_b[i] = Bn0[i];
+      ct_b[8 + i] = Bn1[i];
+    }
+
+    _Pragma("clang loop unroll(full)")
+    for (short i = 0; i < 8; i++) {
+      ct_c[i] = Cn0[i];
+      ct_c[8 + i] = Cn1[i];
+    }
+
+    gemm_op.run(ct_a, ct_b, ct_c);
+
+    _Pragma("clang loop unroll(full)")
+    for (short i = 0; i < 8; i++) {
+      Cn0[i] = ct_c[i];
+      Cn1[i] = ct_c[8 + i];
+    }
+  }
+
+};
+template<typename T,short R,short C> struct NAXTile {
+  using frag_type=metal::vec<T,8>;
+  frag_type data[R*C];
+  thread frag_type& frag_at(short r,short c) thread { return data[r*C+c]; }
+  void clear() thread {
+    STEEL_PRAGMA_UNROLL
+    for(short j=0;j<R*C;j++)data[j]=frag_type(0);
+  }
+  template<typename U,int LD,int STRIDE> void load(const threadgroup U* p) thread {
+    short2 xy=BaseNAXFrag::get_coord();
+    STEEL_PRAGMA_UNROLL
+    for(short r=0;r<R;r++) {
+      STEEL_PRAGMA_UNROLL
+      for(short c=0;c<C;c++) {
+        STEEL_PRAGMA_UNROLL
+        for(short j=0;j<8;j++)data[r*C+c][j]=T(p[(r*16+xy.y+(j/4)*8)*LD+(c*16+xy.x+j%4)*STRIDE]);
+      }
+    }
+  }
+  template<typename U> void load_rows(const device U* p,int ld,short rows) thread {
+    short2 xy=BaseNAXFrag::get_coord();
+    STEEL_PRAGMA_UNROLL
+    for(short r=0;r<R;r++) {
+      STEEL_PRAGMA_UNROLL
+      for(short c=0;c<C;c++) {
+        STEEL_PRAGMA_UNROLL
+        for(short j=0;j<8;j++) {
+          int row=r*16+xy.y+(j/4)*8;
+          data[r*C+c][j]=row<rows ? T(p[row*ld+c*16+xy.x+j%4]) : T(0);
+        }
+      }
+    }
+  }
+  template<typename U> void store_rows(device U* p,int ld,short rows) const thread {
+    short2 xy=BaseNAXFrag::get_coord();
+    STEEL_PRAGMA_UNROLL
+    for(short r=0;r<R;r++) {
+      STEEL_PRAGMA_UNROLL
+      for(short c=0;c<C;c++) {
+        STEEL_PRAGMA_UNROLL
+        for(short j=0;j<8;j++) {
+          int row=r*16+xy.y+(j/4)*8;
+          if(row<rows)p[row*ld+c*16+xy.x+j%4]=U(data[r*C+c][j]);
+        }
+      }
+    }
+  }
+  template<typename Op> void row_reduce(thread metal::vec<T,2*R>& values) const thread {
+    STEEL_PRAGMA_UNROLL
+    for(short r=0;r<R;r++) {
+      STEEL_PRAGMA_UNROLL
+      for(short c=0;c<C;c++) {
+        STEEL_PRAGMA_UNROLL
+        for(short row=0;row<2;row++) {
+          short j=row*4;
+          T v=Op::apply(Op::apply(data[r*C+c][j],data[r*C+c][j+1]),Op::apply(data[r*C+c][j+2],data[r*C+c][j+3]));
+          v=Op::apply(v,metal::simd_shuffle_xor(v,ushort(1)));
+          v=Op::apply(v,metal::simd_shuffle_xor(v,ushort(8)));
+          values[r*2+row]=Op::apply(values[r*2+row],v);
+        }
+      }
+    }
+  }
+  template<typename Op> void row_bin_op(thread metal::vec<T,2*R>& values) thread {
+    STEEL_PRAGMA_UNROLL
+    for(short r=0;r<R;r++) {
+      STEEL_PRAGMA_UNROLL
+      for(short c=0;c<C;c++) {
+        STEEL_PRAGMA_UNROLL
+        for(short j=0;j<8;j++)data[r*C+c][j]=Op::apply(data[r*C+c][j],values[r*2+j/4]);
+      }
+    }
+  }
+};
+}}
+inline int msv_qsa_pos(const device int* blk,int vi,int sel_len,int tail_start,int ratio) {
+  const int b=vi/ratio;
+  return vi<sel_len ? blk[b]*ratio+vi-b*ratio : tail_start+vi-sel_len;
+}
+struct QsaMax { template<typename T> static T apply(T a,T b) { return metal::max(a,b); } };
+struct QsaSum { template<typename T> static T apply(T a,T b) { return a+b; } };
+struct QsaMul { template<typename T> static T apply(T a,T b) { return a*b; } };
+struct QsaExpSub { template<typename T> static T apply(T a,T b) { return metal::exp2(a-b); } };

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -2931,6 +2931,51 @@ fn getAttnQsa256Kernel() !mlx.mlx_fast_metal_kernel {
     return kernel;
 }
 
+// Experimental opt-in until whole-model validation completes. Hardware probe
+// must run BEFORE constructing a Metal 4 cooperative-tensor kernel.
+var qsa_nax_platform_cached: ?bool = null;
+var qsa_nax_kernel_cached: ?mlx.mlx_fast_metal_kernel = null;
+pub var qsa_nax_override: ?bool = null;
+
+fn qsaNaxEnabled() bool {
+    const enabled = qsa_nax_override orelse blk: {
+        const raw = std.c.getenv("MLX_SERVE_QSA_NAX") orelse break :blk false;
+        break :blk std.mem.eql(u8, std.mem.span(raw), "1");
+    };
+    if (!enabled or !verifyQmmNaxAvailable()) return false;
+    if (qsa_nax_platform_cached) |v| return v;
+    var version_buf: [64]u8 = undefined;
+    const supported = qsaNaxOsSupported(macosProductVersion(&version_buf) orelse "");
+    qsa_nax_platform_cached = supported;
+    return supported;
+}
+
+fn qsaNaxOsSupported(version: []const u8) bool {
+    return macosVersionAtLeast(version, 26, 3);
+}
+
+fn getQsaNaxKernel() !mlx.mlx_fast_metal_kernel {
+    if (qsa_nax_kernel_cached) |kernel| return kernel;
+    const names = [_][*:0]const u8{ "q", "k", "v", "scl", "blocks" };
+    const outputs = [_][*:0]const u8{"out"};
+    const in_vec = mlx.mlx_vector_string_new_data(&names, names.len);
+    defer _ = mlx.mlx_vector_string_free(in_vec);
+    const out_vec = mlx.mlx_vector_string_new_data(&outputs, outputs.len);
+    defer _ = mlx.mlx_vector_string_free(out_vec);
+    const kernel = mlx.mlx_fast_metal_kernel_new(
+        "msv_qsa_nax_precise",
+        in_vec,
+        out_vec,
+        @embedFile("kernels/qsa_nax.metal"),
+        @embedFile("kernels/qsa_nax_header.metal"),
+        false,
+        false,
+    );
+    if (kernel.ctx == null) return error.MetalKernelCompileFailed;
+    qsa_nax_kernel_cached = kernel;
+    return kernel;
+}
+
 /// Block-gathered QSA attention (qwen4_exp prefill): `blocks` is the
 /// [B, S, KB] int32 selection, each row ascending with INT_MAX past its
 /// count; `ratio` tokens per block. Same envelope as the p256 kernel (hd
@@ -2961,13 +3006,14 @@ pub fn gatherQsa256(
     if (ratio <= 0) return null;
     if (mlx.mlx_array_dtype(q) != .bfloat16 or mlx.mlx_array_dtype(k) != .bfloat16 or mlx.mlx_array_dtype(v) != .bfloat16) return null;
 
-    const kernel = getAttnQsa256Kernel() catch return null;
+    const use_nax = gqa == 12 and qs[2] >= 16 and qsaNaxEnabled();
+    const kernel = (if (use_nax) getQsaNaxKernel() else getAttnQsa256Kernel()) catch return null;
     const one = [_]c_int{1};
     const scl_data = [_]f32{scale};
     const scl = mlx.mlx_array_new_data(&scl_data, &one, 1, .float32);
     defer _ = mlx.mlx_array_free(scl);
     const nsg: c_int = @divTrunc(gqa + 7, 8);
-    const bk = qsaGatherBk();
+    const bk: c_int = if (use_nax) 32 else qsaGatherBk();
 
     const config = mlx.mlx_fast_metal_kernel_config_new();
     defer _ = mlx.mlx_fast_metal_kernel_config_free(config);
@@ -2990,7 +3036,7 @@ pub fn gatherQsa256(
     var out = mlx.mlx_array_new();
     try mlx.check(mlx.mlx_vector_array_get(&out, outputs_vec, 0));
     if (qsa_engaged_bits.take(qsaEngagedBit(.prefill_gather, qs[2]))) {
-        log.info("[qsa-gather] engaged: msv_attn_qsa256 S={d} kv={d} blocks={d} bk={d} (MLX_SERVE_QSA_GATHER=0 restores the dense mask arm)\n", .{ qs[2], ks[2], bs[2], bk });
+        log.info("[qsa-gather] engaged: {s} S={d} kv={d} blocks={d} bk={d} (MLX_SERVE_QSA_NAX=0 restores stock gather)\n", .{ if (use_nax) "msv_qsa_nax_precise" else "msv_attn_qsa256", qs[2], ks[2], bs[2], bk });
     }
     return out;
 }
@@ -40582,6 +40628,52 @@ const QsaBlockFixture = struct {
         _ = mlx.mlx_array_free(self.mask);
     }
 };
+
+test "qsaNaxOsSupported: cooperative input tensors require macOS 26.3" {
+    try std.testing.expect(!qsaNaxOsSupported("26.2"));
+    try std.testing.expect(qsaNaxOsSupported("26.3"));
+    try std.testing.expect(qsaNaxOsSupported("26.5"));
+    try std.testing.expect(!qsaNaxOsSupported(""));
+}
+
+test "gatherQsa256 NAX: precise sparse attention and stock fallback" {
+    if (!verifyQmmNaxAvailable()) return error.SkipZigTest;
+    qsa_nax_override = true;
+    defer qsa_nax_override = null;
+    if (!qsaNaxEnabled()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+    qsa_gather_override = true;
+    defer qsa_gather_override = null;
+    defer qsa_gather_bk_override = null;
+    var prng = std.Random.DefaultPrng.init(0x9a7e);
+    const rnd = prng.random();
+
+    // qwen4_exp geometry (24/2 heads, hd 256, ratio 4) with a tiny block
+    // budget so the chunk's rows cross from "every block fits" to top-k.
+    const qL: c_int = 40;
+    const kL: c_int = 101;
+    const kb: c_int = 6;
+    const q_shape = [_]c_int{ 1, 24, qL, 256 };
+    const kv_shape = [_]c_int{ 1, 2, kL, 256 };
+    const q = try attn256RandBf16(rnd, &q_shape, s);
+    defer _ = mlx.mlx_array_free(q);
+    const k = try attn256RandBf16(rnd, &kv_shape, s);
+    defer _ = mlx.mlx_array_free(k);
+    const v = try attn256RandBf16(rnd, &kv_shape, s);
+    defer _ = mlx.mlx_array_free(v);
+    var fx = try QsaBlockFixture.build(rnd, qL, kL, kb, 4);
+    defer fx.deinit();
+    const scale: f32 = 1.0 / 16.0;
+
+    const ref = try attn256Reference(q, k, v, scale, "array", fx.mask, s);
+    defer _ = mlx.mlx_array_free(ref);
+    for ([_]bool{ false, true }) |enabled| {
+        qsa_nax_override = enabled;
+        const out = (try gatherQsa256(s, q, k, v, scale, fx.blocks, 4)) orelse return error.GatherDeclined;
+        defer _ = mlx.mlx_array_free(out);
+        try std.testing.expect(try attn256MaxDiff(out, ref, s) < 0.005);
+    }
+}
 
 test "gatherQsa256: block-gathered QSA parity vs composed 'array' SDPA over the expanded mask (gqa 12, sentinel rows, 16/32 key tiles)" {
     const s = mlx.gpuStream();

--- a/tests/qsa_nax_precision.cpp
+++ b/tests/qsa_nax_precision.cpp
@@ -1,0 +1,98 @@
+// Run from the repository root; links the same libmlx as the server.
+// clang++ -std=c++20 -O2 -mmacosx-version-min=26.2 tests/qsa_nax_precision.cpp -Ilib/mlx/include -Llib/mlx/lib -lmlx -o /tmp/qsa-precision
+// DYLD_LIBRARY_PATH="$PWD/lib/mlx/lib" /tmp/qsa-precision
+#include <mlx/mlx.h>
+#include <algorithm>
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
+namespace mx = mlx::core;
+std::string read_file(const std::string& path) {
+    std::ifstream f(path); std::stringstream s; s << f.rdbuf();
+    if (!f) throw std::runtime_error("Cannot read " + path);
+    return s.str();
+}
+mx::array random_array(mx::Shape shape, std::mt19937& rng) {
+    size_t n=1; for(int d:shape)n*=d;
+    std::vector<float> v(n); std::uniform_real_distribution<float> dist(-1,1);
+    for(auto& x:v)x=dist(rng);
+    return mx::astype(mx::array(v.data(),shape),mx::bfloat16);
+}
+
+#include <cmath>
+#include <numeric>
+
+void replace_all(std::string& s,const std::string& a,const std::string& b) {
+  size_t p=0;while((p=s.find(a,p))!=std::string::npos){s.replace(p,a.size(),b);p+=b.size();}
+}
+std::string zig_metal(const std::string& name) {
+  auto file=read_file("src/transformer.zig");
+  auto start=file.find("const "+name+" =");
+  if(start==std::string::npos)throw std::runtime_error("missing kernel "+name);
+  auto end=file.find("\n;",start);
+  std::istringstream lines(file.substr(start,end-start));
+  std::string line,result;
+  while(std::getline(lines,line)) {
+    auto p=line.find("\\\\");
+    if(p!=std::string::npos)result+=line.substr(p+2)+"\n";
+  }
+  return result;
+}
+// CPU double reference computes sparse attention directly, independent of the GPU
+// fragments, online softmax, and MLX's reduced-precision matmul implementation.
+int main() {
+  for(auto cfg:std::vector<std::vector<int>>{{2,17,17,512},{1,40,101,6},{1,65,65599,512}}) {
+    int B=cfg[0],S=cfg[1],KV=cfg[2],KB=cfg[3];
+    std::mt19937 rng(4289+S);std::vector<int> ids(size_t(B)*S*KB,INT_MAX);
+    for(int b=0;b<B;b++)for(int s=0;s<S;s++) {
+      int complete=(KV-S+s+1)/4;std::vector<int> choices(complete);
+      std::iota(choices.begin(),choices.end(),0);std::shuffle(choices.begin(),choices.end(),rng);
+      choices.resize(std::min(KB,complete));std::sort(choices.begin(),choices.end());
+      std::copy(choices.begin(),choices.end(),ids.begin()+(b*S+s)*KB);
+    }
+    // Transposed physical layout exercises head/query/KV strides, as used by the cache.
+    auto q=mx::transpose(random_array({B,S,24,256},rng),{0,2,1,3});
+    auto k=mx::transpose(random_array({B,KV,2,256},rng),{0,2,1,3});
+    auto v=mx::transpose(random_array({B,KV,2,256},rng),{0,2,1,3});
+    auto blocks=mx::array(ids.data(),{B,S,KB});
+    auto qc=mx::contiguous(mx::astype(q,mx::float32));
+    auto kc=mx::contiguous(mx::astype(k,mx::float32));
+    auto vc=mx::contiguous(mx::astype(v,mx::float32));mx::eval(qc,kc,vc);
+    const float *Q=qc.data<float>(),*K=kc.data<float>(),*V=vc.data<float>();
+    std::vector<size_t> indices;std::vector<double> reference;
+    for(int b=0;b<B;b++)for(int s:std::vector<int>{0,1,S-2,S-1})for(int h:std::vector<int>{0,7,11,12,23}) {
+      std::vector<int> positions;int p=KV-S+s,complete=(p+1)/4;
+      for(int j=0;j<std::min(KB,complete);j++)for(int r=0;r<4;r++)positions.push_back(ids[(b*S+s)*KB+j]*4+r);
+      for(int r=complete*4;r<=p;r++)positions.push_back(r);
+      std::vector<double> scores;double m=-INFINITY;
+      for(int pos:positions) {
+        double dot=0;for(int d=0;d<256;d++)dot+=double(Q[((b*24+h)*S+s)*256+d])*K[((b*2+h/12)*KV+pos)*256+d];
+        scores.push_back(dot/16);m=std::max(m,dot/16);
+      }
+      double z=0;for(double& a:scores){a=std::exp(a-m);z+=a;}
+      for(int d=0;d<256;d++) {
+        double y=0;for(size_t j=0;j<positions.size();j++)y+=scores[j]*V[((b*2+h/12)*KV+positions[j])*256+d];
+        indices.push_back(((b*24+h)*S+s)*256+d);reference.push_back(y/z);
+      }
+    }
+    for(int variant:{0,3}) {
+      auto source=variant==3?read_file("src/kernels/qsa_nax.metal"):zig_metal("ATTN_QSA256_KERNEL_SOURCE");
+      auto header=variant==3?read_file("src/kernels/qsa_nax_header.metal"):zig_metal("ATTN256_KERNEL_HEADER")+zig_metal("ATTN_QSA256_KERNEL_HEADER");
+      replace_all(source,"device T* Op=out","device float* Op=out");
+      replace_all(source,"device T* Optr = out","device float* Optr = out");
+      replace_all(source,"T(Ofrag[id].x * inv)","(Ofrag[id].x * inv)");
+      replace_all(source,"T(Ofrag[id].y * inv)","(Ofrag[id].y * inv)");
+      auto kernel=mx::fast::metal_kernel("qsa_validate_"+std::to_string(variant),{"q","k","v","scl","blocks"},{"out"},source,header,false);
+      auto out=kernel({q,k,v,mx::array({0.0625f}),blocks},{{B,24,S,256}},{mx::float32},{S*32,4,B},{32,2,1},{{"T",mx::bfloat16},{"NSG",2},{"BK",32},{"RATIO",4}},{},false,mx::Device::gpu);mx::eval(out);
+      double maxerr=0,ss=0;auto y=out[0].data<float>();
+      for(size_t j=0;j<indices.size();j++) {
+        double e=std::abs(y[indices[j]]-reference[j]);if(!std::isfinite(e))throw std::runtime_error("nonfinite output");
+        maxerr=std::max(maxerr,e);ss+=e*e;
+      }
+      std::cout<<"{\"variant\":"<<variant<<",\"batch\":"<<B<<",\"s\":"<<S<<",\"kv\":"<<KV<<",\"kb\":"<<KB<<",\"checked\":"<<indices.size()<<",\"max_error_vs_f64\":"<<maxerr<<",\"rmse_vs_f64\":"<<std::sqrt(ss/indices.size())<<"}"<<std::endl;
+      if(maxerr>2e-6)throw std::runtime_error("FP32 output accuracy regression");
+    }
+  }
+}

--- a/tests/test_qsa_nax_prefill.py
+++ b/tests/test_qsa_nax_prefill.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""HTTP correctness and engagement guard; point at a disposable server with cache off.
+
+MLX_SERVE_QSA_NAX=1 MLX_SERVE_PREFILL_CHUNK=4096 zig-out/bin/mlx-serve serve \
+  --port 11234 --ctx-size 131072 --prefix-cache-entries 0 > /tmp/qsa-server.log 2>&1
+python3 tests/test_qsa_nax_prefill.py --log /tmp/qsa-server.log --nax on
+Repeat with MLX_SERVE_QSA_NAX=0 and --nax off for the stock arm.
+"""
+import argparse
+import json
+from pathlib import Path
+import urllib.request
+
+p = argparse.ArgumentParser()
+p.add_argument('--url', default='http://127.0.0.1:11234')
+p.add_argument('--model', default='ddalcu/Qwen3.8-Flash-Next-MLX-Serve-4bit')
+p.add_argument('--log', type=Path, required=True)
+p.add_argument('--nax', choices=('on', 'off'), required=True)
+args = p.parse_args()
+source = (Path(__file__).resolve().parents[1] / 'src/transformer.zig').read_text()
+corpus = '\n'.join(source.splitlines()[100:900])
+for nonce in ('81492017', '52839106'):
+    prompt = (f'Nonce {nonce}. Remember the passphrase MAGNOLIA-7731.\n'
+              + (corpus * 4)[:40000]
+              + '\nWhat was the passphrase? Answer with the passphrase only.')
+    body = {'model': args.model, 'messages': [{'role': 'user', 'content': prompt}],
+            'temperature': 0, 'seed': 1234, 'max_tokens': 32,
+            'enable_mtp': False, 'enable_pld': False, 'stream': False}
+    req = urllib.request.Request(args.url + '/v1/chat/completions',
+                                 data=json.dumps(body).encode(),
+                                 headers={'Content-Type': 'application/json'})
+    with urllib.request.urlopen(req, timeout=300) as response:
+        result = json.load(response)
+    usage = result['usage']
+    assert usage['prompt_tokens'] > 8192, usage
+    assert usage.get('prompt_tokens_details', {}).get('cached_tokens', 0) == 0, usage
+    answer = result['choices'][0]['message']['content']
+    assert 'MAGNOLIA-7731' in answer, result
+    print(json.dumps({'arm': args.nax, 'usage': usage, 'answer': answer}), flush=True)
+log = args.log.read_text()
+expected = ('[qsa-gather] engaged: msv_qsa_nax_precise' if args.nax == 'on'
+            else '[qsa-gather] engaged: msv_attn_qsa256')
+assert expected in log, f'Missing engagement: {expected}'
+if args.nax == 'off':
+    assert '[qsa-gather] engaged: msv_qsa_nax_precise' not in log
+print('PASS: long prefill answers and expected QSA arm')


### PR DESCRIPTION
Qwen4 sparse prefill attention can keep Q and output fragments in cooperative NAX registers while gathering the same selected KV blocks. This adds an opt-in path for G17, macOS 26.3+, bf16, head dimension 256 and GQA 12; `MLX_SERVE_QSA_NAX=0` retains the stock gather path.

Softmax probabilities are decomposed into three bf16 terms for PV multiplication, retaining float32 precision with relaxed NAX MMA. Block selection and causal tails are unchanged.

Validation on M5 Max 128 GB, macOS 26.5, against main `16a47ec`:
- ReleaseFast build: 7/7 steps succeeded. Full tests: 2230 passed, 153 skipped, zero failures.
- Independent CPU float64 oracle: max FP32-output error 1.61e-7 across batch 2, strided inputs, sentinel rows, ragged causal tails and KV=65599.
- `tests/test_qsa_nax_prefill.py` checks long HTTP prompts and the selected kernel's engagement line.
- Rebuilt with an independent Zig cache after detecting stale build artifacts from a shared cache. Fresh full-model performance checks are in progress; this remains a draft until results can be tied to the rebuilt binary.
