### PR TITLE
fix(app): reach a server bound to a specific interface host

### DIFF
--- a/app/Sources/MLXServe/Services/APIClient.swift
+++ b/app/Sources/MLXServe/Services/APIClient.swift
@@ -84,6 +84,13 @@ struct RetryPolicy {
 }
 
 class APIClient {
+    /// The host address used to connect to the server. Defaults to loopback;
+    /// set to the configured `ServerOptions.host` so the app can monitor a
+    /// server bound to a specific LAN IP (e.g. `192.168.1.10`).
+    /// When the server binds `0.0.0.0`, loopback still works, so the default
+    /// is safe for the common case.
+    var host: String = "127.0.0.1"
+
     private let session: URLSession = {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = 600
@@ -93,8 +100,18 @@ class APIClient {
     }()
     private let decoder = JSONDecoder()
 
+    /// Build a URL pointing at the local server. Centralises the host so
+    /// callers don't hardcode `127.0.0.1`.
+    func serverURL(port: UInt16, path: String) -> URL {
+        // When the server binds 0.0.0.0, connecting via 127.0.0.1 works and
+        // stays inside the loopback trust boundary (no api-key needed).
+        // Only use the configured host when it's a specific interface address.
+        let effectiveHost = (host.isEmpty || host == "0.0.0.0" || host == "::") ? "127.0.0.1" : host
+        return URL(string: "http://\(effectiveHost):\(port)\(path)")!
+    }
+
     func checkHealth(port: UInt16) async throws -> Bool {
-        let url = URL(string: "http://127.0.0.1:\(port)/health")!
+        let url = serverURL(port: port, path: "/health")
         let (data, response) = try await session.data(from: url)
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             return false
@@ -117,7 +134,7 @@ class APIClient {
     /// callers prefer this over `fetchModels(port:)` so the picker UI can
     /// show loaded/unloaded badges per model.
     func fetchAllModels(port: UInt16) async throws -> [ModelInfo] {
-        let url = URL(string: "http://127.0.0.1:\(port)/v1/models")!
+        let url = serverURL(port: port, path: "/v1/models")
         let (data, _) = try await session.data(from: url)
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataArr = json["data"] as? [[String: Any]] else { return [] }
@@ -211,7 +228,7 @@ class APIClient {
     }
 
     func loadModel(port: UInt16, id: String, drafterPath: String? = nil, setDefault: Bool = false) async throws -> ModelInfo {
-        let url = URL(string: "http://127.0.0.1:\(port)/v1/load-model")!
+        let url = serverURL(port: port, path: "/v1/load-model")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -242,7 +259,7 @@ class APIClient {
     /// Ask the server to absorb models downloaded after it booted (discovery
     /// only walks the roots at startup). Add-only and idempotent server-side.
     func reloadProviders(port: UInt16) async throws {
-        let url = URL(string: "http://127.0.0.1:\(port)/v1/providers/reload")!
+        let url = serverURL(port: port, path: "/v1/providers/reload")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 10
@@ -254,7 +271,7 @@ class APIClient {
     }
 
     func providerStatus(port: UInt16) async throws -> [ProviderStatus] {
-        let url = URL(string: "http://127.0.0.1:\(port)/v1/providers")!
+        let url = serverURL(port: port, path: "/v1/providers")
         var request = URLRequest(url: url)
         request.timeoutInterval = 10
         let (data, _) = try await session.data(for: request)
@@ -262,7 +279,7 @@ class APIClient {
     }
 
     func rescanModels(port: UInt16) async throws {
-        let url = URL(string: "http://127.0.0.1:\(port)/v1/models/rescan")!
+        let url = serverURL(port: port, path: "/v1/models/rescan")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 30
@@ -273,7 +290,7 @@ class APIClient {
     }
 
     func unloadModel(port: UInt16, id: String) async throws {
-        let url = URL(string: "http://127.0.0.1:\(port)/v1/unload-model")!
+        let url = serverURL(port: port, path: "/v1/unload-model")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -297,7 +314,7 @@ class APIClient {
                 do {
                     var body = json
                     body["stream"] = true
-                    var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)\(path)")!)
+                    var req = URLRequest(url: serverURL(port: port, path: path))
                     req.httpMethod = "POST"
                     req.setValue("application/json", forHTTPHeaderField: "Content-Type")
                     req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
@@ -342,7 +359,7 @@ class APIClient {
     /// (the server runs one padded masked GPU forward per 64-text chunk).
     /// Returns one vector per input, in input order.
     func embeddings(port: UInt16, model: String, input: [String]) async throws -> [[Double]] {
-        let url = URL(string: "http://127.0.0.1:\(port)/v1/embeddings")!
+        let url = serverURL(port: port, path: "/v1/embeddings")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -375,7 +392,7 @@ class APIClient {
     }
 
     func fetchProps(port: UInt16) async throws -> PropsSnapshot? {
-        let url = URL(string: "http://127.0.0.1:\(port)/props")!
+        let url = serverURL(port: port, path: "/props")
         let (data, _) = try await session.data(from: url)
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let mem = json["memory"] as? [String: Any] else { return nil }
@@ -385,7 +402,7 @@ class APIClient {
     /// Live throughput feed. 503s when the server was launched without
     /// `--metrics`, which reads as nil (the tray hides the rows).
     func fetchThroughput(port: UInt16) async throws -> ThroughputSnapshot? {
-        let url = URL(string: "http://127.0.0.1:\(port)/metrics.json")!
+        let url = serverURL(port: port, path: "/metrics.json")
         let (data, response) = try await session.data(from: url)
         guard (response as? HTTPURLResponse)?.statusCode == 200,
               let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
@@ -552,7 +569,7 @@ class APIClient {
         continueFinalMessage: Bool = false,
         continuation: AsyncThrowingStream<SSEEvent, Error>.Continuation
     ) async throws {
-        let url = URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!
+        let url = serverURL(port: port, path: "/v1/chat/completions")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/app/Sources/MLXServe/Services/APIClient.swift
+++ b/app/Sources/MLXServe/Services/APIClient.swift
@@ -98,13 +98,21 @@ class APIClient {
     }()
     private let decoder = JSONDecoder()
 
-    /// Build a URL pointing at the server, honouring `host`.
+    /// Build a URL pointing at the server, honouring `host`. The settings
+    /// field is free text, so anything that does not form a valid URL falls
+    /// back to loopback instead of trapping — a 1 s health poll must be able
+    /// to report the server down, not crash the app.
     func serverURL(port: UInt16, path: String) -> URL {
-        let effectiveHost = (host.isEmpty || host == "0.0.0.0" || host == "::") ? "127.0.0.1" : host
-        // An unbracketed IPv6 host makes the authority malformed (the port
-        // parses as part of the address) and URL(string:) returns nil.
+        var effectiveHost = host
+        if effectiveHost.isEmpty || effectiveHost == "0.0.0.0" || effectiveHost == "::" {
+            effectiveHost = "127.0.0.1"
+        }
+        if effectiveHost.hasPrefix("[") && effectiveHost.hasSuffix("]") {
+            effectiveHost = String(effectiveHost.dropFirst().dropLast())
+        }
         let authority = effectiveHost.contains(":") ? "[\(effectiveHost)]" : effectiveHost
-        return URL(string: "http://\(authority):\(port)\(path)")!
+        return URL(string: "http://\(authority):\(port)\(path)")
+            ?? URL(string: "http://127.0.0.1:\(port)\(path)")!
     }
 
     func checkHealth(port: UInt16) async throws -> Bool {

--- a/app/Sources/MLXServe/Services/APIClient.swift
+++ b/app/Sources/MLXServe/Services/APIClient.swift
@@ -84,11 +84,9 @@ struct RetryPolicy {
 }
 
 class APIClient {
-    /// The host address used to connect to the server. Defaults to loopback;
-    /// set to the configured `ServerOptions.host` so the app can monitor a
-    /// server bound to a specific LAN IP (e.g. `192.168.1.10`).
-    /// When the server binds `0.0.0.0`, loopback still works, so the default
-    /// is safe for the common case.
+    /// Host used to reach the server. Set to `ServerOptions.host` at launch so
+    /// a server bound to a specific interface address is still reachable;
+    /// wide binds stay on loopback (the no-api-key trust boundary).
     var host: String = "127.0.0.1"
 
     private let session: URLSession = {
@@ -100,12 +98,8 @@ class APIClient {
     }()
     private let decoder = JSONDecoder()
 
-    /// Build a URL pointing at the local server. Centralises the host so
-    /// callers don't hardcode `127.0.0.1`.
+    /// Build a URL pointing at the server, honouring `host`.
     func serverURL(port: UInt16, path: String) -> URL {
-        // When the server binds 0.0.0.0, connecting via 127.0.0.1 works and
-        // stays inside the loopback trust boundary (no api-key needed).
-        // Only use the configured host when it's a specific interface address.
         let effectiveHost = (host.isEmpty || host == "0.0.0.0" || host == "::") ? "127.0.0.1" : host
         return URL(string: "http://\(effectiveHost):\(port)\(path)")!
     }

--- a/app/Sources/MLXServe/Services/APIClient.swift
+++ b/app/Sources/MLXServe/Services/APIClient.swift
@@ -101,7 +101,10 @@ class APIClient {
     /// Build a URL pointing at the server, honouring `host`.
     func serverURL(port: UInt16, path: String) -> URL {
         let effectiveHost = (host.isEmpty || host == "0.0.0.0" || host == "::") ? "127.0.0.1" : host
-        return URL(string: "http://\(effectiveHost):\(port)\(path)")!
+        // An unbracketed IPv6 host makes the authority malformed (the port
+        // parses as part of the address) and URL(string:) returns nil.
+        let authority = effectiveHost.contains(":") ? "[\(effectiveHost)]" : effectiveHost
+        return URL(string: "http://\(authority):\(port)\(path)")!
     }
 
     func checkHealth(port: UInt16) async throws -> Bool {

--- a/app/Sources/MLXServe/Services/ClonedVoiceSynthesizer.swift
+++ b/app/Sources/MLXServe/Services/ClonedVoiceSynthesizer.swift
@@ -270,9 +270,12 @@ final class VoiceCloneTTS {
     private var loadedModelId: String?
     private var loadedDir: String?
 
-    init(server: ServerManager) { self.server = server }
+    init(server: ServerManager) {
+        self.server = server
+    }
 
     func synthesize(text: String, voice sel: NeuralVoice) async -> Data? {
+        api.host = server.api.host
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         // The engine choice picks the MODEL too — Kokoro is its own checkpoint,
@@ -348,7 +351,8 @@ final class VoiceCloneTTS {
                 loadedDir = dir
             }
             guard let json = VoiceCloneTTS.warmBody(model: loadedModelId ?? dir, voice: sel) else { return }
-            var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/audio/speech")!)
+            api.host = server.api.host
+            var req = URLRequest(url: api.serverURL(port: port, path: "/v1/audio/speech"))
             req.httpMethod = "POST"
             req.setValue("application/json", forHTTPHeaderField: "Content-Type")
             req.httpBody = try? JSONSerialization.data(withJSONObject: json)

--- a/app/Sources/MLXServe/Services/ClonedVoiceSynthesizer.swift
+++ b/app/Sources/MLXServe/Services/ClonedVoiceSynthesizer.swift
@@ -270,9 +270,7 @@ final class VoiceCloneTTS {
     private var loadedModelId: String?
     private var loadedDir: String?
 
-    init(server: ServerManager) {
-        self.server = server
-    }
+    init(server: ServerManager) { self.server = server }
 
     func synthesize(text: String, voice sel: NeuralVoice) async -> Data? {
         api.host = server.api.host

--- a/app/Sources/MLXServe/Services/ServerManager.swift
+++ b/app/Sources/MLXServe/Services/ServerManager.swift
@@ -65,7 +65,7 @@ class ServerManager: ObservableObject {
     private var healthTimer: Timer?
     private var healthTask: Task<Void, Never>?
     private var pollSource: DispatchSourceTimer?
-    private let api = APIClient()
+    let api = APIClient()
     /// True while the tray popover is on screen. Drives the live /props
     /// ticker — when the popover is closed there's nothing to render, so we
     /// stop polling entirely instead of burning 3 s ticks in the background.
@@ -184,6 +184,7 @@ class ServerManager: ObservableObject {
     /// termination handler, and health polling.
     private func launch(args: [String], options: ServerOptions) {
         port = options.port
+        api.host = options.host
         status = .starting
         lastError = ""
         chatDefaultEnsured = false
@@ -528,13 +529,14 @@ class ServerManager: ObservableObject {
     private func startHealthPolling() {
         healthTask?.cancel()
         let checkPort = port
+        let healthURL = api.serverURL(port: checkPort, path: "/health")
         // Use a GCD timer on the main queue — guaranteed to fire even during init.
         // URLSession completion runs on a background queue and dispatches back to main.
         let source = DispatchSource.makeTimerSource(queue: .main)
         source.schedule(deadline: .now() + 1, repeating: 1.0)
         source.setEventHandler { [weak self] in
             guard let self else { source.cancel(); return }
-            let url = URL(string: "http://127.0.0.1:\(checkPort)/health")!
+            let url = healthURL
             URLSession.shared.dataTask(with: url) { data, response, error in
                 guard let http = response as? HTTPURLResponse, http.statusCode == 200,
                       let data, let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/app/Tests/MLXCoreTests/APIClientServerURLTests.swift
+++ b/app/Tests/MLXCoreTests/APIClientServerURLTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import MLXCore
+
+/// Tests for `APIClient.serverURL(port:path:)` — the centralised URL builder
+/// that replaced the hardcoded `127.0.0.1` literals. A wrong host here means
+/// the app silently fails to reach a server bound to a specific LAN IP.
+final class APIClientServerURLTests: XCTestCase {
+
+    // MARK: - Default (loopback)
+
+    func testDefaultHostIsLoopback() {
+        let api = APIClient()
+        XCTAssertEqual(api.host, "127.0.0.1")
+    }
+
+    func testDefaultHostProducesLoopbackURL() {
+        let api = APIClient()
+        let url = api.serverURL(port: 11234, path: "/health")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/health")
+    }
+
+    // MARK: - Wide bind (0.0.0.0) falls back to loopback
+
+    func testWideBind0000FallsBackToLoopback() {
+        let api = APIClient()
+        api.host = "0.0.0.0"
+        let url = api.serverURL(port: 11234, path: "/health")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/health",
+                       "0.0.0.0 should fall back to 127.0.0.1 to stay in the loopback trust boundary")
+    }
+
+    func testWideBindIPv6FallsBackToLoopback() {
+        let api = APIClient()
+        api.host = "::"
+        let url = api.serverURL(port: 11234, path: "/v1/models")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/v1/models",
+                       ":: should fall back to 127.0.0.1")
+    }
+
+    func testEmptyHostFallsBackToLoopback() {
+        let api = APIClient()
+        api.host = ""
+        let url = api.serverURL(port: 8080, path: "/props")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:8080/props",
+                       "Empty host should fall back to 127.0.0.1")
+    }
+
+    // MARK: - Specific LAN IP
+
+    func testSpecificLanIPIsUsedDirectly() {
+        let api = APIClient()
+        api.host = "192.168.1.10"
+        let url = api.serverURL(port: 11234, path: "/health")
+        XCTAssertEqual(url.absoluteString, "http://192.168.1.10:11234/health")
+    }
+
+    func testSpecificLanIPWithDifferentPort() {
+        let api = APIClient()
+        api.host = "10.0.0.5"
+        let url = api.serverURL(port: 9999, path: "/v1/chat/completions")
+        XCTAssertEqual(url.absoluteString, "http://10.0.0.5:9999/v1/chat/completions")
+    }
+
+    // MARK: - Explicit loopback
+
+    func testExplicitLoopbackIsKept() {
+        let api = APIClient()
+        api.host = "127.0.0.1"
+        let url = api.serverURL(port: 11234, path: "/metrics.json")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/metrics.json")
+    }
+
+    // MARK: - Path variations
+
+    func testRootPath() {
+        let api = APIClient()
+        let url = api.serverURL(port: 11234, path: "/")
+        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/")
+    }
+
+    func testDeepPath() {
+        let api = APIClient()
+        api.host = "192.168.0.100"
+        let url = api.serverURL(port: 11234, path: "/v1/audio/speech")
+        XCTAssertEqual(url.absoluteString, "http://192.168.0.100:11234/v1/audio/speech")
+    }
+}

--- a/app/Tests/MLXCoreTests/APIClientServerURLTests.swift
+++ b/app/Tests/MLXCoreTests/APIClientServerURLTests.swift
@@ -53,4 +53,18 @@ final class APIClientServerURLTests: XCTestCase {
         XCTAssertEqual(api.serverURL(port: 11234, path: "/health").absoluteString,
                        "http://[::1]:11234/health")
     }
+
+    func testAlreadyBracketedIPv6IsNotDoubleBracketed() {
+        let api = APIClient()
+        api.host = "[::1]"
+        XCTAssertEqual(api.serverURL(port: 11234, path: "/health").absoluteString,
+                       "http://[::1]:11234/health")
+    }
+
+    func testUnparseableHostFallsBackToLoopback() {
+        let api = APIClient()
+        api.host = "http://192.168.1.10"
+        XCTAssertEqual(api.serverURL(port: 11234, path: "/health").absoluteString,
+                       "http://127.0.0.1:11234/health")
+    }
 }

--- a/app/Tests/MLXCoreTests/APIClientServerURLTests.swift
+++ b/app/Tests/MLXCoreTests/APIClientServerURLTests.swift
@@ -46,4 +46,11 @@ final class APIClientServerURLTests: XCTestCase {
         XCTAssertEqual(api.serverURL(port: 11234, path: "/v1/audio/speech").absoluteString,
                        "http://192.168.1.10:11234/v1/audio/speech")
     }
+
+    func testIPv6HostIsBracketed() {
+        let api = APIClient()
+        api.host = "::1"
+        XCTAssertEqual(api.serverURL(port: 11234, path: "/health").absoluteString,
+                       "http://[::1]:11234/health")
+    }
 }

--- a/app/Tests/MLXCoreTests/APIClientServerURLTests.swift
+++ b/app/Tests/MLXCoreTests/APIClientServerURLTests.swift
@@ -1,87 +1,49 @@
 import XCTest
 @testable import MLXCore
 
-/// Tests for `APIClient.serverURL(port:path:)` — the centralised URL builder
-/// that replaced the hardcoded `127.0.0.1` literals. A wrong host here means
-/// the app silently fails to reach a server bound to a specific LAN IP.
+/// `APIClient.serverURL` must honour a specific interface host while keeping
+/// wide binds on loopback — otherwise the app silently loses a server it
+/// bound to a LAN IP.
 final class APIClientServerURLTests: XCTestCase {
-
-    // MARK: - Default (loopback)
-
-    func testDefaultHostIsLoopback() {
-        let api = APIClient()
-        XCTAssertEqual(api.host, "127.0.0.1")
-    }
 
     func testDefaultHostProducesLoopbackURL() {
         let api = APIClient()
-        let url = api.serverURL(port: 11234, path: "/health")
-        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/health")
+        XCTAssertEqual(api.serverURL(port: 11234, path: "/health").absoluteString,
+                       "http://127.0.0.1:11234/health")
     }
-
-    // MARK: - Wide bind (0.0.0.0) falls back to loopback
 
     func testWideBind0000FallsBackToLoopback() {
         let api = APIClient()
         api.host = "0.0.0.0"
-        let url = api.serverURL(port: 11234, path: "/health")
-        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/health",
-                       "0.0.0.0 should fall back to 127.0.0.1 to stay in the loopback trust boundary")
+        XCTAssertEqual(api.serverURL(port: 11234, path: "/health").absoluteString,
+                       "http://127.0.0.1:11234/health")
     }
 
     func testWideBindIPv6FallsBackToLoopback() {
         let api = APIClient()
         api.host = "::"
-        let url = api.serverURL(port: 11234, path: "/v1/models")
-        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/v1/models",
-                       ":: should fall back to 127.0.0.1")
+        XCTAssertEqual(api.serverURL(port: 11234, path: "/v1/models").absoluteString,
+                       "http://127.0.0.1:11234/v1/models")
     }
 
     func testEmptyHostFallsBackToLoopback() {
         let api = APIClient()
         api.host = ""
-        let url = api.serverURL(port: 8080, path: "/props")
-        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:8080/props",
-                       "Empty host should fall back to 127.0.0.1")
+        XCTAssertEqual(api.serverURL(port: 8080, path: "/props").absoluteString,
+                       "http://127.0.0.1:8080/props")
     }
-
-    // MARK: - Specific LAN IP
-
-    func testSpecificLanIPIsUsedDirectly() {
-        let api = APIClient()
-        api.host = "192.168.1.10"
-        let url = api.serverURL(port: 11234, path: "/health")
-        XCTAssertEqual(url.absoluteString, "http://192.168.1.10:11234/health")
-    }
-
-    func testSpecificLanIPWithDifferentPort() {
-        let api = APIClient()
-        api.host = "10.0.0.5"
-        let url = api.serverURL(port: 9999, path: "/v1/chat/completions")
-        XCTAssertEqual(url.absoluteString, "http://10.0.0.5:9999/v1/chat/completions")
-    }
-
-    // MARK: - Explicit loopback
 
     func testExplicitLoopbackIsKept() {
         let api = APIClient()
         api.host = "127.0.0.1"
-        let url = api.serverURL(port: 11234, path: "/metrics.json")
-        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/metrics.json")
+        XCTAssertEqual(api.serverURL(port: 11234, path: "/metrics.json").absoluteString,
+                       "http://127.0.0.1:11234/metrics.json")
     }
 
-    // MARK: - Path variations
-
-    func testRootPath() {
+    func testSpecificLanIPIsUsedDirectly() {
         let api = APIClient()
-        let url = api.serverURL(port: 11234, path: "/")
-        XCTAssertEqual(url.absoluteString, "http://127.0.0.1:11234/")
-    }
-
-    func testDeepPath() {
-        let api = APIClient()
-        api.host = "192.168.0.100"
-        let url = api.serverURL(port: 11234, path: "/v1/audio/speech")
-        XCTAssertEqual(url.absoluteString, "http://192.168.0.100:11234/v1/audio/speech")
+        api.host = "192.168.1.10"
+        XCTAssertEqual(api.serverURL(port: 11234, path: "/v1/audio/speech").absoluteString,
+                       "http://192.168.1.10:11234/v1/audio/speech")
     }
 }


### PR DESCRIPTION
**What changed / why**
When the Settings host is a specific interface address (e.g. a LAN IP), the app's `APIClient` kept hitting hardcoded `127.0.0.1` and silently lost the server it had just started — no health, no model list, no chat. `APIClient` now carries the host, `ServerManager` sets it from `ServerOptions.host` at launch, and every request URL goes through one `serverURL(port:path:)` helper. Wide binds (`0.0.0.0` / `::`) stay on loopback, which keeps the no-api-key trust boundary. Related to #212 (servers the app did not start); this one is the app losing contact with a server it did start.

**How I verified it** (chip, macOS, `swift test`, live run)
M5 Max, macOS 26.5.1, Xcode 26.2. `FAST_DEV=1 app/build.sh`; `swift test` 3314/0 (9 new in `APIClientServerURLTests`). Served `Qwen3.8-27B-MLX-Serve-8bit` with the host set to a specific LAN IP: health, `/v1/models` and a chat completion all answered through that host while `127.0.0.1` correctly refused.

- [x] Searched open and closed issues, open PRs and recent commits; linked the existing thread if there is one
- [x] Built and ran this tree on a real Apple Silicon Mac in this session
- [x] No comments that restate code, carry history, or cite audit/review items
- [x] No source-scan tests; every test checks behaviour
- [x] One fix or feature; description under ~15 lines
