### PR TITLE
perf(qwen4): batched slots gather their selected QSA blocks; the batched verify carries PLE capture (stacked on #391)

### DIFF
--- a/src/generate.zig
+++ b/src/generate.zig
@@ -6109,6 +6109,7 @@ pub const Generator = struct {
         // the point at which the entry's n-gram history + `spec_ple_tokens`
         // advance. Must precede BOTH the first eval of anything downstream of
         // the leaf (Phase 4) and `ssmRollbackFromCapture` (Phase 5).
+        errdefer xfm.discardDeferredPle(&self.ctx);
         try xfm.flushDeferredPle(&self.ctx);
         st.verify_logits = verify_logits;
         st.new_hidden = new_hidden;
@@ -9256,6 +9257,7 @@ fn lazyForward(xfm: *Transformer, ctx: *ForwardCtx, lazy_token: mlx.mlx_array) !
         return e;
     };
     xfm.flushDeferredPle(ctx) catch |e| {
+        xfm.discardDeferredPle(ctx);
         _ = mlx.mlx_array_free(logits);
         return e;
     };

--- a/src/model.zig
+++ b/src/model.zig
@@ -924,6 +924,14 @@ pub const ModelConfig = struct {
         return self.isQwen4();
     }
 
+    pub fn batchedEffectiveKvLen(self: *const ModelConfig, kv: u32, gather_on: bool, gather_min_kv: u32) u32 {
+        if (!self.isQwen4() or !gather_on) return kv;
+        if (kv <= gather_min_kv) return kv;
+        const cap = self.indexer_budget + self.indexer_compress_ratio;
+        if (cap == 0) return kv;
+        return @min(kv, cap);
+    }
+
     /// SSD-first prefix cache arch predicate; delegates to `longCtxGated`.
     pub fn ssdFirstCapable(self: *const ModelConfig) bool {
         return self.longCtxGated();

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -2298,7 +2298,8 @@ pub fn batchKvLenOf(cache: *const KVCache, cfg: ?*const model_mod.ModelConfig) u
     // so every other arch keeps `cache.step` (and the dead cap) pending a measurement.
     const c = cfg orelse return @intCast(cache.step);
     if (!c.longCtxGated()) return @intCast(cache.step);
-    return @intCast(cache.kvLenForBatching());
+    const raw: u32 = @intCast(cache.kvLenForBatching());
+    return c.batchedEffectiveKvLen(raw, transformer_mod.qsaBatchedGatherEnabled(), @intCast(transformer_mod.qsaGatherMinKv()));
 }
 
 /// Pure-config predicate: is this model's architecture compatible with the
@@ -7039,9 +7040,21 @@ fn mtpGroupEnabled() bool {
 /// qwen4_exp verify rows are expert BYTES (S=1/2/4 = 16/22/31 ms) and the batched forward
 /// has no PLE spec capture at S > 1, so its MTP rounds stay solo; two of them interleave
 /// (68 tok/s aggregate vs 65 plain), three lose to the plain batched tick (67 vs 82).
+var mtp_batched_qwen4_env: ?bool = null;
+fn mtpBatchedQwen4Enabled() bool {
+    if (mtp_batched_qwen4_env) |v| return v;
+    const on = if (std.c.getenv("MLX_SERVE_MTP_BATCHED_QWEN4")) |p| !std.mem.eql(u8, std.mem.span(p), "0") else false;
+    mtp_batched_qwen4_env = on;
+    return on;
+}
+
+fn mtpQwen4StaySolo(has_qwen4: bool, env_on: bool) bool {
+    return has_qwen4 and !env_on;
+}
+
 fn mtpRoundsStaySolo(slot: *const Slot) bool {
     const t = slot.model.transformer orelse return true;
-    return t.qwen4 != null;
+    return mtpQwen4StaySolo(t.qwen4 != null, mtpBatchedQwen4Enabled());
 }
 
 fn mtpCrowdThresholdFor(slot: *const Slot) usize {
@@ -7649,6 +7662,64 @@ test "an attention-first trunk's batching lengths are unchanged by the fix" {
         batchedKvKeepCount(&[_]u32{ 1_000, 1_000, 1_000, 100_000 }),
         batchedKvKeepCount(&kv_lens),
     );
+}
+
+test "batchKvLenOf bills qwen4 selected length when the gather arm is on" {
+    const prev = transformer_mod.qsa_batched_gather_override;
+    defer transformer_mod.qsa_batched_gather_override = prev;
+    transformer_mod.qsa_batched_gather_override = true;
+    var q4 = model_mod.ModelConfig{
+        .model_type = "qwen4_exp",
+        .indexer_budget = 2048,
+        .indexer_compress_ratio = 4,
+    };
+    var cache = try KVCache.init(testing.allocator, 32);
+    defer cache.deinit();
+    cache.entries[3].initialized = true;
+    cache.entries[3].offset = 162_000;
+    try testing.expectEqual(@as(u32, 2052), batchKvLenOf(&cache, &q4));
+    transformer_mod.qsa_batched_gather_override = false;
+    try testing.expectEqual(@as(u32, 162_000), batchKvLenOf(&cache, &q4));
+    var llama = model_mod.ModelConfig{ .model_type = "llama" };
+    cache.step = 162_000;
+    cache.entries[0].initialized = true;
+    cache.entries[0].offset = 162_000;
+    transformer_mod.qsa_batched_gather_override = true;
+    try testing.expectEqual(@as(u32, 162_000), batchKvLenOf(&cache, &llama));
+}
+
+test "batchedEffectiveKvLen: qwen4 bills selected length, other archs keep raw kv" {
+    var q4 = model_mod.ModelConfig{
+        .model_type = "qwen4_exp",
+        .indexer_budget = 2048,
+        .indexer_compress_ratio = 4,
+    };
+    const min_kv: u32 = 8192;
+    try testing.expectEqual(@as(u32, 2052), q4.batchedEffectiveKvLen(162_000, true, min_kv));
+    try testing.expectEqual(@as(u32, 2052), q4.batchedEffectiveKvLen(64_000, true, min_kv));
+    try testing.expectEqual(@as(u32, 8000), q4.batchedEffectiveKvLen(8000, true, min_kv));
+    try testing.expectEqual(@as(u32, 162_000), q4.batchedEffectiveKvLen(162_000, false, min_kv));
+    var llama = model_mod.ModelConfig{ .model_type = "llama" };
+    try testing.expectEqual(@as(u32, 162_000), llama.batchedEffectiveKvLen(162_000, true, min_kv));
+    var q35 = model_mod.ModelConfig{ .model_type = "qwen3_5" };
+    try testing.expectEqual(@as(u32, 162_000), q35.batchedEffectiveKvLen(162_000, true, min_kv));
+
+    const billed = [_]u32{
+        q4.batchedEffectiveKvLen(16_384, true, min_kv),
+        q4.batchedEffectiveKvLen(162_000, true, min_kv),
+    };
+    try testing.expectEqual(@as(usize, 2), batchedKvKeepCount(&billed));
+    const raw_pair = [_]u32{ 16_384, 162_000 };
+    try testing.expectEqual(@as(usize, 0), batchedKvKeepCount(&raw_pair));
+    const other = [_]u32{ 1_000, 162_000 };
+    try testing.expectEqual(@as(usize, 0), batchedKvKeepCount(&other));
+}
+
+test "mtpQwen4StaySolo is opt-in" {
+    try testing.expect(mtpQwen4StaySolo(true, false));
+    try testing.expect(!mtpQwen4StaySolo(true, true));
+    try testing.expect(!mtpQwen4StaySolo(false, false));
+    try testing.expect(!mtpQwen4StaySolo(false, true));
 }
 
 test "modelBatchable permits pure-attention" {

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -731,14 +731,6 @@ pub const Slot = struct {
     }
 
     /// This slot's attention KV length for the batched group; never `cache.step` (0 forever on a linear-layer-0 trunk).
-    pub fn batchKvLen(self: *const Slot) u32 {
-        return self.batchKvLenAt(1);
-    }
-
-    pub fn batchKvLenAt(self: *const Slot, seq_len: c_int) u32 {
-        return batchKvLenOfWith(&self.cache, self.model.config, seq_len, self.mrope_pos != null);
-    }
-
     /// Free everything the slot owns. Only safe to call when no thread can
     /// observe the slot anymore (i.e. after the inference thread has
     /// finished/errored it AND the connection thread has consumed the final

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -732,7 +732,11 @@ pub const Slot = struct {
 
     /// This slot's attention KV length for the batched group; never `cache.step` (0 forever on a linear-layer-0 trunk).
     pub fn batchKvLen(self: *const Slot) u32 {
-        return batchKvLenOf(&self.cache, self.model.config);
+        return self.batchKvLenAt(1);
+    }
+
+    pub fn batchKvLenAt(self: *const Slot, seq_len: c_int) u32 {
+        return batchKvLenOfWith(&self.cache, self.model.config, seq_len, self.mrope_pos != null);
     }
 
     /// Free everything the slot owns. Only safe to call when no thread can
@@ -2294,12 +2298,18 @@ pub fn batchedPadWaste(kv_lens_asc: []const u32) f64 {
 /// KDA) it is 0 forever and the pad-waste cap never fired. `KVCache.kvLenForBatching` reads
 /// the first attention layer's own offset there.
 pub fn batchKvLenOf(cache: *const KVCache, cfg: ?*const model_mod.ModelConfig) u32 {
+    return batchKvLenOfWith(cache, cfg, 1, false);
+}
+
+pub fn batchKvLenOfWith(cache: *const KVCache, cfg: ?*const model_mod.ModelConfig, seq_len: c_int, any_mrope: bool) u32 {
     // Arch gate: the multi-stream batched wins on the 27B were measured with the cap dead,
     // so every other arch keeps `cache.step` (and the dead cap) pending a measurement.
     const c = cfg orelse return @intCast(cache.step);
     if (!c.longCtxGated()) return @intCast(cache.step);
     const raw: u32 = @intCast(cache.kvLenForBatching());
-    return c.batchedEffectiveKvLen(raw, transformer_mod.qsaBatchedGatherEnabled(), @intCast(transformer_mod.qsaGatherMinKv()));
+    const gather_on = transformer_mod.qsaBatchedGatherOn(seq_len, any_mrope);
+    const min_kv: u32 = @intCast(transformer_mod.qsaBatchedGatherFloor(seq_len));
+    return c.batchedEffectiveKvLen(raw, gather_on, min_kv);
 }
 
 /// Pure-config predicate: is this model's architecture compatible with the
@@ -7082,7 +7092,7 @@ fn runMtpGroups(sch: *Scheduler, slots: []*Slot) !void {
         }
         if (group.len >= 2) {
             var kv_lens: [MAX_BATCH_GROUP]u32 = undefined;
-            for (group, 0..) |g, i| kv_lens[i] = g.batchKvLen();
+            for (group, 0..) |g, i| kv_lens[i] = g.batchKvLenAt(2);
             var i: usize = 1;
             while (i < group.len) : (i += 1) {
                 const slot_i = group[i];
@@ -7686,6 +7696,49 @@ test "batchKvLenOf bills qwen4 selected length when the gather arm is on" {
     cache.entries[0].offset = 162_000;
     transformer_mod.qsa_batched_gather_override = true;
     try testing.expectEqual(@as(u32, 162_000), batchKvLenOf(&cache, &llama));
+}
+
+test "batchKvLenOf bills raw when any gather switch is off or the slot is vision" {
+    const prev_b = transformer_mod.qsa_batched_gather_override;
+    const prev_g = transformer_mod.qsa_gather_override;
+    const prev_d = transformer_mod.qsa_decode_gather_override;
+    const prev_v = transformer_mod.qsa_verify_gather_override;
+    defer {
+        transformer_mod.qsa_batched_gather_override = prev_b;
+        transformer_mod.qsa_gather_override = prev_g;
+        transformer_mod.qsa_decode_gather_override = prev_d;
+        transformer_mod.qsa_verify_gather_override = prev_v;
+    }
+    transformer_mod.qsa_batched_gather_override = true;
+    transformer_mod.qsa_gather_override = true;
+    transformer_mod.qsa_decode_gather_override = true;
+    transformer_mod.qsa_verify_gather_override = true;
+    var q4 = model_mod.ModelConfig{
+        .model_type = "qwen4_exp",
+        .indexer_budget = 2048,
+        .indexer_compress_ratio = 4,
+    };
+    var cache = try KVCache.init(testing.allocator, 32);
+    defer cache.deinit();
+    cache.entries[3].initialized = true;
+    cache.entries[3].offset = 162_000;
+    try testing.expectEqual(@as(u32, 2052), batchKvLenOfWith(&cache, &q4, 1, false));
+    try testing.expectEqual(@as(u32, 2052), batchKvLenOfWith(&cache, &q4, 4, false));
+    try testing.expectEqual(@as(u32, 162_000), batchKvLenOfWith(&cache, &q4, 1, true));
+    try testing.expectEqual(@as(u32, 162_000), batchKvLenOfWith(&cache, &q4, 4, true));
+    transformer_mod.qsa_batched_gather_override = false;
+    try testing.expectEqual(@as(u32, 162_000), batchKvLenOfWith(&cache, &q4, 1, false));
+    transformer_mod.qsa_batched_gather_override = true;
+    transformer_mod.qsa_gather_override = false;
+    try testing.expectEqual(@as(u32, 162_000), batchKvLenOfWith(&cache, &q4, 1, false));
+    transformer_mod.qsa_gather_override = true;
+    transformer_mod.qsa_decode_gather_override = false;
+    try testing.expectEqual(@as(u32, 162_000), batchKvLenOfWith(&cache, &q4, 1, false));
+    try testing.expectEqual(@as(u32, 2052), batchKvLenOfWith(&cache, &q4, 4, false));
+    transformer_mod.qsa_decode_gather_override = true;
+    transformer_mod.qsa_verify_gather_override = false;
+    try testing.expectEqual(@as(u32, 2052), batchKvLenOfWith(&cache, &q4, 1, false));
+    try testing.expectEqual(@as(u32, 162_000), batchKvLenOfWith(&cache, &q4, 4, false));
 }
 
 test "batchedEffectiveKvLen: qwen4 bills selected length, other archs keep raw kv" {

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -2312,6 +2312,20 @@ pub fn batchKvLenOfWith(cache: *const KVCache, cfg: ?*const model_mod.ModelConfi
     return c.batchedEffectiveKvLen(raw, gather_on, min_kv);
 }
 
+pub fn fillGroupPadWasteKvLens(
+    caches: []const *const KVCache,
+    cfg: ?*const model_mod.ModelConfig,
+    seq_len: c_int,
+    mrope: []const bool,
+    out: []u32,
+) void {
+    var any_mrope = false;
+    for (mrope) |m| if (m) {
+        any_mrope = true;
+    };
+    for (caches, 0..) |c, i| out[i] = batchKvLenOfWith(c, cfg, seq_len, any_mrope);
+}
+
 /// Pure-config predicate: is this model's architecture compatible with the
 /// batched-decode kernel? Used by `Scheduler.batchable` after slot-level
 /// flags are checked. MoE / hybrid / encoder have shape mismatches with
@@ -6347,7 +6361,13 @@ fn runDecodeTick(sch: *Scheduler, active: []*Slot) !void {
             // The stable insertion sort is part of the change: `std.sort.pdq` is unstable and
             // off qwen4_exp every key is `cache.step` == 0, so the sort decides the ordering.
             if (gate_batch_kv_len) {
-                for (group, 0..) |g, i| kv_lens[i] = g.batchKvLen();
+                var caches_buf: [MAX_BATCH_GROUP]*const KVCache = undefined;
+                var mrope_buf: [MAX_BATCH_GROUP]bool = undefined;
+                for (group, 0..) |g, i| {
+                    caches_buf[i] = &g.cache;
+                    mrope_buf[i] = g.mrope_pos != null;
+                }
+                fillGroupPadWasteKvLens(caches_buf[0..group.len], group[0].model.config, 1, mrope_buf[0..group.len], kv_lens[0..group.len]);
                 // Stable insertion sort, ascending, slots and lengths moving together.
                 var i: usize = 1;
                 while (i < group.len) : (i += 1) {
@@ -7092,7 +7112,13 @@ fn runMtpGroups(sch: *Scheduler, slots: []*Slot) !void {
         }
         if (group.len >= 2) {
             var kv_lens: [MAX_BATCH_GROUP]u32 = undefined;
-            for (group, 0..) |g, i| kv_lens[i] = g.batchKvLenAt(2);
+            var caches_buf: [MAX_BATCH_GROUP]*const KVCache = undefined;
+            var mrope_buf: [MAX_BATCH_GROUP]bool = undefined;
+            for (group, 0..) |g, i| {
+                caches_buf[i] = &g.cache;
+                mrope_buf[i] = g.mrope_pos != null;
+            }
+            fillGroupPadWasteKvLens(caches_buf[0..group.len], group[0].model.config, 2, mrope_buf[0..group.len], kv_lens[0..group.len]);
             var i: usize = 1;
             while (i < group.len) : (i += 1) {
                 const slot_i = group[i];
@@ -7739,6 +7765,81 @@ test "batchKvLenOf bills raw when any gather switch is off or the slot is vision
     transformer_mod.qsa_verify_gather_override = false;
     try testing.expectEqual(@as(u32, 2052), batchKvLenOfWith(&cache, &q4, 1, false));
     try testing.expectEqual(@as(u32, 162_000), batchKvLenOfWith(&cache, &q4, 4, false));
+}
+
+test "grouping a 300k text slot beside a 1k vision slot is not admitted on the sparse bill" {
+    const prev_b = transformer_mod.qsa_batched_gather_override;
+    const prev_g = transformer_mod.qsa_gather_override;
+    const prev_d = transformer_mod.qsa_decode_gather_override;
+    defer {
+        transformer_mod.qsa_batched_gather_override = prev_b;
+        transformer_mod.qsa_gather_override = prev_g;
+        transformer_mod.qsa_decode_gather_override = prev_d;
+    }
+    transformer_mod.qsa_batched_gather_override = true;
+    transformer_mod.qsa_gather_override = true;
+    transformer_mod.qsa_decode_gather_override = true;
+    var q4 = model_mod.ModelConfig{
+        .model_type = "qwen4_exp",
+        .indexer_budget = 2048,
+        .indexer_compress_ratio = 4,
+    };
+    var caches: [2]KVCache = undefined;
+    var built: usize = 0;
+    defer for (caches[0..built]) |*c| c.deinit();
+    caches[0] = try KVCache.init(testing.allocator, 32);
+    built = 1;
+    caches[0].entries[3].initialized = true;
+    caches[0].entries[3].offset = 300_000;
+    caches[1] = try KVCache.init(testing.allocator, 32);
+    built = 2;
+    caches[1].entries[3].initialized = true;
+    caches[1].entries[3].offset = 1_000;
+    const ptrs = [_]*const KVCache{ &caches[0], &caches[1] };
+    var billed: [2]u32 = undefined;
+    fillGroupPadWasteKvLens(&ptrs, &q4, 1, &.{ false, true }, &billed);
+    try testing.expectEqual(@as(u32, 300_000), billed[0]);
+    try testing.expectEqual(@as(u32, 1_000), billed[1]);
+    var billed_asc = billed;
+    std.mem.sort(u32, &billed_asc, {}, std.sort.asc(u32));
+    try testing.expectEqual(@as(usize, 0), batchedKvKeepCount(&billed_asc));
+    const per_slot = [_]u32{
+        batchKvLenOfWith(&caches[1], &q4, 1, true),
+        batchKvLenOfWith(&caches[0], &q4, 1, false),
+    };
+    try testing.expectEqual(@as(usize, 2), batchedKvKeepCount(&per_slot));
+}
+
+test "S>=2 pad-waste floor is max of gather and verify mins" {
+    const prev_b = transformer_mod.qsa_batched_gather_override;
+    const prev_g = transformer_mod.qsa_gather_override;
+    const prev_v = transformer_mod.qsa_verify_gather_override;
+    const prev_gm = transformer_mod.qsa_gather_min_kv_override;
+    const prev_vm = transformer_mod.qsa_verify_gather_min_kv_override;
+    defer {
+        transformer_mod.qsa_batched_gather_override = prev_b;
+        transformer_mod.qsa_gather_override = prev_g;
+        transformer_mod.qsa_verify_gather_override = prev_v;
+        transformer_mod.qsa_gather_min_kv_override = prev_gm;
+        transformer_mod.qsa_verify_gather_min_kv_override = prev_vm;
+    }
+    transformer_mod.qsa_batched_gather_override = true;
+    transformer_mod.qsa_gather_override = true;
+    transformer_mod.qsa_verify_gather_override = true;
+    transformer_mod.qsa_gather_min_kv_override = 20_000;
+    transformer_mod.qsa_verify_gather_min_kv_override = 16_384;
+    var q4 = model_mod.ModelConfig{
+        .model_type = "qwen4_exp",
+        .indexer_budget = 2048,
+        .indexer_compress_ratio = 4,
+    };
+    var cache = try KVCache.init(testing.allocator, 32);
+    defer cache.deinit();
+    cache.entries[3].initialized = true;
+    cache.entries[3].offset = 18_000;
+    try testing.expectEqual(@as(u32, 18_000), batchKvLenOfWith(&cache, &q4, 4, false));
+    cache.entries[3].offset = 162_000;
+    try testing.expectEqual(@as(u32, 2052), batchKvLenOfWith(&cache, &q4, 4, false));
 }
 
 test "batchedEffectiveKvLen: qwen4 bills selected length, other archs keep raw kv" {

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -2744,6 +2744,8 @@ pub fn qsaBatchedGatherEnabled() bool {
 
 pub fn qsaBatchedGatherOn(seq_len: c_int, any_mrope: bool) bool {
     if (any_mrope) return false;
+    const st = qwen4Standin();
+    if (st.attn_qsa or st.attn_sdpa) return false;
     if (!qsaBatchedGatherEnabled()) return false;
     if (!qsaGatherEnabled()) return false;
     if (seq_len <= 1) return qsaDecodeGatherEnabled();
@@ -2751,7 +2753,7 @@ pub fn qsaBatchedGatherOn(seq_len: c_int, any_mrope: bool) bool {
 }
 
 pub fn qsaBatchedGatherFloor(seq_len: c_int) c_int {
-    if (seq_len >= 2) return qsaVerifyGatherMinKv();
+    if (seq_len >= 2) return @max(qsaGatherMinKv(), qsaVerifyGatherMinKv());
     return qsaGatherMinKv();
 }
 
@@ -4473,6 +4475,7 @@ pub fn qsaBatchedGatherAttn(
     masks: []const mlx.mlx_array,
     ratio: c_int,
     attn_scale: f32,
+    out_arms: []QsaArm,
 ) !mlx.mlx_array {
     const qs = mlx.getShape(q_rope);
     const n: usize = @intCast(qs[0]);
@@ -4481,6 +4484,7 @@ pub fn qsaBatchedGatherAttn(
     const hd: c_int = qs[3];
     if (views.len != n or blocks.len != n) return error.QsaBatchedGatherLen;
     if (masks.len != 0 and masks.len != n) return error.QsaBatchedGatherLen;
+    if (out_arms.len != 0 and out_arms.len != n) return error.QsaBatchedGatherLen;
     const fused_min_s = qsaAttnMinS();
     const standin_sdpa = qwen4Standin().attn_sdpa;
     var outs = try allocator.alloc(mlx.mlx_array, n);
@@ -4520,6 +4524,11 @@ pub fn qsaBatchedGatherAttn(
         if (gathered) |g| {
             outs[i] = g;
             built = i + 1;
+            if (out_arms.len == n) out_arms[i] = switch (qsaWidthBucket(seq_len)) {
+                0 => .decode_gather,
+                1 => .verify_gather,
+                else => .prefill_gather,
+            };
             continue;
         }
         var mask_tmp: mlx.mlx_array = .{ .ctx = null };
@@ -4532,6 +4541,7 @@ pub fn qsaBatchedGatherAttn(
         } else .{ .ctx = null };
         outs[i] = mlx.mlx_array_new();
         built = i + 1;
+        if (out_arms.len == n) out_arms[i] = .mask;
         if (mask.ctx != null) {
             if (try fusedSdpa256Masked(s, q_slot, kv_view.k, kv_view.v, attn_scale, mask)) |fused| {
                 _ = mlx.mlx_array_free(outs[i]);
@@ -16191,11 +16201,6 @@ pub const Transformer = struct {
         entry.ple_prev_valid = true;
     }
 
-    pub fn pleDeferApplies(ple_defer: bool, batched: bool) bool {
-        _ = batched;
-        return ple_defer;
-    }
-
     /// Host-side n-gram gather: `[B, S, ple_embed_dim]` bf16 for this chunk's
     /// token ids, advancing the token history. Serial: `entry`'s history over
     /// `[1, S]`. Batched (`ctx.batch_slots`): `[N, 1]`, each row hashed
@@ -16224,8 +16229,8 @@ pub const Transformer = struct {
             }
             break :blk self.pleClaimSpecCapture(entry, n);
         };
-        if (pleDeferApplies(ctx.ple_defer, ctx.batch_slots != null)) {
-            std.debug.assert(ctx.ple_pending == null);
+        if (ctx.ple_defer) {
+            if (ctx.ple_pending != null) return error.PlePendingAlreadySet;
             @memset(pk, 0);
             const emb = mlx.mlx_array_new_data(pk.ptr, &shape, 3, .bfloat16);
             errdefer _ = mlx.mlx_array_free(emb);
@@ -16259,14 +16264,12 @@ pub const Transformer = struct {
     /// n-gram history advanced. No-op without a pending leaf.
     pub fn flushDeferredPle(self: *Transformer, ctx: *ForwardCtx) !void {
         const p = ctx.ple_pending orelse return;
-        ctx.ple_pending = null;
-        defer {
-            _ = mlx.mlx_array_free(p.emb);
-            _ = mlx.mlx_array_free(p.token_ids);
-        }
         const dst = mlx.mlx_array_data_bfloat16(p.emb) orelse return error.PleLeafUnreadable;
         const out: [*]u16 = @constCast(dst);
         try self.pleGatherBf16(ctx, p.token_ids, p.entry, p.layer, p.seq_len, out[0..mlx.mlx_array_size(p.emb)], p.capture);
+        ctx.ple_pending = null;
+        _ = mlx.mlx_array_free(p.emb);
+        _ = mlx.mlx_array_free(p.token_ids);
     }
 
     /// Drop a pending leaf without filling it (the forward that built on it
@@ -17056,9 +17059,9 @@ pub const Transformer = struct {
         // the selection too: `qsaVerifyGatherAttn` reads the UNION of the
         // rows' selections instead of the whole cache. Its own kv floor is
         // higher than the prefill/decode one — the union is fixed-size.
-        const want_blocks = batch == 1 and kv > qsaGatherMinKv() and qsaGatherEnabled() and
+        const want_blocks = batch == 1 and kv > (if (seq_len >= 2) @max(qsaGatherMinKv(), qsaVerifyGatherMinKv()) else qsaGatherMinKv()) and qsaGatherEnabled() and
             (seq_len >= FUSED256_MIN_Q_LEN or (seq_len == 1 and qsaDecodeGatherEnabled()) or
-                (seq_len >= 2 and seq_len < FUSED256_MIN_Q_LEN and qsaVerifyGatherEnabled() and kv > qsaVerifyGatherMinKv()));
+                (seq_len >= 2 and seq_len < FUSED256_MIN_Q_LEN and qsaVerifyGatherEnabled()));
         if (want_blocks) {
             // Prefill: sorted per-row block indices for the gather kernel;
             // the dense [S, kv] mask is never built. Decode (S==1): the same
@@ -19731,7 +19734,7 @@ pub const Transformer = struct {
     ) !?mlx.mlx_array {
         if (!qsaBatchedGatherEnabled()) return null;
         if (self.qwen4 == null) return null;
-        std.debug.assert(ctx.qsa_mask.ctx == null);
+        if (ctx.qsa_mask.ctx != null) return null;
         for (slots) |sc| if (sc.mrope_pos != null) return null;
         var any_blocks = false;
         for (slots) |sc| if (sc.qsa_blocks.ctx != null) {
@@ -19748,17 +19751,20 @@ pub const Transformer = struct {
         defer self.allocator.free(blks);
         var slot_masks = try self.allocator.alloc(mlx.mlx_array, slots.len);
         defer self.allocator.free(slot_masks);
+        const arms = try self.allocator.alloc(QsaArm, slots.len);
+        defer self.allocator.free(arms);
         for (slots, 0..) |slot_ctx, i| {
             views[i] = try slot_ctx.cache.denseView(layer, self.s);
             blks[i] = slot_ctx.qsa_blocks;
             slot_masks[i] = slot_ctx.qsa_mask;
-            if (slot_ctx.qsa_blocks.ctx != null) slot_ctx.qsa_arms.noteGather(seq_len) else slot_ctx.qsa_arms.note(.mask);
         }
         if (!qsa_batched_gather_logged) {
             qsa_batched_gather_logged = true;
             log.info("[qsa-batched-gather] engaged (slots={d} S={d}) — MLX_SERVE_QSA_BATCHED_GATHER=0 restores the dense padded mask\n", .{ slots.len, seq_len });
         }
-        return try qsaBatchedGatherAttn(self.allocator, self.s, q_rope, views, blks, slot_masks, ratio, attn_scale);
+        const stacked = try qsaBatchedGatherAttn(self.allocator, self.s, q_rope, views, blks, slot_masks, ratio, attn_scale, arms);
+        for (slots, arms) |slot_ctx, arm| slot_ctx.qsa_arms.note(arm);
+        return stacked;
     }
 
     fn gatedFullAttnWith(
@@ -26747,7 +26753,9 @@ var decode_prof_enabled: ?bool = null;
 /// in-situ fwd-ubench reports what that block costs. Diagnostic only.
 pub const Standin = packed struct(u16) { gdn: bool = false, attn: bool = false, mlp: bool = false, gdn_recur: bool = false, gdn_proj: bool = false, attn_qsa: bool = false, attn_sdpa: bool = false, hc: bool = false, moe_shared: bool = false, moe_router: bool = false, moe_gateup: bool = false, moe_down: bool = false, _pad: u4 = 0 };
 var standin_cached: ?Standin = null;
+pub var qwen4_standin_override: ?Standin = null;
 pub fn qwen4Standin() Standin {
+    if (qwen4_standin_override) |v| return v;
     if (standin_cached) |v| return v;
     var v = Standin{};
     if (std.c.getenv("QWEN4_STANDIN")) |raw| {
@@ -41506,7 +41514,7 @@ test "qsa batched gather S=1: N=1 is byte-identical to solo, N=2 matches per-slo
 
     const solo0 = (try qsaDecodeGatherAttn(s, q0, &view0, fx0.blocks, ratio, scale)) orelse return error.GatherDeclined;
     defer _ = mlx.mlx_array_free(solo0);
-    const bat1 = try qsaBatchedGatherAttn(ta, s, q0, &.{view0}, &.{fx0.blocks}, &.{}, ratio, scale);
+    const bat1 = try qsaBatchedGatherAttn(ta, s, q0, &.{view0}, &.{fx0.blocks}, &.{}, ratio, scale, &.{});
     defer _ = mlx.mlx_array_free(bat1);
     try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat1, solo0, s));
 
@@ -41518,7 +41526,7 @@ test "qsa batched gather S=1: N=1 is byte-identical to solo, N=2 matches per-slo
     try mlx.check(mlx.mlx_concatenate_axis(&q_n2, qvec, 0, s));
     const views = [_]DenseKVView{ view0, view1 };
     const blks = [_]mlx.mlx_array{ fx0.blocks, fx1.blocks };
-    const bat2 = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &.{}, ratio, scale);
+    const bat2 = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &.{}, ratio, scale, &.{});
     defer _ = mlx.mlx_array_free(bat2);
     const solo1 = (try qsaDecodeGatherAttn(s, q1, &view1, fx1.blocks, ratio, scale)) orelse return error.GatherDeclined;
     defer _ = mlx.mlx_array_free(solo1);
@@ -41580,7 +41588,7 @@ test "qsa batched gather mixed group: a mask-only slot matches its solo masked S
     const views = [_]DenseKVView{ view0, view1 };
     const blks = [_]mlx.mlx_array{ fx0.blocks, .{ .ctx = null } };
     const masks = [_]mlx.mlx_array{ .{ .ctx = null }, fx1.mask };
-    const bat = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &masks, ratio, scale);
+    const bat = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &masks, ratio, scale, &.{});
     defer _ = mlx.mlx_array_free(bat);
     var want = mlx.mlx_array_new();
     defer _ = mlx.mlx_array_free(want);
@@ -41632,7 +41640,7 @@ test "qsa batched gather S=2 and S=4: N=1 is byte-identical to solo verify, N=2 
         const view1 = DenseKVView{ .k = k1, .v = v1, .owned = false };
         const solo0 = (try qsaVerifyGatherAttn(s, q0, &view0, fx0.blocks, ratio, scale)) orelse return error.GatherDeclined;
         defer _ = mlx.mlx_array_free(solo0);
-        const bat1 = try qsaBatchedGatherAttn(ta, s, q0, &.{view0}, &.{fx0.blocks}, &.{}, ratio, scale);
+        const bat1 = try qsaBatchedGatherAttn(ta, s, q0, &.{view0}, &.{fx0.blocks}, &.{}, ratio, scale, &.{});
         defer _ = mlx.mlx_array_free(bat1);
         try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat1, solo0, s));
 
@@ -41644,7 +41652,7 @@ test "qsa batched gather S=2 and S=4: N=1 is byte-identical to solo verify, N=2 
         try mlx.check(mlx.mlx_concatenate_axis(&q_n2, qvec, 0, s));
         const views = [_]DenseKVView{ view0, view1 };
         const blks = [_]mlx.mlx_array{ fx0.blocks, fx1.blocks };
-        const bat2 = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &.{}, ratio, scale);
+        const bat2 = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &.{}, ratio, scale, &.{});
         defer _ = mlx.mlx_array_free(bat2);
         const solo1 = (try qsaVerifyGatherAttn(s, q1, &view1, fx1.blocks, ratio, scale)) orelse return error.GatherDeclined;
         defer _ = mlx.mlx_array_free(solo1);
@@ -41660,13 +41668,16 @@ test "qsa batched gather S=2 and S=4: N=1 is byte-identical to solo verify, N=2 
 
 test "qsaBatchedAttn: kill switch and mrope refuse the gather arm" {
     if (mlx.noGpuBackend()) return error.SkipZigTest;
-    var xfm: Transformer = undefined;
+    var xfm_bytes: [@sizeOf(Transformer)]u8 align(@alignOf(Transformer)) = @splat(0);
+    const xfm: *Transformer = @ptrCast(&xfm_bytes);
     xfm.allocator = std.testing.allocator;
-    xfm.qwen4 = @ptrFromInt(@alignOf(qwen4_mod.Qwen4State));
-    var cache: KVCache = undefined;
+    var q4_bytes: [@sizeOf(qwen4_mod.Qwen4State)]u8 align(@alignOf(qwen4_mod.Qwen4State)) = @splat(0);
+    xfm.qwen4 = @ptrCast(&q4_bytes);
+    var cache_bytes: [@sizeOf(KVCache)]u8 align(@alignOf(KVCache)) = @splat(0);
+    const cache: *KVCache = @ptrCast(&cache_bytes);
     var off: usize = 0;
-    var ctx: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
-    var slot: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+    var ctx: ForwardCtx = .{ .cache = cache, .moe_seq_offset = &off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+    var slot: ForwardCtx = .{ .cache = cache, .moe_seq_offset = &off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
     const slots = [_]*ForwardCtx{&slot};
     const dummy = mlx.mlx_array_new();
     defer _ = mlx.mlx_array_free(dummy);
@@ -41714,6 +41725,15 @@ test "qsaBatchedGatherOn matches the arm's switches and vision refusal" {
     qsa_verify_gather_override = false;
     try std.testing.expect(qsaBatchedGatherOn(1, false));
     try std.testing.expect(!qsaBatchedGatherOn(4, false));
+    qsa_verify_gather_override = true;
+    const prev_st = qwen4_standin_override;
+    defer qwen4_standin_override = prev_st;
+    qwen4_standin_override = .{ .attn_qsa = true };
+    try std.testing.expect(!qsaBatchedGatherOn(1, false));
+    qwen4_standin_override = .{ .attn_sdpa = true };
+    try std.testing.expect(!qsaBatchedGatherOn(1, false));
+    qwen4_standin_override = .{};
+    try std.testing.expect(qsaBatchedGatherOn(1, false));
 }
 
 // ── Verify-width QSA gather (S = 2 .. FUSED256_MIN_Q_LEN-1) ──
@@ -46388,13 +46408,6 @@ fn qwen4BatchedPleForward(
     }
     for (slots) |sl| sl.off += @intCast(seq_len);
     return .{ .logits = logits, .pending = pending };
-}
-
-test "ple_defer applies on the batched arm" {
-    try std.testing.expect(Transformer.pleDeferApplies(true, false));
-    try std.testing.expect(Transformer.pleDeferApplies(true, true));
-    try std.testing.expect(!Transformer.pleDeferApplies(false, false));
-    try std.testing.expect(!Transformer.pleDeferApplies(false, true));
 }
 
 test "batched PLE defer engages at N=2 and matches eager at S=1 and S=4" {

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -17059,9 +17059,9 @@ pub const Transformer = struct {
         // the selection too: `qsaVerifyGatherAttn` reads the UNION of the
         // rows' selections instead of the whole cache. Its own kv floor is
         // higher than the prefill/decode one — the union is fixed-size.
-        const want_blocks = batch == 1 and kv > (if (seq_len >= 2) @max(qsaGatherMinKv(), qsaVerifyGatherMinKv()) else qsaGatherMinKv()) and qsaGatherEnabled() and
+        const want_blocks = batch == 1 and kv > qsaGatherMinKv() and qsaGatherEnabled() and
             (seq_len >= FUSED256_MIN_Q_LEN or (seq_len == 1 and qsaDecodeGatherEnabled()) or
-                (seq_len >= 2 and seq_len < FUSED256_MIN_Q_LEN and qsaVerifyGatherEnabled()));
+                (seq_len >= 2 and seq_len < FUSED256_MIN_Q_LEN and qsaVerifyGatherEnabled() and kv > qsaVerifyGatherMinKv()));
         if (want_blocks) {
             // Prefill: sorted per-row block indices for the gather kernel;
             // the dense [S, kv] mask is never built. Decode (S==1): the same

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -2681,7 +2681,7 @@ pub const QSA_GATHER_MIN_KV_DEFAULT: c_int = 8192;
 var qsa_gather_min_kv_cached: ?c_int = null;
 pub var qsa_gather_min_kv_override: ?c_int = null;
 
-fn qsaGatherMinKv() c_int {
+pub fn qsaGatherMinKv() c_int {
     if (qsa_gather_min_kv_override) |v| return v;
     if (qsa_gather_min_kv_cached) |v| return v;
     var v: c_int = QSA_GATHER_MIN_KV_DEFAULT;
@@ -2724,6 +2724,21 @@ pub fn qsaDecodeGatherEnabled() bool {
         break :blk !std.mem.eql(u8, std.mem.sliceTo(raw, 0), "0");
     };
     qsa_decode_gather_env_cached = v;
+    return v;
+}
+
+pub var qsa_batched_gather_override: ?bool = null;
+var qsa_batched_gather_env_cached: ?bool = null;
+var qsa_batched_gather_logged: bool = false;
+
+pub fn qsaBatchedGatherEnabled() bool {
+    if (qsa_batched_gather_override) |v| return v;
+    if (qsa_batched_gather_env_cached) |v| return v;
+    const v = blk: {
+        const raw = std.c.getenv("MLX_SERVE_QSA_BATCHED_GATHER") orelse break :blk true;
+        break :blk !std.mem.eql(u8, std.mem.sliceTo(raw, 0), "0");
+    };
+    qsa_batched_gather_env_cached = v;
     return v;
 }
 
@@ -4436,6 +4451,87 @@ pub fn qsaDecodeGatherAttn(
     return out;
 }
 
+pub fn qsaBatchedGatherAttn(
+    allocator: std.mem.Allocator,
+    s: mlx.mlx_stream,
+    q_rope: mlx.mlx_array,
+    views: []const DenseKVView,
+    blocks: []const mlx.mlx_array,
+    ratio: c_int,
+    attn_scale: f32,
+) !mlx.mlx_array {
+    const qs = mlx.getShape(q_rope);
+    const n: usize = @intCast(qs[0]);
+    const seq_len: c_int = qs[2];
+    const h_count: c_int = qs[1];
+    const hd: c_int = qs[3];
+    if (views.len != n or blocks.len != n) return error.QsaBatchedGatherLen;
+    const fused_min_s = qsaAttnMinS();
+    var outs = try allocator.alloc(mlx.mlx_array, n);
+    defer allocator.free(outs);
+    var built: usize = 0;
+    errdefer {
+        var fi: usize = 0;
+        while (fi < built) : (fi += 1) _ = mlx.mlx_array_free(outs[fi]);
+    }
+    for (views, blocks, 0..) |*kv_view, blk, i| {
+        const i_c: c_int = @intCast(i);
+        var q_slot = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(q_slot);
+        try mlx.check(mlx.mlx_slice(
+            &q_slot,
+            q_rope,
+            &[_]c_int{ i_c, 0, 0, 0 },
+            4,
+            &[_]c_int{ i_c + 1, h_count, seq_len, hd },
+            4,
+            &[_]c_int{ 1, 1, 1, 1 },
+            4,
+            s,
+        ));
+        var gathered: ?mlx.mlx_array = null;
+        if (blk.ctx != null and seq_len >= fused_min_s and seq_len < FUSED256_MIN_Q_LEN) {
+            gathered = try qsaSparseAttn(s, q_slot, kv_view, blk, ratio, attn_scale);
+        }
+        if (gathered == null and blk.ctx != null and seq_len == 1) {
+            gathered = try qsaDecodeGatherAttn(s, q_slot, kv_view, blk, ratio, attn_scale);
+        }
+        if (gathered == null and blk.ctx != null and seq_len >= 2 and seq_len < FUSED256_MIN_Q_LEN) {
+            gathered = try qsaVerifyGatherAttn(s, q_slot, kv_view, blk, ratio, attn_scale);
+        }
+        if (gathered) |g| {
+            outs[i] = g;
+        } else if (blk.ctx != null) {
+            const mask = try qsaMaskFromBlocks(s, blk, mlx.getShape(kv_view.k)[2], ratio);
+            defer _ = mlx.mlx_array_free(mask);
+            outs[i] = mlx.mlx_array_new();
+            if (try fusedSdpa256Masked(s, q_slot, kv_view.k, kv_view.v, attn_scale, mask)) |fused| {
+                _ = mlx.mlx_array_free(outs[i]);
+                outs[i] = fused;
+            } else if (try splitMaskedSdpa256(s, q_slot, kv_view.k, kv_view.v, attn_scale, mask)) |split_out| {
+                _ = mlx.mlx_array_free(outs[i]);
+                outs[i] = split_out;
+            } else {
+                try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&outs[i], q_slot, kv_view.k, kv_view.v, attn_scale, "array", mask, .{ .ctx = null }, false, s));
+            }
+        } else {
+            outs[i] = mlx.mlx_array_new();
+            const none = mlx.mlx_array_new();
+            defer _ = mlx.mlx_array_free(none);
+            try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&outs[i], q_slot, kv_view.k, kv_view.v, attn_scale, "causal", none, .{ .ctx = null }, false, s));
+        }
+        built = i + 1;
+    }
+    const vec = mlx.mlx_vector_array_new_data(outs.ptr, n);
+    defer _ = mlx.mlx_vector_array_free(vec);
+    var stacked = mlx.mlx_array_new();
+    errdefer _ = mlx.mlx_array_free(stacked);
+    try mlx.check(mlx.mlx_concatenate_axis(&stacked, vec, 0, s));
+    var fi: usize = 0;
+    while (fi < built) : (fi += 1) _ = mlx.mlx_array_free(outs[fi]);
+    return stacked;
+}
+
 pub var qsa_verify_gather_override: ?bool = null;
 var qsa_verify_gather_env_cached: ?bool = null;
 
@@ -4625,6 +4721,83 @@ pub fn qsaVerifyPlanHost(
         }
     }
     return .{ .rows = rows, .mask = mask };
+}
+
+pub fn qsaDecodeGatherIdsHost(
+    alloc: std.mem.Allocator,
+    blocks: []const i32,
+    kb: c_int,
+    kv: c_int,
+    ratio: c_int,
+) ![]i32 {
+    const kbu: usize = @intCast(kb);
+    if (blocks.len != kbu) return error.QsaDecodeBadSelection;
+    if (ratio <= 0 or kb <= 0 or kv <= 0) return error.QsaDecodeGeometry;
+    const nb: c_int = @divTrunc(kv, ratio);
+    const tail_start: c_int = nb * ratio;
+    const tail_len: c_int = kv - tail_start;
+    const sel_len: c_int = kb * ratio;
+    const gathered_len: c_int = sel_len + tail_len;
+    const rows = try alloc.alloc(i32, @intCast(gathered_len));
+    var r: usize = 0;
+    for (0..kbu) |c| {
+        const b = blocks[c];
+        const use = b >= 0 and b < nb;
+        const base: i32 = if (use) b else 0;
+        var j: c_int = 0;
+        while (j < ratio) : (j += 1) {
+            rows[r] = base * ratio + j;
+            r += 1;
+        }
+    }
+    var t: c_int = tail_start;
+    while (t < kv) : (t += 1) {
+        rows[r] = t;
+        r += 1;
+    }
+    return rows;
+}
+
+pub const QsaSlotPlan = struct {
+    rows: []i32,
+    mask: []bool,
+
+    pub fn deinit(self: *QsaSlotPlan, alloc: std.mem.Allocator) void {
+        alloc.free(self.rows);
+        if (self.mask.len != 0) alloc.free(self.mask);
+        self.rows = &.{};
+        self.mask = &.{};
+    }
+};
+
+pub fn qsaBatchedPlanHost(
+    alloc: std.mem.Allocator,
+    slot_blocks: []const []const i32,
+    seq_len: c_int,
+    kb: c_int,
+    kv_lens: []const c_int,
+    ratio: c_int,
+) ![]QsaSlotPlan {
+    if (slot_blocks.len != kv_lens.len) return error.QsaBatchedPlanLen;
+    const out = try alloc.alloc(QsaSlotPlan, slot_blocks.len);
+    var built: usize = 0;
+    errdefer {
+        for (out[0..built]) |*p| p.deinit(alloc);
+        alloc.free(out);
+    }
+    for (slot_blocks, kv_lens, 0..) |blocks, kv, i| {
+        if (seq_len == 1) {
+            const rows = try qsaDecodeGatherIdsHost(alloc, blocks, kb, kv, ratio);
+            out[i] = .{ .rows = rows, .mask = &.{} };
+        } else {
+            var plan = try qsaVerifyPlanHost(alloc, blocks, seq_len, kb, kv, ratio);
+            out[i] = .{ .rows = plan.rows, .mask = plan.mask };
+            plan.rows = &.{};
+            plan.mask = &.{};
+        }
+        built = i + 1;
+    }
+    return out;
 }
 
 /// Verify-width QSA gather (2 <= S < FUSED256_MIN_Q_LEN, sorted `blocks`):
@@ -7036,6 +7209,53 @@ pub fn ssmFreeSpecCapture(entry: *SSMCacheEntry) void {
     entry.spec_ple_len = 0;
 }
 
+pub fn claimPleSpecCapture(entry: *SSMCacheEntry, n: usize, ctx_len: usize, capturing: bool) bool {
+    if (capturing and ctx_len + n <= entry.spec_ple_tokens.len) {
+        entry.spec_ple_len = @intCast(ctx_len + n);
+        return true;
+    }
+    entry.spec_ple_len = 0;
+    return false;
+}
+
+pub fn fillPleSpecTokens(entry: *SSMCacheEntry, prev: []const u32, ids: []const u32) void {
+    const ctx_len = prev.len;
+    for (0..ctx_len) |i| entry.spec_ple_tokens[i] = prev[i];
+    for (ids, 0..) |id, j| entry.spec_ple_tokens[ctx_len + j] = id;
+}
+
+fn ssmAxisView(s: mlx.mlx_stream, arr: mlx.mlx_array, axis: usize, i: usize) !mlx.mlx_array {
+    const shape = mlx.getShape(arr);
+    var start: [8]c_int = @splat(0);
+    var stop: [8]c_int = @splat(0);
+    const strides: [8]c_int = @splat(1);
+    for (0..shape.len) |d| stop[d] = shape[d];
+    start[axis] = @intCast(i);
+    stop[axis] = @intCast(i + 1);
+    var out = mlx.mlx_array_new();
+    errdefer _ = mlx.mlx_array_free(out);
+    try mlx.check(mlx.mlx_slice(&out, arr, &start, @intCast(shape.len), &stop, @intCast(shape.len), &strides, @intCast(shape.len), s));
+    return out;
+}
+
+fn splitSpecCaptures(s: mlx.mlx_stream, m: *const SSMCacheEntry, e: *SSMCacheEntry, i: usize) !void {
+    if (m.spec_state_seq.ctx != null) {
+        const own = try ssmAxisView(s, m.spec_state_seq, 1, i);
+        if (e.spec_state_seq.ctx != null) _ = mlx.mlx_array_free(e.spec_state_seq);
+        e.spec_state_seq = own;
+    }
+    if (m.spec_conv_input.ctx != null) {
+        const own = try ssmAxisView(s, m.spec_conv_input, 0, i);
+        if (e.spec_conv_input.ctx != null) _ = mlx.mlx_array_free(e.spec_conv_input);
+        e.spec_conv_input = own;
+    }
+    if (m.spec_ple_input.ctx != null) {
+        const own = try ssmAxisView(s, m.spec_ple_input, 0, i);
+        if (e.spec_ple_input.ctx != null) _ = mlx.mlx_array_free(e.spec_ple_input);
+        e.spec_ple_input = own;
+    }
+}
+
 /// PLD partial-accept rollback for a GatedDeltaNet layer, using the
 /// per-position capture from the verify forward instead of a re-forward.
 /// Sets `conv_state` + `ssm_state` to the state AFTER processing the first
@@ -7151,6 +7371,27 @@ pub fn ssmRollbackFromCapture(entry: *SSMCacheEntry, accepted: u32, verify_len: 
     }
 }
 
+test "pleClaimSpecCapture: two S>1 entries keep their own prev ++ ids" {
+    const t = std.testing;
+    var a: SSMCacheEntry = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true };
+    var b: SSMCacheEntry = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true };
+    const ctx_len: usize = 2;
+    const ids_a = [_]u32{ 11, 12, 13, 14 };
+    const ids_b = [_]u32{ 21, 22, 23, 24 };
+    const prev_a = [_]u32{ 1, 2 };
+    const prev_b = [_]u32{ 8, 9 };
+    try t.expect(claimPleSpecCapture(&a, ids_a.len, ctx_len, true));
+    try t.expect(claimPleSpecCapture(&b, ids_b.len, ctx_len, true));
+    try t.expectEqual(@as(u32, @intCast(ctx_len + ids_a.len)), a.spec_ple_len);
+    try t.expectEqual(@as(u32, @intCast(ctx_len + ids_b.len)), b.spec_ple_len);
+    fillPleSpecTokens(&a, &prev_a, &ids_a);
+    fillPleSpecTokens(&b, &prev_b, &ids_b);
+    try t.expectEqualSlices(u32, &.{ 1, 2, 11, 12, 13, 14 }, a.spec_ple_tokens[0..a.spec_ple_len]);
+    try t.expectEqualSlices(u32, &.{ 8, 9, 21, 22, 23, 24 }, b.spec_ple_tokens[0..b.spec_ple_len]);
+    try t.expect(!claimPleSpecCapture(&a, 40, ctx_len, true));
+    try t.expectEqual(@as(u32, 0), a.spec_ple_len);
+}
+
 test "a PLE rollback leaves no freed-but-non-null QSA handle behind" {
     // The PLE arm never assigns `qsa_pooled` after `ssmFreeQsaState`; this pins that the helper nulls what it frees.
     const t = std.testing;
@@ -7198,6 +7439,98 @@ test "a PLE rollback leaves no freed-but-non-null QSA handle behind" {
     try t.expect(e.qsa_score_buf.ctx == null);
     try t.expectEqual(@as(c_int, 0), e.qsa_key_rows);
     try t.expectEqual(@as(c_int, 0), e.qsa_pooled_blocks);
+}
+
+test "splitSpecCaptures: spec_ple_input row view is the rollback shape" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const t = std.testing;
+    const s = mlx.gpuStream();
+    const N: c_int = 2;
+    const state_len: c_int = 3;
+    const verify_len: c_int = 4;
+    const width: c_int = 5;
+    var merged: SSMCacheEntry = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true };
+    defer ssmFreeSpecCapture(&merged);
+    const n: f64 = @floatFromInt(N * (state_len + verify_len) * width);
+    var flat = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(flat);
+    try mlx.check(mlx.mlx_arange(&flat, 0.0, n, 1.0, .float32, s));
+    const shape = [_]c_int{ N, state_len + verify_len, width };
+    merged.spec_ple_input = mlx.mlx_array_new();
+    try mlx.check(mlx.mlx_reshape(&merged.spec_ple_input, flat, &shape, 3, s));
+
+    var slots: [2]SSMCacheEntry = .{
+        .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true },
+        .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true },
+    };
+    defer for (&slots) |*e| {
+        ssmFreeSpecCapture(e);
+        if (e.aux_state.ctx != null) _ = mlx.mlx_array_free(e.aux_state);
+    };
+    try splitSpecCaptures(s, &merged, &slots[0], 0);
+    try splitSpecCaptures(s, &merged, &slots[1], 1);
+    for (&slots, 0..) |*e, i| {
+        try t.expect(e.spec_ple_input.ctx != null);
+        const sh = mlx.getShape(e.spec_ple_input);
+        try t.expectEqual(@as(c_int, 1), sh[0]);
+        try t.expectEqual(state_len + verify_len, sh[1]);
+        try t.expectEqual(width, sh[2]);
+        e.spec_ple_len = @intCast(state_len + verify_len);
+        const accepted: u32 = if (i == 0) 1 else 0;
+        try ssmRollbackFromCapture(e, accepted, @intCast(verify_len), s);
+        try t.expect(e.aux_state.ctx != null);
+        const ash = mlx.getShape(e.aux_state);
+        try t.expectEqual(@as(c_int, 1), ash[0]);
+        try t.expectEqual(state_len, ash[1]);
+        try t.expectEqual(width, ash[2]);
+    }
+}
+
+test "ssmRollbackFromCapture: padded verify_len keeps PLE tokens inside the real prefix" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const t = std.testing;
+    const s = mlx.gpuStream();
+    var e: SSMCacheEntry = .{ .conv_state = mlx.mlx_array_new(), .ssm_state = mlx.mlx_array_new(), .initialized = true };
+    defer {
+        ssmFreeSpecCapture(&e);
+        _ = mlx.mlx_array_free(e.conv_state);
+        _ = mlx.mlx_array_free(e.ssm_state);
+        ssmFreeQsaState(&e);
+    }
+    const state_len: c_int = 2;
+    const m: u32 = 2;
+    const verify_len: c_int = 4;
+    var flat = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(flat);
+    const n: f64 = @floatFromInt((state_len + verify_len) * 3);
+    try mlx.check(mlx.mlx_arange(&flat, 0.0, n, 1.0, .float32, s));
+    const shape = [_]c_int{ 1, state_len + verify_len, 3 };
+    try mlx.check(mlx.mlx_reshape(&e.spec_ple_input, flat, &shape, 3, s));
+    e.spec_ple_tokens = .{ 9, 8, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+    e.spec_ple_len = @intCast(state_len + verify_len);
+    try ssmRollbackFromCapture(&e, m, @intCast(verify_len), s);
+    try t.expect(e.aux_state.ctx != null);
+    try t.expectEqual(state_len, mlx.getShape(e.aux_state)[1]);
+    try t.expectEqual(@as(u32, 2), e.ple_prev[0]);
+    try t.expectEqual(@as(u32, 3), e.ple_prev[1]);
+    try t.expect(e.ple_prev_valid);
+}
+
+test "QSA key history advances by S not 1" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const t = std.testing;
+    const s = mlx.gpuStream();
+    var xfm: Transformer = undefined;
+    xfm.s = s;
+    xfm.allocator = t.allocator;
+    var entry: SSMCacheEntry = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true };
+    defer ssmFreeQsaState(&entry);
+    entry.qsa_ratio = 4;
+    var prng = std.Random.DefaultPrng.init(0x51A0_0004);
+    const chunk = try attn256RandBf16(prng.random(), &[_]c_int{ 1, 4, 16 }, s);
+    defer _ = mlx.mlx_array_free(chunk);
+    try xfm.qsaAppendKeys(&entry, chunk, 0);
+    try t.expectEqual(@as(c_int, 4), qsaHistoryRows(&entry));
 }
 
 test "qsa raw-key ring is O(RING_ROWS) at N rows" {
@@ -15454,17 +15787,7 @@ pub const Transformer = struct {
                 ssmFreeQsaState(e); // PLE layer: no QSA state to lose
                 e.aux_state = aux_own;
             }
-            // A verify's per-position captures, row i: [T, N, …] on axis 1, [N, k-1+T, C] on axis 0.
-            if (m.spec_state_seq.ctx != null) {
-                const own = try axisView(self.s, m.spec_state_seq, 1, i);
-                if (e.spec_state_seq.ctx != null) _ = mlx.mlx_array_free(e.spec_state_seq);
-                e.spec_state_seq = own;
-            }
-            if (m.spec_conv_input.ctx != null) {
-                const own = try rowView(self.s, m.spec_conv_input, i);
-                if (e.spec_conv_input.ctx != null) _ = mlx.mlx_array_free(e.spec_conv_input);
-                e.spec_conv_input = own;
-            }
+            try splitSpecCaptures(self.s, m, e, i);
         }
     }
 
@@ -15849,8 +16172,19 @@ pub const Transformer = struct {
         // mid-graph eval, no GPU sync inside the layer loop.
         const pk = try self.allocator.alloc(u16, n * emb_dim);
         defer self.allocator.free(pk);
-        // The batched arm keeps its history per SLOT and never captures.
-        const capture = ctx.batch_slots == null and self.pleClaimSpecCapture(entry, n);
+        const capture = blk: {
+            if (ctx.batch_slots) |slots| {
+                if (!self.spec_capture_ssm) break :blk false;
+                const per: usize = @intCast(seq_len);
+                var any = false;
+                for (slots) |sc| {
+                    if (self.pleClaimSpecCapture(&sc.ssm_entries.?[layer], per)) any = true;
+                }
+                if (any) _ = self.pleClaimSpecCapture(entry, per);
+                break :blk any;
+            }
+            break :blk self.pleClaimSpecCapture(entry, n);
+        };
         if (ctx.ple_defer and ctx.batch_slots == null) {
             std.debug.assert(ctx.ple_pending == null);
             @memset(pk, 0);
@@ -15877,12 +16211,7 @@ pub const Transformer = struct {
     /// gather only fills the tokens.
     fn pleClaimSpecCapture(self: *Transformer, entry: *SSMCacheEntry, n: usize) bool {
         const ctx_len: usize = self.qwen4.?.hash.ngram_size - 1;
-        if (self.spec_capture_ssm and ctx_len + n <= entry.spec_ple_tokens.len) {
-            entry.spec_ple_len = @intCast(ctx_len + n);
-            return true;
-        }
-        entry.spec_ple_len = 0;
-        return false;
+        return claimPleSpecCapture(entry, n, ctx_len, self.spec_capture_ssm);
     }
 
     /// Fill the leaf a `ple_defer` forward was built on: the token ids are
@@ -15938,21 +16267,27 @@ pub const Transformer = struct {
         const rows = try self.allocator.alloc(i64, n * nh);
         defer self.allocator.free(rows);
         if (ctx.batch_slots) |slots| {
-            std.debug.assert(seq_len == 1 and n == slots.len);
+            const S: usize = @intCast(seq_len);
+            std.debug.assert(n == slots.len * S);
             for (slots, 0..) |sc, i| {
                 const e = &sc.ssm_entries.?[layer];
                 std.debug.assert(e.ple_prev_valid); // batchedGdnReady
                 const prev = e.ple_prev;
-                st.hash.rowIds(prev[0..ctx_len], ids[i .. i + 1], rows[i * nh ..][0..nh]);
-                advancePlePrev(e, prev, ids[i .. i + 1], ctx_len);
+                const ids_i = ids[i * S .. (i + 1) * S];
+                if (capture) {
+                    std.debug.assert(ctx_len + S <= e.spec_ple_tokens.len);
+                    fillPleSpecTokens(e, prev[0..ctx_len], ids_i);
+                    e.spec_ple_len = @intCast(ctx_len + S);
+                } else e.spec_ple_len = 0;
+                st.hash.rowIds(prev[0..ctx_len], ids_i, rows[i * S * nh ..][0 .. S * nh]);
+                advancePlePrev(e, prev, ids_i, ctx_len);
             }
         } else {
             var prev: [8]u32 = @splat(st.hash.eos);
             if (entry.ple_prev_valid) prev = entry.ple_prev;
             if (capture) {
                 std.debug.assert(ctx_len + n <= entry.spec_ple_tokens.len);
-                for (0..ctx_len) |i| entry.spec_ple_tokens[i] = prev[i];
-                for (0..n) |i| entry.spec_ple_tokens[ctx_len + i] = ids[i];
+                fillPleSpecTokens(entry, prev[0..ctx_len], ids);
                 entry.spec_ple_len = @intCast(ctx_len + n);
             } else entry.spec_ple_len = 0;
             st.hash.rowIds(prev[0..ctx_len], ids, rows);
@@ -16453,7 +16788,9 @@ pub const Transformer = struct {
             if (sc.qsa_blocks.ctx != null) _ = mlx.mlx_array_free(sc.qsa_blocks);
             sc.qsa_blocks = .{ .ctx = null };
         };
-        const w: c_int = mlx.getShape(qk)[2];
+        const qk_sh = mlx.getShape(qk);
+        const seq_len: c_int = qk_sh[1];
+        const w: c_int = qk_sh[2];
         const masks = try self.allocator.alloc(mlx.mlx_array, N);
         defer self.allocator.free(masks);
         for (masks) |*m| m.* = .{ .ctx = null };
@@ -16464,28 +16801,37 @@ pub const Transformer = struct {
         defer self.allocator.free(kv_lens);
         var kv_max: c_int = 0;
         var any = false;
+        var any_mrope = false;
+        var any_blocks = false;
         const ratio: c_int = @intCast(self.config.indexer_compress_ratio);
         for (slots, 0..) |sc, i| {
+            if (sc.mrope_pos != null) any_mrope = true;
             const e = &sc.ssm_entries.?[layer];
             const cache_len: c_int = @intCast(sc.moe_seq_offset.*);
             const i_c: c_int = @intCast(i);
             var qk_i = mlx.mlx_array_new();
             defer _ = mlx.mlx_array_free(qk_i);
-            try mlx.check(mlx.mlx_slice(&qk_i, qk, &[_]c_int{ i_c, 0, 0 }, 3, &[_]c_int{ i_c + 1, 1, w }, 3, &[_]c_int{ 1, 1, 1 }, 3, self.s));
-            masks[i] = try self.qsaMaskFromQk(sc, qk_i, fa, e, cache_len, 0, 1, 1);
+            try mlx.check(mlx.mlx_slice(&qk_i, qk, &[_]c_int{ i_c, 0, 0 }, 3, &[_]c_int{ i_c + 1, seq_len, w }, 3, &[_]c_int{ 1, 1, 1 }, 3, self.s));
+            masks[i] = try self.qsaMaskFromQk(sc, qk_i, fa, e, cache_len, 0, 1, seq_len);
+            kv_lens[i] = cache_len + seq_len;
+            if (kv_lens[i] > kv_max) kv_max = kv_lens[i];
+            if (masks[i].ctx != null) any = true;
+            if (sc.qsa_blocks.ctx != null) any_blocks = true;
+        }
+        const keep_blocks = qsaBatchedGatherEnabled() and self.qwen4 != null and !any_mrope and any_blocks;
+        if (keep_blocks) return mlx.mlx_array_new();
+        for (slots, 0..) |sc, i| {
             if (sc.qsa_blocks.ctx != null) {
                 // Decode-width selection is per-slot unusable in the stacked
                 // mask path — expand it to the equivalent dense mask (the same
                 // fallback the serial arm uses when its gatherer declines).
-                const m = try qsaMaskFromBlocks(self.s, sc.qsa_blocks, cache_len + 1, ratio);
+                const m = try qsaMaskFromBlocks(self.s, sc.qsa_blocks, kv_lens[i], ratio);
                 _ = mlx.mlx_array_free(sc.qsa_blocks);
                 sc.qsa_blocks = .{ .ctx = null };
                 _ = mlx.mlx_array_free(masks[i]);
                 masks[i] = m;
+                any = true;
             }
-            kv_lens[i] = cache_len + 1;
-            if (kv_lens[i] > kv_max) kv_max = kv_lens[i];
-            if (masks[i].ctx != null) any = true;
         }
         if (!any) return mlx.mlx_array_new();
         const padded = try self.allocator.alloc(mlx.mlx_array, N);
@@ -16502,7 +16848,7 @@ pub const Transformer = struct {
             if (masks[i].ctx != null) {
                 try mlx.check(mlx.mlx_array_set(&row, masks[i]));
             } else {
-                try mlx.check(mlx.mlx_ones(&row, &[_]c_int{ 1, 1, 1, kv_lens[i] }, 4, .bool_, self.s));
+                try mlx.check(mlx.mlx_ones(&row, &[_]c_int{ 1, 1, seq_len, kv_lens[i] }, 4, .bool_, self.s));
             }
             const pad_axes = [_]c_int{3};
             const low = [_]c_int{0};
@@ -16923,6 +17269,14 @@ pub const Transformer = struct {
             ctx.qsa_mask = .{ .ctx = null };
             if (ctx.qsa_blocks.ctx != null) _ = mlx.mlx_array_free(ctx.qsa_blocks);
             ctx.qsa_blocks = .{ .ctx = null };
+            if (ctx.batch_slots) |slots| {
+                for (slots) |sc| {
+                    if (sc.qsa_mask.ctx != null) _ = mlx.mlx_array_free(sc.qsa_mask);
+                    sc.qsa_mask = .{ .ctx = null };
+                    if (sc.qsa_blocks.ctx != null) _ = mlx.mlx_array_free(sc.qsa_blocks);
+                    sc.qsa_blocks = .{ .ctx = null };
+                }
+            }
         }
         if (fa.idx_qk_w.ctx != null and !qwen4Standin().attn_qsa) {
             ctx.qsa_mask = try self.qsaMask(ctx, x, fa, entry, layer, cache_len, pos_base, batch, seq_len);
@@ -19316,6 +19670,42 @@ pub const Transformer = struct {
         q.* = out;
     }
 
+    fn qsaBatchedAttn(
+        self: *Transformer,
+        slots: []const *ForwardCtx,
+        q_rope: mlx.mlx_array,
+        layer: u32,
+        seq_len: c_int,
+        attn_scale: f32,
+    ) !?mlx.mlx_array {
+        if (!qsaBatchedGatherEnabled()) return null;
+        if (self.qwen4 == null) return null;
+        for (slots) |sc| if (sc.mrope_pos != null) return null;
+        var any_blocks = false;
+        for (slots) |sc| if (sc.qsa_blocks.ctx != null) {
+            any_blocks = true;
+        };
+        if (!any_blocks) return null;
+        const ratio: c_int = @intCast(self.config.indexer_compress_ratio);
+        var views = try self.allocator.alloc(DenseKVView, slots.len);
+        defer {
+            for (views) |*dv| dv.deinit();
+            self.allocator.free(views);
+        }
+        var blks = try self.allocator.alloc(mlx.mlx_array, slots.len);
+        defer self.allocator.free(blks);
+        for (slots, 0..) |slot_ctx, i| {
+            views[i] = try slot_ctx.cache.denseView(layer, self.s);
+            blks[i] = slot_ctx.qsa_blocks;
+            if (slot_ctx.qsa_blocks.ctx != null) slot_ctx.qsa_arms.noteGather(seq_len) else slot_ctx.qsa_arms.note(.mask);
+        }
+        if (!qsa_batched_gather_logged) {
+            qsa_batched_gather_logged = true;
+            log.info("[qsa-batched-gather] engaged (slots={d} S={d}) — MLX_SERVE_QSA_BATCHED_GATHER=0 restores the dense padded mask\n", .{ slots.len, seq_len });
+        }
+        return try qsaBatchedGatherAttn(self.allocator, self.s, q_rope, views, blks, ratio, attn_scale);
+    }
+
     fn gatedFullAttnWith(
         self: *Transformer,
         ctx: *ForwardCtx,
@@ -19534,6 +19924,10 @@ pub const Transformer = struct {
                     slot_view.deinit();
                 }
 
+                if (try self.qsaBatchedAttn(slots, q_rope, layer, seq_len, attn_scale)) |gathered| {
+                    _ = mlx.mlx_array_free(attn_out_b);
+                    attn_out_b = gathered;
+                } else {
                 const dense_views = try self.allocator.alloc(DenseKVView, slots.len);
                 defer {
                     for (dense_views) |*dv| dv.deinit();
@@ -19571,6 +19965,7 @@ pub const Transformer = struct {
                 }
 
                 try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&attn_out_b, q_rope, stacked_k, stacked_v, attn_scale, "array", stacked_mask, .{ .ctx = null }, false, self.s));
+                }
             }
             return self.gatedAttnTail(attn_out_b, gate, fa, flat_shape, batch, is_prefill, layer);
         }
@@ -41016,6 +41411,71 @@ test "qsa decode gather: subset SDPA matches masked full SDPA at decode width" {
     try std.testing.expect((try qsaDecodeGatherAttn(s, q, &view, fx.blocks, ratio, scale)) == null);
 }
 
+test "qsa batched gather S=1: N=1 is byte-identical to solo, N=2 matches per-slot solos" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+    const ta = std.testing.allocator;
+    qsa_decode_gather_override = true;
+    defer qsa_decode_gather_override = null;
+    qsa_batched_gather_override = true;
+    defer qsa_batched_gather_override = null;
+    var prng = std.Random.DefaultPrng.init(0xb07a);
+    const rnd = prng.random();
+    const ratio: c_int = 4;
+    const kb: c_int = 3;
+    const hq: c_int = 4;
+    const hkv: c_int = 2;
+    const hd: c_int = 64;
+    const scale: f32 = 1.0 / 8.0;
+
+    const kL0: c_int = 50;
+    const kL1: c_int = 36;
+    const q0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hq, 1, hd }, s);
+    defer _ = mlx.mlx_array_free(q0);
+    const q1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hq, 1, hd }, s);
+    defer _ = mlx.mlx_array_free(q1);
+    const k0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL0, hd }, s);
+    defer _ = mlx.mlx_array_free(k0);
+    const v0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL0, hd }, s);
+    defer _ = mlx.mlx_array_free(v0);
+    const k1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL1, hd }, s);
+    defer _ = mlx.mlx_array_free(k1);
+    const v1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL1, hd }, s);
+    defer _ = mlx.mlx_array_free(v1);
+    var fx0 = try QsaBlockFixture.build(rnd, 1, kL0, kb, ratio);
+    defer fx0.deinit();
+    var fx1 = try QsaBlockFixture.build(rnd, 1, kL1, kb, ratio);
+    defer fx1.deinit();
+    const view0 = DenseKVView{ .k = k0, .v = v0, .owned = false };
+    const view1 = DenseKVView{ .k = k1, .v = v1, .owned = false };
+
+    const solo0 = (try qsaDecodeGatherAttn(s, q0, &view0, fx0.blocks, ratio, scale)) orelse return error.GatherDeclined;
+    defer _ = mlx.mlx_array_free(solo0);
+    const bat1 = try qsaBatchedGatherAttn(ta, s, q0, &.{view0}, &.{fx0.blocks}, ratio, scale);
+    defer _ = mlx.mlx_array_free(bat1);
+    try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat1, solo0, s));
+
+    var q_n2 = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(q_n2);
+    const qparts = [_]mlx.mlx_array{ q0, q1 };
+    const qvec = mlx.mlx_vector_array_new_data(&qparts, 2);
+    defer _ = mlx.mlx_vector_array_free(qvec);
+    try mlx.check(mlx.mlx_concatenate_axis(&q_n2, qvec, 0, s));
+    const views = [_]DenseKVView{ view0, view1 };
+    const blks = [_]mlx.mlx_array{ fx0.blocks, fx1.blocks };
+    const bat2 = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, ratio, scale);
+    defer _ = mlx.mlx_array_free(bat2);
+    const solo1 = (try qsaDecodeGatherAttn(s, q1, &view1, fx1.blocks, ratio, scale)) orelse return error.GatherDeclined;
+    defer _ = mlx.mlx_array_free(solo1);
+    var want = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(want);
+    const wparts = [_]mlx.mlx_array{ solo0, solo1 };
+    const wvec = mlx.mlx_vector_array_new_data(&wparts, 2);
+    defer _ = mlx.mlx_vector_array_free(wvec);
+    try mlx.check(mlx.mlx_concatenate_axis(&want, wvec, 0, s));
+    try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat2, want, s));
+}
+
 // ── Verify-width QSA gather (S = 2 .. FUSED256_MIN_Q_LEN-1) ──
 
 /// Host `[S, kb]` block selection in the shape `qsaSelectBlocks` hands the
@@ -41130,6 +41590,71 @@ test "qsa verify gather plan: gathered rows carry exactly the dense [S, kv] mask
                     return error.VerifyPlanMismatch;
                 }
             }
+        }
+    }
+}
+
+test "qsaBatchedGatherEnabled: default on, override restores the dense padded mask" {
+    const prev = qsa_batched_gather_override;
+    defer qsa_batched_gather_override = prev;
+    qsa_batched_gather_override = true;
+    try std.testing.expect(qsaBatchedGatherEnabled());
+    qsa_batched_gather_override = false;
+    try std.testing.expect(!qsaBatchedGatherEnabled());
+}
+
+test "qsa batched gather plan: per-slot rows match the solo planner at S=1 and S=2..8" {
+    const ta = std.testing.allocator;
+    var prng = std.Random.DefaultPrng.init(0xa11c3);
+    const rnd = prng.random();
+    const ratio: c_int = 4;
+    const kb: c_int = 32;
+    const kvs = [_]c_int{ 4096, 20000 };
+    for (kvs) |kv_a| {
+        const kv_b: c_int = @divTrunc(kv_a, 2) + 17;
+        {
+            const s: c_int = 1;
+            const ba = try qsaVerifyBlocksHost(ta, rnd, s, kv_a, kb, ratio);
+            defer ta.free(ba);
+            const bb = try qsaVerifyBlocksHost(ta, rnd, s, kv_b, kb, ratio);
+            defer ta.free(bb);
+            const slot_blocks = [_][]const i32{ ba, bb };
+            const kv_lens = [_]c_int{ kv_a, kv_b };
+            var plans = try qsaBatchedPlanHost(ta, &slot_blocks, s, kb, &kv_lens, ratio);
+            defer {
+                var pi: usize = 0;
+                while (pi < plans.len) : (pi += 1) plans[pi].deinit(ta);
+                ta.free(plans);
+            }
+            try std.testing.expectEqual(@as(usize, 2), plans.len);
+            const ea = try qsaDecodeGatherIdsHost(ta, ba, kb, kv_a, ratio);
+            defer ta.free(ea);
+            const eb = try qsaDecodeGatherIdsHost(ta, bb, kb, kv_b, ratio);
+            defer ta.free(eb);
+            try std.testing.expectEqualSlices(i32, ea, plans[0].rows);
+            try std.testing.expectEqualSlices(i32, eb, plans[1].rows);
+        }
+        for ([_]c_int{ 2, 4, 5, 8 }) |s| {
+            const ba = try qsaVerifyBlocksHost(ta, rnd, s, kv_a, kb, ratio);
+            defer ta.free(ba);
+            const bb = try qsaVerifyBlocksHost(ta, rnd, s, kv_b, kb, ratio);
+            defer ta.free(bb);
+            const slot_blocks = [_][]const i32{ ba, bb };
+            const kv_lens = [_]c_int{ kv_a, kv_b };
+            var plans = try qsaBatchedPlanHost(ta, &slot_blocks, s, kb, &kv_lens, ratio);
+            defer {
+                var pi: usize = 0;
+                while (pi < plans.len) : (pi += 1) plans[pi].deinit(ta);
+                ta.free(plans);
+            }
+            var pa = try qsaVerifyPlanHost(ta, ba, s, kb, kv_a, ratio);
+            defer pa.deinit(ta);
+            var pb = try qsaVerifyPlanHost(ta, bb, s, kb, kv_b, ratio);
+            defer pb.deinit(ta);
+            try std.testing.expectEqualSlices(i32, pa.rows, plans[0].rows);
+            try std.testing.expectEqualSlices(bool, pa.mask, plans[0].mask);
+            try std.testing.expectEqualSlices(i32, pb.rows, plans[1].rows);
+            try std.testing.expectEqualSlices(bool, pb.mask, plans[1].mask);
         }
     }
 }

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -15679,6 +15679,7 @@ pub const Transformer = struct {
             .vision_embeddings = null,
             .batch_slots = ctxs,
             .batch_rope_offsets = rope_offset_arr,
+            .ple_defer = self.qwen4 != null,
         };
         // A verify's captures live on the merged entries until split below.
         defer if (capture_ssm) {
@@ -15687,8 +15688,15 @@ pub const Transformer = struct {
 
         // qwen4_exp rides the same driver: GDN + PLE window merged here, QSA
         // key histories reached per slot through `batch_slots` (kv differs).
-        const logits = if (self.qwen4 != null) try self.forwardQwen4With(&bctx, token_arr) else try self.forwardMoeWith(&bctx, token_arr);
-        errdefer _ = mlx.mlx_array_free(logits);
+        const logits = (if (self.qwen4 != null) self.forwardQwen4With(&bctx, token_arr) else self.forwardMoeWith(&bctx, token_arr)) catch |e| {
+            self.discardDeferredPle(&bctx);
+            return e;
+        };
+        errdefer {
+            self.discardDeferredPle(&bctx);
+            _ = mlx.mlx_array_free(logits);
+        }
+        try self.flushDeferredPle(&bctx);
 
         // Hand the advanced state back to the slots it came from, as views,
         // and record the handles so next tick can prove nothing moved.
@@ -16157,6 +16165,11 @@ pub const Transformer = struct {
         entry.ple_prev_valid = true;
     }
 
+    pub fn pleDeferApplies(ple_defer: bool, batched: bool) bool {
+        _ = batched;
+        return ple_defer;
+    }
+
     /// Host-side n-gram gather: `[B, S, ple_embed_dim]` bf16 for this chunk's
     /// token ids, advancing the token history. Serial: `entry`'s history over
     /// `[1, S]`. Batched (`ctx.batch_slots`): `[N, 1]`, each row hashed
@@ -16185,7 +16198,7 @@ pub const Transformer = struct {
             }
             break :blk self.pleClaimSpecCapture(entry, n);
         };
-        if (ctx.ple_defer and ctx.batch_slots == null) {
+        if (pleDeferApplies(ctx.ple_defer, ctx.batch_slots != null)) {
             std.debug.assert(ctx.ple_pending == null);
             @memset(pk, 0);
             const emb = mlx.mlx_array_new_data(pk.ptr, &shape, 3, .bfloat16);
@@ -16237,6 +16250,9 @@ pub const Transformer = struct {
         const p = ctx.ple_pending orelse return;
         ctx.ple_pending = null;
         p.entry.spec_ple_len = 0;
+        if (ctx.batch_slots) |slots| {
+            for (slots) |sc| sc.ssm_entries.?[p.layer].spec_ple_len = 0;
+        }
         _ = mlx.mlx_array_free(p.emb);
         _ = mlx.mlx_array_free(p.token_ids);
     }
@@ -46080,6 +46096,170 @@ test "qwen4 deferred PLE: pipelined decode AND MTP verify widths match the direc
         defer allocator.free(b);
         xfm.discardDeferredPle(&lctx);
         try testing.expect(!std.mem.eql(f32, a, b));
+    }
+}
+
+const Qwen4BatchedPleRun = struct {
+    logits: mlx.mlx_array,
+    pending: bool,
+};
+
+fn qwen4BatchedPleForward(
+    xfm: *Transformer,
+    slots: []const *Qwen4TestSlot,
+    ids: []const i32,
+    seq_len: c_int,
+    capture: bool,
+    defer_ple: bool,
+    do_flush: bool,
+) !Qwen4BatchedPleRun {
+    const N = slots.len;
+    const ctxs = try xfm.allocator.alloc(*ForwardCtx, N);
+    defer xfm.allocator.free(ctxs);
+    var off_buf = try xfm.allocator.alloc(i32, N);
+    defer xfm.allocator.free(off_buf);
+    for (slots, 0..) |sl, i| {
+        ctxs[i] = &sl.ctx;
+        off_buf[i] = @intCast(sl.off);
+    }
+    const ml = xfm.moe_layers.?;
+    const merged = try xfm.allocator.alloc(SSMCacheEntry, ml.len);
+    defer xfm.allocator.free(merged);
+    for (merged) |*m| m.* = .{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = false };
+    defer for (merged) |*m| {
+        if (m.conv_state.ctx != null) _ = mlx.mlx_array_free(m.conv_state);
+        if (m.ssm_state.ctx != null) _ = mlx.mlx_array_free(m.ssm_state);
+        if (m.aux_state.ctx != null) _ = mlx.mlx_array_free(m.aux_state);
+        ssmFreeSpecCapture(m);
+    };
+    for (ml, 0..) |*lw, l| {
+        if (!lw.is_linear and lw.ple == null) continue;
+        merged[l] = try xfm.mergeSsmAcrossSlots(ctxs, l);
+    }
+    const off_shape = [_]c_int{@intCast(N)};
+    const rope_offset_arr = mlx.mlx_array_new_data(off_buf.ptr, &off_shape, 1, .int32);
+    defer _ = mlx.mlx_array_free(rope_offset_arr);
+    var scratch_offset: usize = @intCast(off_buf[0]);
+    var bctx: ForwardCtx = .{
+        .cache = ctxs[0].cache,
+        .moe_seq_offset = &scratch_offset,
+        .ssm_entries = merged,
+        .capture_hidden = null,
+        .capture_ssm_seq = capture,
+        .vision_embeddings = null,
+        .batch_slots = ctxs,
+        .batch_rope_offsets = rope_offset_arr,
+        .ple_defer = defer_ple,
+    };
+    const tshape = [_]c_int{ @intCast(N), seq_len };
+    const tarr = mlx.mlx_array_new_data(@ptrCast(ids.ptr), &tshape, 2, .int32);
+    defer _ = mlx.mlx_array_free(tarr);
+    const logits = try xfm.forwardQwen4With(&bctx, tarr);
+    errdefer _ = mlx.mlx_array_free(logits);
+    const pending = bctx.ple_pending != null;
+    if (do_flush) try xfm.flushDeferredPle(&bctx) else if (bctx.ple_pending != null) xfm.discardDeferredPle(&bctx);
+    for (merged, 0..) |*m, li| {
+        if (!ml[li].is_linear and ml[li].ple == null) continue;
+        try xfm.splitSsmToSlots(m, ctxs, li);
+    }
+    for (slots) |sl| sl.off += @intCast(seq_len);
+    return .{ .logits = logits, .pending = pending };
+}
+
+test "ple_defer applies on the batched arm" {
+    try std.testing.expect(Transformer.pleDeferApplies(true, false));
+    try std.testing.expect(Transformer.pleDeferApplies(true, true));
+    try std.testing.expect(!Transformer.pleDeferApplies(false, false));
+    try std.testing.expect(!Transformer.pleDeferApplies(false, true));
+}
+
+test "batched PLE defer engages at N=2 and matches eager at S=1 and S=4" {
+    const model_dir = std.c.getenv("QWEN4_TEST_MODEL") orelse return error.SkipZigTest;
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const allocator = testing.allocator;
+    const s = mlx.gpuStream();
+    const io = std.Io.Threaded.global_single_threaded.io();
+
+    var config = try model_mod.parseConfig(io, allocator, std.mem.span(model_dir));
+    defer if (config.ngram_table_path) |p| allocator.free(p);
+    var weights = try model_mod.loadWeights(io, allocator, std.mem.span(model_dir));
+    defer weights.deinit();
+    model_mod.resolveWeightPrefix(&config, &weights);
+    var xfm = try Transformer.init(io, allocator, config, &weights);
+    defer xfm.deinit();
+    try testing.expect(xfm.qwen4 != null);
+    xfm.qwen4_stream_f32 = true;
+    xfm.compileQwen4Hc();
+    xfm.compileGdnGate();
+    xfm.compileMoeRouting();
+
+    const n_layers = config.num_hidden_layers;
+    const prompt_a = [_]i32{ 5, 17, 42, 9, 23, 8, 31, 2 };
+    const prompt_b = [_]i32{ 11, 4, 19, 7, 28, 3 };
+    const a_e = try Qwen4TestSlot.init(allocator, n_layers);
+    defer a_e.deinit(allocator);
+    const b_e = try Qwen4TestSlot.init(allocator, n_layers);
+    defer b_e.deinit(allocator);
+    const a_d = try Qwen4TestSlot.init(allocator, n_layers);
+    defer a_d.deinit(allocator);
+    const b_d = try Qwen4TestSlot.init(allocator, n_layers);
+    defer b_d.deinit(allocator);
+    _ = mlx.mlx_array_free(try a_e.forward(&xfm, &prompt_a));
+    _ = mlx.mlx_array_free(try b_e.forward(&xfm, &prompt_b));
+    _ = mlx.mlx_array_free(try a_d.forward(&xfm, &prompt_a));
+    _ = mlx.mlx_array_free(try b_d.forward(&xfm, &prompt_b));
+
+    const widths = [_]c_int{ 1, 4 };
+    const decode_ids = [_]i32{ 13, 6 };
+    const verify_ids = [_]i32{ 13, 6, 27, 3, 19, 40, 12, 8 };
+    for (widths) |w| {
+        const ids: []const i32 = if (w == 1) &decode_ids else &verify_ids;
+        const capture = w > 1;
+        const eager_slots = [_]*Qwen4TestSlot{ a_e, b_e };
+        const defer_slots = [_]*Qwen4TestSlot{ a_d, b_d };
+        const eager = try qwen4BatchedPleForward(&xfm, &eager_slots, ids, w, capture, false, true);
+        defer _ = mlx.mlx_array_free(eager.logits);
+        try testing.expect(!eager.pending);
+        const deferred = try qwen4BatchedPleForward(&xfm, &defer_slots, ids, w, capture, true, true);
+        defer _ = mlx.mlx_array_free(deferred.logits);
+        try testing.expect(deferred.pending);
+        const ea = try qwen4ReadF32(allocator, eager.logits, s);
+        defer allocator.free(ea);
+        const da = try qwen4ReadF32(allocator, deferred.logits, s);
+        defer allocator.free(da);
+        try testing.expectEqualSlices(f32, ea, da);
+        for (a_e.entries, a_d.entries) |*ee, *de| {
+            try testing.expectEqual(ee.ple_prev_valid, de.ple_prev_valid);
+            try testing.expectEqualSlices(u32, &ee.ple_prev, &de.ple_prev);
+            try testing.expectEqual(ee.spec_ple_len, de.spec_ple_len);
+            const n: usize = ee.spec_ple_len;
+            try testing.expectEqualSlices(u32, ee.spec_ple_tokens[0..n], de.spec_ple_tokens[0..n]);
+        }
+        for (b_e.entries, b_d.entries) |*ee, *de| {
+            try testing.expectEqual(ee.ple_prev_valid, de.ple_prev_valid);
+            try testing.expectEqualSlices(u32, &ee.ple_prev, &de.ple_prev);
+            try testing.expectEqual(ee.spec_ple_len, de.spec_ple_len);
+            const n: usize = ee.spec_ple_len;
+            try testing.expectEqualSlices(u32, ee.spec_ple_tokens[0..n], de.spec_ple_tokens[0..n]);
+        }
+        if (capture) {
+            const acc: u32 = 1;
+            const vl: u32 = @intCast(w);
+            for (a_e.entries, a_d.entries) |*ee, *de| {
+                try ssmRollbackFromCapture(ee, acc, vl, s);
+                try ssmRollbackFromCapture(de, acc, vl, s);
+                try testing.expectEqualSlices(u32, &ee.ple_prev, &de.ple_prev);
+            }
+            for (b_e.entries, b_d.entries) |*ee, *de| {
+                try ssmRollbackFromCapture(ee, acc, vl, s);
+                try ssmRollbackFromCapture(de, acc, vl, s);
+                try testing.expectEqualSlices(u32, &ee.ple_prev, &de.ple_prev);
+            }
+            for (a_e.entries) |*e| ssmFreeSpecCapture(e);
+            for (b_e.entries) |*e| ssmFreeSpecCapture(e);
+            for (a_d.entries) |*e| ssmFreeSpecCapture(e);
+            for (b_d.entries) |*e| ssmFreeSpecCapture(e);
+        }
     }
 }
 

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -2742,6 +2742,19 @@ pub fn qsaBatchedGatherEnabled() bool {
     return v;
 }
 
+pub fn qsaBatchedGatherOn(seq_len: c_int, any_mrope: bool) bool {
+    if (any_mrope) return false;
+    if (!qsaBatchedGatherEnabled()) return false;
+    if (!qsaGatherEnabled()) return false;
+    if (seq_len <= 1) return qsaDecodeGatherEnabled();
+    return qsaVerifyGatherEnabled();
+}
+
+pub fn qsaBatchedGatherFloor(seq_len: c_int) c_int {
+    if (seq_len >= 2) return qsaVerifyGatherMinKv();
+    return qsaGatherMinKv();
+}
+
 var qsa_history_share_env_cached: ?bool = null;
 pub var qsa_history_share_override: ?bool = null;
 
@@ -4457,6 +4470,7 @@ pub fn qsaBatchedGatherAttn(
     q_rope: mlx.mlx_array,
     views: []const DenseKVView,
     blocks: []const mlx.mlx_array,
+    masks: []const mlx.mlx_array,
     ratio: c_int,
     attn_scale: f32,
 ) !mlx.mlx_array {
@@ -4466,7 +4480,9 @@ pub fn qsaBatchedGatherAttn(
     const h_count: c_int = qs[1];
     const hd: c_int = qs[3];
     if (views.len != n or blocks.len != n) return error.QsaBatchedGatherLen;
+    if (masks.len != 0 and masks.len != n) return error.QsaBatchedGatherLen;
     const fused_min_s = qsaAttnMinS();
+    const standin_sdpa = qwen4Standin().attn_sdpa;
     var outs = try allocator.alloc(mlx.mlx_array, n);
     defer allocator.free(outs);
     var built: usize = 0;
@@ -4475,6 +4491,7 @@ pub fn qsaBatchedGatherAttn(
         while (fi < built) : (fi += 1) _ = mlx.mlx_array_free(outs[fi]);
     }
     for (views, blocks, 0..) |*kv_view, blk, i| {
+        const slot_mask: mlx.mlx_array = if (i < masks.len) masks[i] else .{ .ctx = null };
         const i_c: c_int = @intCast(i);
         var q_slot = mlx.mlx_array_new();
         defer _ = mlx.mlx_array_free(q_slot);
@@ -4490,21 +4507,32 @@ pub fn qsaBatchedGatherAttn(
             s,
         ));
         var gathered: ?mlx.mlx_array = null;
-        if (blk.ctx != null and seq_len >= fused_min_s and seq_len < FUSED256_MIN_Q_LEN) {
+        const qsa_ok = blk.ctx != null and slot_mask.ctx == null and !standin_sdpa;
+        if (qsa_ok and seq_len >= fused_min_s and seq_len < FUSED256_MIN_Q_LEN) {
             gathered = try qsaSparseAttn(s, q_slot, kv_view, blk, ratio, attn_scale);
         }
-        if (gathered == null and blk.ctx != null and seq_len == 1) {
+        if (gathered == null and qsa_ok and seq_len == 1) {
             gathered = try qsaDecodeGatherAttn(s, q_slot, kv_view, blk, ratio, attn_scale);
         }
-        if (gathered == null and blk.ctx != null and seq_len >= 2 and seq_len < FUSED256_MIN_Q_LEN) {
+        if (gathered == null and qsa_ok and seq_len >= 2 and seq_len < FUSED256_MIN_Q_LEN) {
             gathered = try qsaVerifyGatherAttn(s, q_slot, kv_view, blk, ratio, attn_scale);
         }
         if (gathered) |g| {
             outs[i] = g;
-        } else if (blk.ctx != null) {
-            const mask = try qsaMaskFromBlocks(s, blk, mlx.getShape(kv_view.k)[2], ratio);
-            defer _ = mlx.mlx_array_free(mask);
-            outs[i] = mlx.mlx_array_new();
+            built = i + 1;
+            continue;
+        }
+        var mask_tmp: mlx.mlx_array = .{ .ctx = null };
+        defer if (mask_tmp.ctx != null) {
+            _ = mlx.mlx_array_free(mask_tmp);
+        };
+        const mask: mlx.mlx_array = if (slot_mask.ctx != null) slot_mask else if (blk.ctx != null) blk: {
+            mask_tmp = try qsaMaskFromBlocks(s, blk, mlx.getShape(kv_view.k)[2], ratio);
+            break :blk mask_tmp;
+        } else .{ .ctx = null };
+        outs[i] = mlx.mlx_array_new();
+        built = i + 1;
+        if (mask.ctx != null) {
             if (try fusedSdpa256Masked(s, q_slot, kv_view.k, kv_view.v, attn_scale, mask)) |fused| {
                 _ = mlx.mlx_array_free(outs[i]);
                 outs[i] = fused;
@@ -4515,12 +4543,10 @@ pub fn qsaBatchedGatherAttn(
                 try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&outs[i], q_slot, kv_view.k, kv_view.v, attn_scale, "array", mask, .{ .ctx = null }, false, s));
             }
         } else {
-            outs[i] = mlx.mlx_array_new();
             const none = mlx.mlx_array_new();
             defer _ = mlx.mlx_array_free(none);
             try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&outs[i], q_slot, kv_view.k, kv_view.v, attn_scale, "causal", none, .{ .ctx = null }, false, s));
         }
-        built = i + 1;
     }
     const vec = mlx.mlx_vector_array_new_data(outs.ptr, n);
     defer _ = mlx.mlx_vector_array_free(vec);
@@ -4560,7 +4586,7 @@ pub const QSA_VERIFY_GATHER_MIN_KV_DEFAULT: c_int = 16384;
 var qsa_verify_gather_min_kv_cached: ?c_int = null;
 pub var qsa_verify_gather_min_kv_override: ?c_int = null;
 
-fn qsaVerifyGatherMinKv() c_int {
+pub fn qsaVerifyGatherMinKv() c_int {
     if (qsa_verify_gather_min_kv_override) |v| return v;
     if (qsa_verify_gather_min_kv_cached) |v| return v;
     var v: c_int = QSA_VERIFY_GATHER_MIN_KV_DEFAULT;
@@ -16835,7 +16861,15 @@ pub const Transformer = struct {
             if (sc.qsa_blocks.ctx != null) any_blocks = true;
         }
         const keep_blocks = qsaBatchedGatherEnabled() and self.qwen4 != null and !any_mrope and any_blocks;
-        if (keep_blocks) return mlx.mlx_array_new();
+        if (keep_blocks) {
+            for (slots, 0..) |sc, i| {
+                if (sc.qsa_blocks.ctx == null and masks[i].ctx != null) {
+                    sc.qsa_mask = masks[i];
+                    masks[i] = .{ .ctx = null };
+                }
+            }
+            return mlx.mlx_array_new();
+        }
         for (slots, 0..) |sc, i| {
             if (sc.qsa_blocks.ctx != null) {
                 // Decode-width selection is per-slot unusable in the stacked
@@ -19688,6 +19722,7 @@ pub const Transformer = struct {
 
     fn qsaBatchedAttn(
         self: *Transformer,
+        ctx: *ForwardCtx,
         slots: []const *ForwardCtx,
         q_rope: mlx.mlx_array,
         layer: u32,
@@ -19696,6 +19731,7 @@ pub const Transformer = struct {
     ) !?mlx.mlx_array {
         if (!qsaBatchedGatherEnabled()) return null;
         if (self.qwen4 == null) return null;
+        std.debug.assert(ctx.qsa_mask.ctx == null);
         for (slots) |sc| if (sc.mrope_pos != null) return null;
         var any_blocks = false;
         for (slots) |sc| if (sc.qsa_blocks.ctx != null) {
@@ -19710,16 +19746,19 @@ pub const Transformer = struct {
         }
         var blks = try self.allocator.alloc(mlx.mlx_array, slots.len);
         defer self.allocator.free(blks);
+        var slot_masks = try self.allocator.alloc(mlx.mlx_array, slots.len);
+        defer self.allocator.free(slot_masks);
         for (slots, 0..) |slot_ctx, i| {
             views[i] = try slot_ctx.cache.denseView(layer, self.s);
             blks[i] = slot_ctx.qsa_blocks;
+            slot_masks[i] = slot_ctx.qsa_mask;
             if (slot_ctx.qsa_blocks.ctx != null) slot_ctx.qsa_arms.noteGather(seq_len) else slot_ctx.qsa_arms.note(.mask);
         }
         if (!qsa_batched_gather_logged) {
             qsa_batched_gather_logged = true;
             log.info("[qsa-batched-gather] engaged (slots={d} S={d}) — MLX_SERVE_QSA_BATCHED_GATHER=0 restores the dense padded mask\n", .{ slots.len, seq_len });
         }
-        return try qsaBatchedGatherAttn(self.allocator, self.s, q_rope, views, blks, ratio, attn_scale);
+        return try qsaBatchedGatherAttn(self.allocator, self.s, q_rope, views, blks, slot_masks, ratio, attn_scale);
     }
 
     fn gatedFullAttnWith(
@@ -19940,47 +19979,47 @@ pub const Transformer = struct {
                     slot_view.deinit();
                 }
 
-                if (try self.qsaBatchedAttn(slots, q_rope, layer, seq_len, attn_scale)) |gathered| {
+                if (try self.qsaBatchedAttn(ctx, slots, q_rope, layer, seq_len, attn_scale)) |gathered| {
                     _ = mlx.mlx_array_free(attn_out_b);
                     attn_out_b = gathered;
                 } else {
-                const dense_views = try self.allocator.alloc(DenseKVView, slots.len);
-                defer {
-                    for (dense_views) |*dv| dv.deinit();
-                    self.allocator.free(dense_views);
-                }
-                for (dense_views) |*dv| dv.* = .{ .k = .{ .ctx = null }, .v = .{ .ctx = null }, .owned = false };
-                const kv_len_buf = try self.allocator.alloc(i32, slots.len);
-                defer self.allocator.free(kv_len_buf);
-                var kv_max: c_int = 0;
-                for (slots, 0..) |slot_ctx, i| {
-                    dense_views[i] = try slot_ctx.cache.denseView(layer, self.s);
-                    const klen: c_int = mlx.getShape(dense_views[i].k)[2];
-                    kv_len_buf[i] = klen;
-                    if (klen > kv_max) kv_max = klen;
-                }
+                    const dense_views = try self.allocator.alloc(DenseKVView, slots.len);
+                    defer {
+                        for (dense_views) |*dv| dv.deinit();
+                        self.allocator.free(dense_views);
+                    }
+                    for (dense_views) |*dv| dv.* = .{ .k = .{ .ctx = null }, .v = .{ .ctx = null }, .owned = false };
+                    const kv_len_buf = try self.allocator.alloc(i32, slots.len);
+                    defer self.allocator.free(kv_len_buf);
+                    var kv_max: c_int = 0;
+                    for (slots, 0..) |slot_ctx, i| {
+                        dense_views[i] = try slot_ctx.cache.denseView(layer, self.s);
+                        const klen: c_int = mlx.getShape(dense_views[i].k)[2];
+                        kv_len_buf[i] = klen;
+                        if (klen > kv_max) kv_max = klen;
+                    }
 
-                const stacked_k = try self.padAndStackBatchedKV(dense_views, true, kv_max);
-                defer _ = mlx.mlx_array_free(stacked_k);
-                const stacked_v = try self.padAndStackBatchedKV(dense_views, false, kv_max);
-                defer _ = mlx.mlx_array_free(stacked_v);
-                var stacked_mask = try self.buildBatchedDecodeMask(kv_len_buf, kv_max, seq_len);
-                defer _ = mlx.mlx_array_free(stacked_mask);
-                if (ctx.qsa_mask.ctx != null) {
-                    // qwen4 QSA: the per-slot block selection (bool, false-
-                    // padded to kv_max) narrows the additive pad mask. One
-                    // dense-mask call serves the whole group, so it is billed
-                    // to every slot in it — the tally is per REQUEST.
-                    noteQsaArmForSlots(slots, .mask);
-                    const neg_inf = bf16Scalar(-std.math.inf(f32), self.s);
-                    defer _ = mlx.mlx_array_free(neg_inf);
-                    var narrowed = mlx.mlx_array_new();
-                    try mlx.check(mlx.mlx_where(&narrowed, ctx.qsa_mask, stacked_mask, neg_inf, self.s));
-                    _ = mlx.mlx_array_free(stacked_mask);
-                    stacked_mask = narrowed;
-                }
+                    const stacked_k = try self.padAndStackBatchedKV(dense_views, true, kv_max);
+                    defer _ = mlx.mlx_array_free(stacked_k);
+                    const stacked_v = try self.padAndStackBatchedKV(dense_views, false, kv_max);
+                    defer _ = mlx.mlx_array_free(stacked_v);
+                    var stacked_mask = try self.buildBatchedDecodeMask(kv_len_buf, kv_max, seq_len);
+                    defer _ = mlx.mlx_array_free(stacked_mask);
+                    if (ctx.qsa_mask.ctx != null) {
+                        // qwen4 QSA: the per-slot block selection (bool, false-
+                        // padded to kv_max) narrows the additive pad mask. One
+                        // dense-mask call serves the whole group, so it is billed
+                        // to every slot in it — the tally is per REQUEST.
+                        noteQsaArmForSlots(slots, .mask);
+                        const neg_inf = bf16Scalar(-std.math.inf(f32), self.s);
+                        defer _ = mlx.mlx_array_free(neg_inf);
+                        var narrowed = mlx.mlx_array_new();
+                        try mlx.check(mlx.mlx_where(&narrowed, ctx.qsa_mask, stacked_mask, neg_inf, self.s));
+                        _ = mlx.mlx_array_free(stacked_mask);
+                        stacked_mask = narrowed;
+                    }
 
-                try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&attn_out_b, q_rope, stacked_k, stacked_v, attn_scale, "array", stacked_mask, .{ .ctx = null }, false, self.s));
+                    try mlx.check(mlx.mlx_fast_scaled_dot_product_attention(&attn_out_b, q_rope, stacked_k, stacked_v, attn_scale, "array", stacked_mask, .{ .ctx = null }, false, self.s));
                 }
             }
             return self.gatedAttnTail(attn_out_b, gate, fa, flat_shape, batch, is_prefill, layer);
@@ -41467,7 +41506,7 @@ test "qsa batched gather S=1: N=1 is byte-identical to solo, N=2 matches per-slo
 
     const solo0 = (try qsaDecodeGatherAttn(s, q0, &view0, fx0.blocks, ratio, scale)) orelse return error.GatherDeclined;
     defer _ = mlx.mlx_array_free(solo0);
-    const bat1 = try qsaBatchedGatherAttn(ta, s, q0, &.{view0}, &.{fx0.blocks}, ratio, scale);
+    const bat1 = try qsaBatchedGatherAttn(ta, s, q0, &.{view0}, &.{fx0.blocks}, &.{}, ratio, scale);
     defer _ = mlx.mlx_array_free(bat1);
     try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat1, solo0, s));
 
@@ -41479,7 +41518,7 @@ test "qsa batched gather S=1: N=1 is byte-identical to solo, N=2 matches per-slo
     try mlx.check(mlx.mlx_concatenate_axis(&q_n2, qvec, 0, s));
     const views = [_]DenseKVView{ view0, view1 };
     const blks = [_]mlx.mlx_array{ fx0.blocks, fx1.blocks };
-    const bat2 = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, ratio, scale);
+    const bat2 = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &.{}, ratio, scale);
     defer _ = mlx.mlx_array_free(bat2);
     const solo1 = (try qsaDecodeGatherAttn(s, q1, &view1, fx1.blocks, ratio, scale)) orelse return error.GatherDeclined;
     defer _ = mlx.mlx_array_free(solo1);
@@ -41490,6 +41529,191 @@ test "qsa batched gather S=1: N=1 is byte-identical to solo, N=2 matches per-slo
     defer _ = mlx.mlx_vector_array_free(wvec);
     try mlx.check(mlx.mlx_concatenate_axis(&want, wvec, 0, s));
     try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat2, want, s));
+}
+
+test "qsa batched gather mixed group: a mask-only slot matches its solo masked SDPA" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+    const ta = std.testing.allocator;
+    qsa_decode_gather_override = true;
+    defer qsa_decode_gather_override = null;
+    qsa_batched_gather_override = true;
+    defer qsa_batched_gather_override = null;
+    var prng = std.Random.DefaultPrng.init(0x51a0);
+    const rnd = prng.random();
+    const ratio: c_int = 4;
+    const kb: c_int = 3;
+    const hq: c_int = 4;
+    const hkv: c_int = 2;
+    const hd: c_int = 64;
+    const scale: f32 = 1.0 / 8.0;
+    const kL0: c_int = 50;
+    const kL1: c_int = 36;
+    const q0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hq, 1, hd }, s);
+    defer _ = mlx.mlx_array_free(q0);
+    const q1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hq, 1, hd }, s);
+    defer _ = mlx.mlx_array_free(q1);
+    const k0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL0, hd }, s);
+    defer _ = mlx.mlx_array_free(k0);
+    const v0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL0, hd }, s);
+    defer _ = mlx.mlx_array_free(v0);
+    const k1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL1, hd }, s);
+    defer _ = mlx.mlx_array_free(k1);
+    const v1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL1, hd }, s);
+    defer _ = mlx.mlx_array_free(v1);
+    var fx0 = try QsaBlockFixture.build(rnd, 1, kL0, kb, ratio);
+    defer fx0.deinit();
+    var fx1 = try QsaBlockFixture.build(rnd, 1, kL1, kb, ratio);
+    defer fx1.deinit();
+    const view0 = DenseKVView{ .k = k0, .v = v0, .owned = false };
+    const view1 = DenseKVView{ .k = k1, .v = v1, .owned = false };
+    const solo0 = (try qsaDecodeGatherAttn(s, q0, &view0, fx0.blocks, ratio, scale)) orelse return error.GatherDeclined;
+    defer _ = mlx.mlx_array_free(solo0);
+    const solo1 = try attn256Reference(q1, k1, v1, scale, "array", fx1.mask, s);
+    defer _ = mlx.mlx_array_free(solo1);
+    var q_n2 = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(q_n2);
+    const qparts = [_]mlx.mlx_array{ q0, q1 };
+    const qvec = mlx.mlx_vector_array_new_data(&qparts, 2);
+    defer _ = mlx.mlx_vector_array_free(qvec);
+    try mlx.check(mlx.mlx_concatenate_axis(&q_n2, qvec, 0, s));
+    const views = [_]DenseKVView{ view0, view1 };
+    const blks = [_]mlx.mlx_array{ fx0.blocks, .{ .ctx = null } };
+    const masks = [_]mlx.mlx_array{ .{ .ctx = null }, fx1.mask };
+    const bat = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &masks, ratio, scale);
+    defer _ = mlx.mlx_array_free(bat);
+    var want = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(want);
+    const wparts = [_]mlx.mlx_array{ solo0, solo1 };
+    const wvec = mlx.mlx_vector_array_new_data(&wparts, 2);
+    defer _ = mlx.mlx_vector_array_free(wvec);
+    try mlx.check(mlx.mlx_concatenate_axis(&want, wvec, 0, s));
+    try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat, want, s));
+}
+
+test "qsa batched gather S=2 and S=4: N=1 is byte-identical to solo verify, N=2 matches per-slot solos" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+    const ta = std.testing.allocator;
+    qsa_verify_gather_override = true;
+    defer qsa_verify_gather_override = null;
+    qsa_verify_gather_min_kv_override = 16;
+    defer qsa_verify_gather_min_kv_override = null;
+    qsa_batched_gather_override = true;
+    defer qsa_batched_gather_override = null;
+    var prng = std.Random.DefaultPrng.init(0xc0de);
+    const rnd = prng.random();
+    const ratio: c_int = 4;
+    const kb: c_int = 3;
+    const hq: c_int = 4;
+    const hkv: c_int = 2;
+    const hd: c_int = 256;
+    const scale: f32 = 1.0 / 16.0;
+    const kL0: c_int = 96;
+    const kL1: c_int = 80;
+    for ([_]c_int{ 2, 4 }) |seq| {
+        const q0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hq, seq, hd }, s);
+        defer _ = mlx.mlx_array_free(q0);
+        const q1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hq, seq, hd }, s);
+        defer _ = mlx.mlx_array_free(q1);
+        const k0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL0, hd }, s);
+        defer _ = mlx.mlx_array_free(k0);
+        const v0 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL0, hd }, s);
+        defer _ = mlx.mlx_array_free(v0);
+        const k1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL1, hd }, s);
+        defer _ = mlx.mlx_array_free(k1);
+        const v1 = try attn256RandBf16(rnd, &[_]c_int{ 1, hkv, kL1, hd }, s);
+        defer _ = mlx.mlx_array_free(v1);
+        var fx0 = try QsaBlockFixture.build(rnd, seq, kL0, kb, ratio);
+        defer fx0.deinit();
+        var fx1 = try QsaBlockFixture.build(rnd, seq, kL1, kb, ratio);
+        defer fx1.deinit();
+        const view0 = DenseKVView{ .k = k0, .v = v0, .owned = false };
+        const view1 = DenseKVView{ .k = k1, .v = v1, .owned = false };
+        const solo0 = (try qsaVerifyGatherAttn(s, q0, &view0, fx0.blocks, ratio, scale)) orelse return error.GatherDeclined;
+        defer _ = mlx.mlx_array_free(solo0);
+        const bat1 = try qsaBatchedGatherAttn(ta, s, q0, &.{view0}, &.{fx0.blocks}, &.{}, ratio, scale);
+        defer _ = mlx.mlx_array_free(bat1);
+        try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat1, solo0, s));
+
+        var q_n2 = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(q_n2);
+        const qparts = [_]mlx.mlx_array{ q0, q1 };
+        const qvec = mlx.mlx_vector_array_new_data(&qparts, 2);
+        defer _ = mlx.mlx_vector_array_free(qvec);
+        try mlx.check(mlx.mlx_concatenate_axis(&q_n2, qvec, 0, s));
+        const views = [_]DenseKVView{ view0, view1 };
+        const blks = [_]mlx.mlx_array{ fx0.blocks, fx1.blocks };
+        const bat2 = try qsaBatchedGatherAttn(ta, s, q_n2, &views, &blks, &.{}, ratio, scale);
+        defer _ = mlx.mlx_array_free(bat2);
+        const solo1 = (try qsaVerifyGatherAttn(s, q1, &view1, fx1.blocks, ratio, scale)) orelse return error.GatherDeclined;
+        defer _ = mlx.mlx_array_free(solo1);
+        var want = mlx.mlx_array_new();
+        defer _ = mlx.mlx_array_free(want);
+        const wparts = [_]mlx.mlx_array{ solo0, solo1 };
+        const wvec = mlx.mlx_vector_array_new_data(&wparts, 2);
+        defer _ = mlx.mlx_vector_array_free(wvec);
+        try mlx.check(mlx.mlx_concatenate_axis(&want, wvec, 0, s));
+        try std.testing.expectEqual(@as(f32, 0), try attn256MaxDiff(bat2, want, s));
+    }
+}
+
+test "qsaBatchedAttn: kill switch and mrope refuse the gather arm" {
+    if (mlx.noGpuBackend()) return error.SkipZigTest;
+    var xfm: Transformer = undefined;
+    xfm.allocator = std.testing.allocator;
+    xfm.qwen4 = @ptrFromInt(@alignOf(qwen4_mod.Qwen4State));
+    var cache: KVCache = undefined;
+    var off: usize = 0;
+    var ctx: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+    var slot: ForwardCtx = .{ .cache = &cache, .moe_seq_offset = &off, .ssm_entries = null, .capture_hidden = null, .vision_embeddings = null };
+    const slots = [_]*ForwardCtx{&slot};
+    const dummy = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(dummy);
+
+    const prev_g = qsa_batched_gather_override;
+    defer qsa_batched_gather_override = prev_g;
+    qsa_batched_gather_override = false;
+    try std.testing.expect((try xfm.qsaBatchedAttn(&ctx, &slots, dummy, 0, 4, 1.0)) == null);
+
+    qsa_batched_gather_override = true;
+    const pos = [_]i32{ 0, 1, 2 };
+    slot.mrope_pos = &pos;
+    try std.testing.expect((try xfm.qsaBatchedAttn(&ctx, &slots, dummy, 0, 4, 1.0)) == null);
+}
+
+test "qsaBatchedGatherOn matches the arm's switches and vision refusal" {
+    const prev_b = qsa_batched_gather_override;
+    const prev_g = qsa_gather_override;
+    const prev_d = qsa_decode_gather_override;
+    const prev_v = qsa_verify_gather_override;
+    defer {
+        qsa_batched_gather_override = prev_b;
+        qsa_gather_override = prev_g;
+        qsa_decode_gather_override = prev_d;
+        qsa_verify_gather_override = prev_v;
+    }
+    qsa_batched_gather_override = true;
+    qsa_gather_override = true;
+    qsa_decode_gather_override = true;
+    qsa_verify_gather_override = true;
+    try std.testing.expect(qsaBatchedGatherOn(1, false));
+    try std.testing.expect(qsaBatchedGatherOn(4, false));
+    try std.testing.expect(!qsaBatchedGatherOn(1, true));
+    try std.testing.expect(!qsaBatchedGatherOn(4, true));
+    qsa_batched_gather_override = false;
+    try std.testing.expect(!qsaBatchedGatherOn(1, false));
+    qsa_batched_gather_override = true;
+    qsa_gather_override = false;
+    try std.testing.expect(!qsaBatchedGatherOn(1, false));
+    qsa_gather_override = true;
+    qsa_decode_gather_override = false;
+    try std.testing.expect(!qsaBatchedGatherOn(1, false));
+    try std.testing.expect(qsaBatchedGatherOn(4, false));
+    qsa_decode_gather_override = true;
+    qsa_verify_gather_override = false;
+    try std.testing.expect(qsaBatchedGatherOn(1, false));
+    try std.testing.expect(!qsaBatchedGatherOn(4, false));
 }
 
 // ── Verify-width QSA gather (S = 2 .. FUSED256_MIN_Q_LEN-1) ──

--- a/tests/bench_batched_qsa_gather.sh
+++ b/tests/bench_batched_qsa_gather.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Tick-time A/B: two streams at ~64k and ~162k, MLX_SERVE_QSA_BATCHED_GATHER=0|1.
+# Same-boot pair, 100s idle first, MLX_SERVE_ROUND_COST_PERSIST=0 on both arms.
+# Counterbalance by running twice with GATHER_ORDER=1,0 then GATHER_ORDER=0,1.
+# Usage: BENCH_MODEL=<qwen4_exp dir> ./tests/bench_batched_qsa_gather.sh [port]
+set -euo pipefail
+PORT=${1:-8098}
+MODEL="${BENCH_MODEL:?set BENCH_MODEL to a qwen4_exp pack}"
+BINARY="${MLX_SERVE_BINARY:-./zig-out/bin/mlx-serve}"
+ORDER="${GATHER_ORDER:-1,0}"
+OUT="${BENCH_OUT:-$HOME/claude-tmp/qsa-batched-gather}"
+mkdir -p "$OUT"
+if [ ! -x "$BINARY" ]; then
+    echo "FAIL $BINARY missing — build first"
+    exit 1
+fi
+pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
+prompt_of() {
+    python3 -c "print(('The history of computing. ' * int($1 * 4))[:int($1 * 16)])"
+}
+one() {
+    local toks=$1
+    python3 -c "
+import json,sys,time
+t0=time.time()
+body=json.dumps({
+    'model':'mlx-serve',
+    'messages':[{'role':'user','content':sys.argv[1]}],
+    'max_tokens': 64,
+    'temperature': 0,
+    'stream': False,
+})
+print(body)
+" "$(prompt_of "$toks")" | curl -s -m 3600 -X POST -H 'Content-Type: application/json' -d @- "http://127.0.0.1:$PORT/v1/chat/completions" | python3 -c "
+import sys,json
+j=json.load(sys.stdin)
+t=j.get('timings') or {}
+n=t.get('predicted_n') or j.get('usage',{}).get('completion_tokens') or 0
+ms=t.get('predicted_ms') or 0
+pt=t.get('prompt_n') or j.get('usage',{}).get('prompt_tokens') or 0
+tick = (ms/n) if n else 0
+print(f\"prompt={pt} predicted={n} predicted_ms={ms:.1f} ms/tick={tick:.2f} tok/s={t.get('predicted_per_second',0):.1f}\")
+"
+}
+run_arm() {
+    local gather=$1
+    local log="$OUT/gather_$gather.log"
+    echo "== MLX_SERVE_QSA_BATCHED_GATHER=$gather =="
+    MLX_SERVE_ROUND_COST_PERSIST=0 MLX_SERVE_QSA_BATCHED_GATHER=$gather \
+        "$BINARY" --model "$MODEL" --serve --host 127.0.0.1 --port "$PORT" \
+        --max-concurrent 4 --prefix-cache-entries 0 --no-pld --log-level info \
+        > "$log" 2>&1 &
+    local pid=$!
+    for i in $(seq 1 300); do
+        curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && grep -q "Model ready" "$log" && break
+        sleep 1
+    done
+    echo "idle 100s"
+    sleep 100
+    local t0
+    t0=$(python3 -c 'import time; print(time.time())')
+    one 64000 > "$OUT/g${gather}_64k.out" &
+    local p1=$!
+    one 162000 > "$OUT/g${gather}_162k.out" &
+    local p2=$!
+    wait $p1 $p2
+    echo "64k  $(cat "$OUT/g${gather}_64k.out")"
+    echo "162k $(cat "$OUT/g${gather}_162k.out")"
+    echo "wall $(python3 -c "import time; print(f'{time.time()-$t0:.1f}s')")"
+    echo "batched engaged: $(grep -c '\[batched\].*engaged' "$log" || true)"
+    echo "qsa-batched-gather: $(grep -c '\[qsa-batched-gather\] engaged' "$log" || true)"
+    grep -E '\[batched\].*engaged|\[qsa-batched-gather\] engaged|\[qsa-arms\]|\[qsa-decode-gather\]|\[qsa-verify-gather\]' "$log" || true
+    kill $pid 2>/dev/null || true
+    wait $pid 2>/dev/null || true
+    pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
+    for i in $(seq 1 30); do
+        lsof -nP -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1 || break
+        sleep 1
+    done
+}
+IFS=',' read -r -a arms <<< "$ORDER"
+for g in "${arms[@]}"; do
+    run_arm "$g"
+done


### PR DESCRIPTION
## Summary

Stacked on #391 (`feature/batch-decode-mtp`), taking its two open follow-ups plus the batching lever from our audit. Five commits (`14fde82`, `3e5b83e`, `cb41abe`, `dff98f3`, `c2807f9`):

- **Gather arm (default on).** Batched qwen4_exp slots each gather their own selected QSA blocks instead of padding one dense `[N,H,S,kv_max]` mask over the group's stacked KV; a slot with a mask but no blocks keeps its mask through the masked-SDPA ladder, plain causal only when a slot has neither. Forced N=1 is byte-identical to the solo arm; N=2 equals the concat of two solos. `MLX_SERVE_QSA_BATCHED_GATHER=0` restores the stacked mask.
- **Deferred PLE on the batched arm.** The batched tick plants the same zero `[N,S,C]` leaf the solo tick does, claims the spec-capture length per slot at build time and fills every row from its own slot's history after the build, removing the host read from inside the layer-1 graph.
- **Batched verify on Flash Next behind `MLX_SERVE_MTP_BATCHED_QWEN4=1`** (off until measured): `pleGatherBf16` is row-correct at `[N,S]`, `qsaMaskBatched` passes the real S so the indexer history advances per slot, `splitSsmToSlots` carries `spec_ple_input` so a partial accept rolls back per slot.
- **Billing.** The pad-waste cap bills the SELECTED length on qwen4_exp, reading exactly the switches, kv floors and the group's vision flag the arm reads, so a group is never admitted on a sparse bill and served the padded stack.

## Bars

- `tests/test_batched_equivalence.sh` two-stream on qwen4_exp: 4/4 (byte-identical single vs batched at N=1, near-ties acquitted at N=2, kv-quant 8 alive).
- Tick time, two concurrent streams (68.6k and 163k tokens), same binary, `MLX_SERVE_QSA_BATCHED_GATHER=1` vs `0`, counterbalanced 1,0,0,1, `MLX_SERVE_ROUND_COST_PERSIST=0`, fans max (M5 Max):

| arm | 64k stream ms/token | 162k stream ms/token | per-slot tok/s |
|---|---|---|---|
| stacked dense mask (as #391) | 113.6 / 114.9 | 113.1 / 114.2 | 8.8 |
| per-slot gather (this stack) | 28.6 / 29.1 | 27.5 / 27.7 | 35 |

  4.0x per tick; `[qsa-arms] qsa=decode_gather` on both slots with the gather, `qsa=mask` without. Concurrent throughput at short context (default 200-token prompt, N=4): base 1.71x, stack 1.70x (the gather does not engage below 8k, no regression).
- Model-backed deferred-PLE identity test (`QWEN4_TEST_MODEL`, pack loaded): 3/3 pass (logits and per-slot PLE state bit-identical deferred vs eager at S=1 and S=4, incl. a partial-accept rollback).
- Note for the maintainer: `tests/test_mtp_batched.sh` fails at N=3 (streams 0 and 2 differ from solo) on this stack **and on the unmodified `ed3ba65`**: pre-existing.

A base-vs-stack tick A/B with the unmodified `ed3ba65` binary follows as a comment (the OFF arm above still carries the deferred PLE, so 4.0x is a lower bound on the kernel term and compound with admission).

Suite: 2258 pass, 154 skip, 0 fail. Audits: one Opus design pass and three Opus review rounds; every P0/P1 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
