### PR TITLE
serve: prefill_tokens_expected for the monitor plugin; #394 follow-up (self-heal cache, view restore, per-lookup skip, sequential live test)

### DIFF
--- a/src/generate.zig
+++ b/src/generate.zig
@@ -1951,6 +1951,9 @@ pub const Generator = struct {
         /// prefill saturates the GPU while both tiles read 0 / "—". The
         /// scheduler resets it to 0 when the prefill ends.
         prefill_progress: ?*std.atomic.Value(u64) = null,
+        /// Total tokens this prefill will forward (post-cache tail, same scale
+        /// as `prefill_progress`), published once; null on the bypass engines.
+        prefill_expected: ?*std.atomic.Value(u64) = null,
 
         /// Called once per completed prefill chunk boundary (chunk state
         /// evaluated, allocator cache cleared), except the final one. The
@@ -2350,6 +2353,7 @@ pub const Generator = struct {
             );
 
             var pos: usize = 0;
+            if (options.prefill_expected) |e| e.store(@intCast(loop_end), .monotonic);
             while (pos < loop_end) {
                 // Abandoned-request abort: the client disconnected and the
                 // conn thread flagged the slot. Bail before the next chunk —

--- a/src/kv_disk_cache.zig
+++ b/src/kv_disk_cache.zig
@@ -786,7 +786,7 @@ pub const DiskTier = struct {
             }
         }
         if (qsa_overlay) |*qsa_cp| {
-            try transformer_mod.applyQsaHistoryAt(ssm_entries, qsa_cp, cp_pos, s);
+            try transformer_mod.applyQsaHistoryAt(ssm_entries, qsa_cp, cp_pos, s, true);
         }
         e.last_used = self.bump();
         self.writeMeta(e.*) catch {};

--- a/src/metrics.zig
+++ b/src/metrics.zig
@@ -97,6 +97,9 @@ pub const Metrics = struct {
     // the sampler from `Scheduler.inflight_prefill_tokens` (published once per
     // prefill CHUNK, never per token).
     prefill_tokens_live: Gauge,
+    /// Post-cache tail the in-flight prefill will forward, same scale as
+    /// `prefill_tokens_live`; 0 when idle.
+    prefill_tokens_expected: Gauge,
     // Slots currently in prefill. Flips as soon as prefill starts, so the panel
     // can name the phase without waiting for the first chunk's token count.
     requests_prefilling: Gauge,
@@ -140,6 +143,7 @@ pub const Metrics = struct {
             .memory_mb = Gauge.init(),
             .generation_tokens_live = Gauge.init(),
             .prefill_tokens_live = Gauge.init(),
+            .prefill_tokens_expected = Gauge.init(),
             .requests_prefilling = Gauge.init(),
             .mlx_active_bytes = Gauge.init(),
             .mlx_cache_bytes = Gauge.init(),
@@ -253,6 +257,7 @@ pub fn renderPrometheus(m: *const Metrics, w: *std.Io.Writer) !void {
     try writeGauge(w, "mlx_serve:memory_mb", "Server physical memory footprint in megabytes (phys_footprint)", m.memory_mb.load());
     try writeGauge(w, "mlx_serve:generation_tokens_live", "Generation tokens completed plus generated-so-far by in-flight slots (real-time tok/s source)", m.generation_tokens_live.load());
     try writeGauge(w, "mlx_serve:prefill_tokens_live", "Prompt tokens forwarded so far by the in-flight prefill (0 when idle; real-time prefill tok/s source)", m.prefill_tokens_live.load());
+    try writeGauge(w, "mlx_serve:prefill_tokens_expected", "Total tokens the in-flight prefill will forward, post-cache tail on the same scale as prefill_tokens_live (0 when idle; the bar's real target)", m.prefill_tokens_expected.load());
     try writeGauge(w, "mlx_serve:requests_prefilling", "Requests currently in the prefill phase", m.requests_prefilling.load());
     try writeGauge(w, "mlx_serve:mlx_active_bytes", "Bytes MLX's allocator currently has in use", m.mlx_active_bytes.load());
     try writeGauge(w, "mlx_serve:mlx_cache_bytes", "Bytes parked in MLX's reclaimable buffer pool (held by the process, not in use)", m.mlx_cache_bytes.load());
@@ -297,6 +302,7 @@ pub fn renderJson(m: *const Metrics, w: *std.Io.Writer) !void {
             "\"memory_mb\":{d}," ++
             "\"generation_tokens_live\":{d}," ++
             "\"prefill_tokens_live\":{d}," ++
+            "\"prefill_tokens_expected\":{d}," ++
             "\"requests_prefilling\":{d}," ++
             "\"mlx_active_bytes\":{d}," ++
             "\"mlx_cache_bytes\":{d}," ++
@@ -319,6 +325,7 @@ pub fn renderJson(m: *const Metrics, w: *std.Io.Writer) !void {
             m.memory_mb.load(),
             m.generation_tokens_live.load(),
             m.prefill_tokens_live.load(),
+            m.prefill_tokens_expected.load(),
             m.requests_prefilling.load(),
             m.mlx_active_bytes.load(),
             m.mlx_cache_bytes.load(),
@@ -582,6 +589,7 @@ test "prefill progress is exposed live, not only at request completion" {
     // the in-flight prefill, 0 when none is running.
     var m = Metrics.init();
     m.prefill_tokens_live.set(16384);
+    m.prefill_tokens_expected.set(48000);
 
     var buf: [8192]u8 = undefined;
     var w = std.Io.Writer.fixed(&buf);
@@ -589,15 +597,19 @@ test "prefill progress is exposed live, not only at request completion" {
     const out = w.buffered();
     try testing.expect(std.mem.indexOf(u8, out, "# TYPE mlx_serve:prefill_tokens_live gauge") != null);
     try testing.expect(std.mem.indexOf(u8, out, "mlx_serve:prefill_tokens_live 16384") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "mlx_serve:prefill_tokens_expected 48000") != null);
 
     var jbuf: [8192]u8 = undefined;
     var jw = std.Io.Writer.fixed(&jbuf);
     try renderJson(&m, &jw);
     try testing.expect(std.mem.indexOf(u8, jw.buffered(), "\"prefill_tokens_live\":16384") != null);
+    try testing.expect(std.mem.indexOf(u8, jw.buffered(), "\"prefill_tokens_expected\":48000") != null);
 
-    // At rest it is zero — "prefilling" must mean exactly that.
+    // At rest both gauges are zero.
     m.prefill_tokens_live.set(0);
+    m.prefill_tokens_expected.set(0);
     try testing.expectEqual(@as(u64, 0), m.prefill_tokens_live.load());
+    try testing.expectEqual(@as(u64, 0), m.prefill_tokens_expected.load());
 
     // The phase flag is separate from the token count: it flips at prefill
     // START, so the panel isn't blind for the ~40 s a 27B takes to finish its

--- a/src/prefix_cache.zig
+++ b/src/prefix_cache.zig
@@ -395,7 +395,6 @@ pub const HotPrefixCache = struct {
     /// `last_used` of the entry the current request restored from; `evictLruToAdmit` refuses to evict it.
     last_restored_used: ?u64 = null,
     last_restored_disk_id: ?u64 = null,
-    skip_prefix_cache: bool = false,
     /// The arch keeps a QSA indexer history beside its SSM state (qwen4_exp).
     /// A restore that leaves the live entries without it cannot prefill —
     /// `qsaMaskFromQk` errors on every turn on that prefix — so it is a MISS.
@@ -1002,6 +1001,7 @@ pub const HotPrefixCache = struct {
             dflash_target,
             mtp_target,
             null,
+            false,
         );
     }
 
@@ -1032,6 +1032,7 @@ pub const HotPrefixCache = struct {
             dflash_target,
             mtp_target,
             slot_id,
+            false,
         );
     }
 
@@ -1050,11 +1051,11 @@ pub const HotPrefixCache = struct {
         /// Restore by move: non-null opts this request into the checkout (the caller promises
         /// `releaseCheckout` on every path that ends the slot).
         slot_id: ?usize,
+        skip: bool,
     ) !LookupResult {
         self.last_restored_used = null;
         self.last_restored_disk_id = null;
-        if (self.skip_prefix_cache) {
-            self.skip_prefix_cache = false;
+        if (skip) {
             try target_cache.truncate(0, s);
             if (target_ssm_entries) |entries| resetSsmEntries(entries);
             target_moe_seq_offset.* = 0;
@@ -1138,16 +1139,6 @@ pub const HotPrefixCache = struct {
                 const ms = sw.read() / std.time.ns_per_ms;
                 log.info("  [disk-cache] restored {d}/{d} tokens from SSD in {d}ms (ssm@{d})\n", .{ restored, prompt_ids.len, ms, disk_cp });
                 const disk_mtp = diskRestoreSpec(d, hm.idx, mtp_target, restored, s, .mtp);
-                _ = restore_dump.dumpRestoreIfEnabled(target_cache, ssm_entries, s, .{
-                    .kind = "restore",
-                    .pos = restored,
-                    .cp = disk_cp,
-                    .bank_from = disk_cp,
-                    .source = "disk",
-                    .entry_idx = hm.idx + 1,
-                    .entry_count = d.entryCount(),
-                    .mtp_base = disk_mtp,
-                });
                 return .{
                     .matched = restored,
                     .full_match = false,
@@ -1182,16 +1173,6 @@ pub const HotPrefixCache = struct {
             const ms = sw.read() / std.time.ns_per_ms;
             log.info("  [disk-cache] restored {d}/{d} tokens from SSD ({d} chunks) in {d}ms\n", .{ final_len, prompt_ids.len, d.chunks_loaded_last, ms });
             const disk_mtp = diskRestoreSpec(d, dm.idx, mtp_target, final_len, s, .mtp);
-            _ = restore_dump.dumpRestoreIfEnabled(target_cache, target_ssm_entries, s, .{
-                .kind = "restore",
-                .pos = final_len,
-                .cp = final_len,
-                .bank_from = final_len,
-                .source = "disk",
-                .entry_idx = dm.idx + 1,
-                .entry_count = d.entryCount(),
-                .mtp_base = disk_mtp,
-            });
             return .{
                 .matched = final_len,
                 .full_match = full_match,
@@ -1268,9 +1249,7 @@ pub const HotPrefixCache = struct {
         // the effective matched length to that position. KV is positionally
         // trimmable; SSM is only restorable at the snapshotted positions.
         // The two MUST stay in sync, so we rewind KV further too.
-        var dump_cp: usize = 0;
-        var dump_bank: usize = 0;
-        var dump_src: []const u8 = "own";
+        var dump = restore_dump.RestoreDumpMeta{ .kind = "restore", .pos = 0 };
         var effective_matched: usize = restore_cap;
         if (target_ssm_entries) |entries| {
             if (e.ssm_checkpoints) |cps| {
@@ -1279,7 +1258,7 @@ pub const HotPrefixCache = struct {
                     effective_matched = cp.pos;
                     const bank = qsaHistorySource(cps, cp);
                     if (bank) |src| {
-                        try applyQsaHistoryAt(entries, src, cp.pos, s);
+                        try applyQsaHistoryAt(entries, src, cp.pos, s, false);
                     }
                     const ring_rows: c_int = blk: {
                         for (entries) |*ent| {
@@ -1289,15 +1268,17 @@ pub const HotPrefixCache = struct {
                         }
                         break :blk 0;
                     };
-                    dump_cp = cp.pos;
-                    dump_bank = if (bank) |b| b.pos else cp.pos;
-                    dump_src = if (bank == null) "own" else "donor";
+                    dump.cp = cp.pos;
+                    dump.bank_from = if (bank) |b| b.pos else cp.pos;
+                    dump.source = if (bank == null) "own" else "donor";
+                    dump.entry_idx = m.idx + 1;
+                    dump.entry_count = self.entries.items.len;
                     log.debug("  [hot-cache] restore pos={d} cp={d} bank_from=cp@{d} ring_rows={d} source={s}\n", .{
                         effective_matched,
-                        dump_cp,
-                        dump_bank,
+                        dump.cp,
+                        dump.bank_from,
                         ring_rows,
-                        dump_src,
+                        dump.source,
                     });
                     if (self.qsa_history_required and !(entriesHaveQsaHistory(entries) and qsaRestoreSatisfiesForward(entries, effective_matched))) {
                         resetSsmEntries(entries);
@@ -1350,46 +1331,28 @@ pub const HotPrefixCache = struct {
         // token id, so the match can never reach into it — discarding it is correct.
         try target_cache.truncate(final_len, s);
 
-        if (full_match and effective_matched > 1) {
-            target_moe_seq_offset.* = effective_matched - 1;
-            log.info("  [hot-cache] full reuse {d}/{d}, re-forwarding last token\n", .{ effective_matched - 1, prompt_ids.len });
-            const full_mtp = restoreMtp(e, mtp_target, effective_matched - 1, s);
-            _ = restore_dump.dumpRestoreIfEnabled(target_cache, target_ssm_entries, s, .{
-                .kind = "restore",
-                .pos = effective_matched - 1,
-                .cp = dump_cp,
-                .bank_from = dump_bank,
-                .source = dump_src,
-                .entry_idx = m.idx + 1,
-                .entry_count = self.entries.items.len,
-                .mtp_base = full_mtp,
-            });
-            return .{
-                .matched = effective_matched - 1,
-                .full_match = true,
-                .dflash_base = restoreDflash(e, dflash_target, effective_matched - 1, s),
-                .mtp_base = full_mtp,
-            };
+        const full_reuse = full_match and effective_matched > 1;
+        const matched = if (full_reuse) effective_matched - 1 else effective_matched;
+        if (full_reuse) {
+            target_moe_seq_offset.* = matched;
+            log.info("  [hot-cache] full reuse {d}/{d}, re-forwarding last token\n", .{ matched, prompt_ids.len });
+        } else {
+            log.info("  [hot-cache] reused {d}/{d} tokens (matched {d}; entry {d}/{d})\n", .{ effective_matched, prompt_ids.len, m.shared, m.idx + 1, self.entries.items.len });
         }
-
-        log.info("  [hot-cache] reused {d}/{d} tokens (matched {d}; entry {d}/{d})\n", .{ effective_matched, prompt_ids.len, m.shared, m.idx + 1, self.entries.items.len });
         var res: LookupResult = .{
-            .matched = effective_matched,
+            .matched = matched,
             .full_match = full_match,
-            .dflash_base = restoreDflash(e, dflash_target, effective_matched, s),
-            .mtp_base = restoreMtp(e, mtp_target, effective_matched, s),
+            .dflash_base = restoreDflash(e, dflash_target, matched, s),
+            .mtp_base = restoreMtp(e, mtp_target, matched, s),
         };
-        res.checked_out = self.checkoutIfEligible(m.idx, m.shared, prompt_ids.len, slot_id);
-        _ = restore_dump.dumpRestoreIfEnabled(target_cache, target_ssm_entries, s, .{
-            .kind = "restore",
-            .pos = res.matched,
-            .cp = dump_cp,
-            .bank_from = dump_bank,
-            .source = dump_src,
-            .entry_idx = m.idx + 1,
-            .entry_count = self.entries.items.len,
-            .mtp_base = res.mtp_base,
-        });
+        if (!full_reuse) {
+            res.checked_out = self.checkoutIfEligible(m.idx, m.shared, prompt_ids.len, slot_id);
+        }
+        dump.pos = res.matched;
+        dump.mtp_base = res.mtp_base;
+        dump.entry_idx = m.idx + 1;
+        dump.entry_count = self.entries.items.len;
+        _ = restore_dump.dumpRestoreIfEnabled(target_cache, target_ssm_entries, s, dump);
         return res;
     }
 
@@ -1811,12 +1774,8 @@ pub const HotPrefixCache = struct {
             else
                 self.max_kv_bytes - new_bytes;
             const donor_cps = self.entries.items[donor.idx].ssm_checkpoints.?;
-            const donor_toks = self.entries.items[donor.idx].tokens;
-            var div: usize = 0;
-            const max_div = @min(donor_toks.len, eff_tokens.len);
-            while (div < max_div and donor_toks[div] == eff_tokens[div]) div += 1;
             const prompt_cap = @min(if (prompt_len == 0) eff_tokens.len else prompt_len, eff_tokens.len);
-            const inherit_limit = @min(@min(donor.shared, div), prompt_cap);
+            const inherit_limit = @min(donor.shared, prompt_cap);
             const cloned = (cloneCheckpointsUpTo(self.allocator, donor_cps, inherit_limit, budget) catch |err| {
                 log.warn("  [hot-cache] checkpoint inheritance failed: {s}\n", .{@errorName(err)});
                 break :inherit;
@@ -2655,6 +2614,11 @@ pub const HotPrefixCache = struct {
         return dropped;
     }
 
+    pub fn dropQsaGapEntry(slot_cache: ?*HotPrefixCache) bool {
+        if (slot_cache) |hc| return hc.dropLastRestored();
+        return false;
+    }
+
     fn evictAt(self: *HotPrefixCache, lru_idx: usize, reason: []const u8) void {
         var evicted = self.entries.swapRemove(lru_idx);
         const tokens_len = evicted.tokens.len;
@@ -3394,7 +3358,7 @@ test "HotPrefixCache: an entry shorter than its media boundary is pure text" {
         var c2 = try KVCache.init(testing.allocator, 2);
         defer c2.deinit();
         var moe: usize = 0;
-        const res = try hc.lookupAndRestoreWithMedia(&c2, &moe, null, s, &tokens, false, 0, null, null, null, null);
+        const res = try hc.lookupAndRestoreWithMedia(&c2, &moe, null, s, &tokens, false, 0, null, null, null, null, false);
         try testing.expectEqual(@as(usize, 400), res.matched);
     }
     // A different-image request caps at ITS media boundary (500 > 400 here,
@@ -3403,7 +3367,7 @@ test "HotPrefixCache: an entry shorter than its media boundary is pure text" {
         var c3 = try KVCache.init(testing.allocator, 2);
         defer c3.deinit();
         var moe: usize = 0;
-        const res = try hc.lookupAndRestoreWithMedia(&c3, &moe, null, s, &tokens, false, 0xFFFF, 500, null, null, null);
+        const res = try hc.lookupAndRestoreWithMedia(&c3, &moe, null, s, &tokens, false, 0xFFFF, 500, null, null, null, false);
         try testing.expectEqual(@as(usize, 400), res.matched);
     }
 
@@ -3464,7 +3428,7 @@ test "HotPrefixCache: media request restores the pre-media text prefix from SSD"
         var cache2 = try KVCache.init(testing.allocator, 2);
         defer cache2.deinit();
         var moe: usize = 0;
-        const res = try hc2.lookupAndRestoreWithMedia(&cache2, &moe, null, s, &tokens, false, 0xDEAD, 400, null, null, null);
+        const res = try hc2.lookupAndRestoreWithMedia(&cache2, &moe, null, s, &tokens, false, 0xDEAD, 400, null, null, null, false);
         try testing.expect(!res.full_match);
         try testing.expectEqual(@as(usize, 400), res.matched);
         try testing.expectEqual(@as(usize, 400), cache2.step);
@@ -3775,6 +3739,7 @@ test "HotPrefixCache: hybrid lookup reuses only the prefix before changed media"
         null,
         null,
         null,
+        false,
     );
 
     try testing.expectEqual(media_start, result.matched);
@@ -3892,6 +3857,7 @@ test "HotPrefixCache: a text turn after image turns restores the pre-media prefi
         null,
         null,
         null,
+        false,
     );
     try testing.expectEqual(@as(usize, 10), restored.matched);
 
@@ -3926,6 +3892,7 @@ test "HotPrefixCache: a text turn after image turns restores the pre-media prefi
         null,
         null,
         null,
+        false,
     );
     try testing.expectEqual(@as(usize, 10), result.matched);
     try testing.expectEqual(@as(usize, 10), later_cache.step);
@@ -5757,6 +5724,58 @@ test "HotPrefixCache: dropLastRestored removes the restored entry so the next lo
     try testing.expectEqual(@as(usize, 0), second.matched);
 }
 
+test "HotPrefixCache: QSA self-heal drops the slot model cache and leaves a sibling cache" {
+    const s = mlx.gpuStream();
+    const tokens_a = [_]u32{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    const tokens_b = [_]u32{ 11, 12, 13, 14, 15, 16, 17, 18, 19, 20 };
+
+    var last_loaded = HotPrefixCache.initWithMem(testing.allocator, 4, 0);
+    defer last_loaded.deinit();
+    last_loaded.qsa_history_required = true;
+    var cache_a = try KVCache.init(testing.allocator, 3);
+    defer cache_a.deinit();
+    try testFillCache(&cache_a, s, 3, tokens_a.len);
+    var live_a = pcBuildQsaHybrid(s, 10, 100.0);
+    defer pcFreeQsaHybrid(&live_a);
+    const cps_a = try testing.allocator.alloc(SSMCheckpoint, 1);
+    cps_a[0] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &live_a, 8, s);
+    try transformer_mod.attachQsaHistoryToLatest(cps_a, &live_a, s);
+    _ = try last_loaded.commitWithState(&cache_a, &tokens_a, false, 0, cps_a, null, null);
+
+    var slot_hc = HotPrefixCache.initWithMem(testing.allocator, 4, 0);
+    defer slot_hc.deinit();
+    slot_hc.qsa_history_required = true;
+    var cache_b = try KVCache.init(testing.allocator, 3);
+    defer cache_b.deinit();
+    try testFillCache(&cache_b, s, 3, tokens_b.len);
+    var live_b = pcBuildQsaHybrid(s, 10, 200.0);
+    defer pcFreeQsaHybrid(&live_b);
+    const cps_b = try testing.allocator.alloc(SSMCheckpoint, 1);
+    cps_b[0] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &live_b, 8, s);
+    try transformer_mod.attachQsaHistoryToLatest(cps_b, &live_b, s);
+    _ = try slot_hc.commitWithState(&cache_b, &tokens_b, false, 0, cps_b, null, null);
+
+    var tgt_a = try KVCache.init(testing.allocator, 3);
+    defer tgt_a.deinit();
+    var ssm_a = pcEmptySsm();
+    defer pcFreeQsaHybrid(&ssm_a);
+    var moe_a: usize = 0;
+    const ra = try last_loaded.lookupAndRestore(&tgt_a, &moe_a, &ssm_a, s, &tokens_a, false, 0, null, null);
+    try testing.expect(ra.matched > 0);
+
+    var tgt_b = try KVCache.init(testing.allocator, 3);
+    defer tgt_b.deinit();
+    var ssm_b = pcEmptySsm();
+    defer pcFreeQsaHybrid(&ssm_b);
+    var moe_b: usize = 0;
+    const rb = try slot_hc.lookupAndRestore(&tgt_b, &moe_b, &ssm_b, s, &tokens_b, false, 0, null, null);
+    try testing.expect(rb.matched > 0);
+
+    try testing.expect(HotPrefixCache.dropQsaGapEntry(&slot_hc));
+    try testing.expectEqual(@as(usize, 0), slot_hc.entryCount());
+    try testing.expectEqual(@as(usize, 1), last_loaded.entryCount());
+}
+
 test "HotPrefixCache: inherited checkpoints never exceed the shared prefix" {
     const s = mlx.gpuStream();
     var prefix: [18]u32 = undefined;
@@ -5847,7 +5866,7 @@ fn pcCaptureFed(
     return transformer_mod.captureSsmCheckpoint(allocator, &live, @intCast(pos), s);
 }
 
-test "HotPrefixCache: inherit does not clone checkpoints past token divergence" {
+test "HotPrefixCache: inherit does not clone checkpoints past donor.shared" {
     if (mlx.noGpuBackend()) return error.SkipZigTest;
     const s = mlx.gpuStream();
     const P: usize = 20;
@@ -6025,7 +6044,7 @@ test "HotPrefixCache: sliced qsa bank apply at backoff matches the full bank at 
     var from_full = pcEmptySsm();
     defer pcFreeQsaHybrid(&from_full);
     try transformer_mod.restoreSsmCheckpoint(&from_full, &cps[0]);
-    transformer_mod.applyQsaHistoryAt(&from_full, &cps[1], B, s) catch |err| {
+    transformer_mod.applyQsaHistoryAt(&from_full, &cps[1], B, s, false) catch |err| {
         std.debug.print("sliced-apply residue fail K=full field=apply {s}\n", .{@errorName(err)});
         return err;
     };
@@ -6048,7 +6067,7 @@ test "HotPrefixCache: sliced qsa bank apply at backoff matches the full bank at 
         var from_sliced = pcEmptySsm();
         defer pcFreeQsaHybrid(&from_sliced);
         try transformer_mod.restoreSsmCheckpoint(&from_sliced, &cps[0]);
-        transformer_mod.applyQsaHistoryAt(&from_sliced, &sliced, B, s) catch |err| {
+        transformer_mod.applyQsaHistoryAt(&from_sliced, &sliced, B, s, false) catch |err| {
             std.debug.print("sliced-apply residue fail K={d} field=apply {s}\n", .{ K, @errorName(err) });
             return err;
         };
@@ -6272,6 +6291,38 @@ test "HotPrefixCache: walk-down restores the higher covering checkpoint, not a l
     try testing.expect(target[0].qsa_pooled.ctx != null);
 }
 
+test "HotPrefixCache: skip set on the cache without a lookup does not poison the next request" {
+    const s = mlx.gpuStream();
+    const tokens = [_]u32{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    var hc = HotPrefixCache.initWithMem(testing.allocator, 4, 0);
+    defer hc.deinit();
+    hc.qsa_history_required = true;
+    var cache = try KVCache.init(testing.allocator, 3);
+    defer cache.deinit();
+    try testFillCache(&cache, s, 3, tokens.len);
+    var live = pcBuildQsaHybrid(s, 10, 100.0);
+    defer pcFreeQsaHybrid(&live);
+    const cps = try testing.allocator.alloc(SSMCheckpoint, 1);
+    cps[0] = try transformer_mod.captureSsmCheckpoint(testing.allocator, &live, 8, s);
+    try transformer_mod.attachQsaHistoryToLatest(cps, &live, s);
+    _ = try hc.commitWithState(&cache, &tokens, false, 0, cps, null, null);
+
+    var target_cache = try KVCache.init(testing.allocator, 3);
+    defer target_cache.deinit();
+    var target = pcEmptySsm();
+    defer pcFreeQsaHybrid(&target);
+    var moe_off: usize = 0;
+    const skipped = try hc.lookupAndRestoreWithMedia(&target_cache, &moe_off, &target, s, &tokens, false, 0, null, null, null, null, true);
+    try testing.expectEqual(@as(usize, 0), skipped.matched);
+    var cache2 = try KVCache.init(testing.allocator, 3);
+    defer cache2.deinit();
+    var target2 = pcEmptySsm();
+    defer pcFreeQsaHybrid(&target2);
+    var moe2: usize = 0;
+    const leaked = try hc.lookupAndRestoreWithMedia(&cache2, &moe2, &target2, s, &tokens, false, 0, null, null, null, null, false);
+    try testing.expect(leaked.matched > 0);
+}
+
 test "HotPrefixCache: skip_prefix_cache lookup is cold even when a covering entry exists" {
     const s = mlx.gpuStream();
     const tokens = [_]u32{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
@@ -6288,15 +6339,13 @@ test "HotPrefixCache: skip_prefix_cache lookup is cold even when a covering entr
     try transformer_mod.attachQsaHistoryToLatest(cps, &live, s);
     _ = try hc.commitWithState(&cache, &tokens, false, 0, cps, null, null);
 
-    hc.skip_prefix_cache = true;
     var target_cache = try KVCache.init(testing.allocator, 3);
     defer target_cache.deinit();
     var target = pcEmptySsm();
     defer pcFreeQsaHybrid(&target);
     var moe_off: usize = 0;
-    const skipped = try hc.lookupAndRestore(&target_cache, &moe_off, &target, s, &tokens, false, 0, null, null);
+    const skipped = try hc.lookupAndRestoreWithMedia(&target_cache, &moe_off, &target, s, &tokens, false, 0, null, null, null, null, true);
     try testing.expectEqual(@as(usize, 0), skipped.matched);
-    try testing.expect(!hc.skip_prefix_cache);
 
     var target2 = pcEmptySsm();
     defer pcFreeQsaHybrid(&target2);
@@ -6323,13 +6372,12 @@ test "HotPrefixCache: a skipped lookup of a covering prompt matches a cold cache
     try transformer_mod.attachQsaHistoryToLatest(cps, &live, s);
     _ = try hc.commitWithState(&cache, &tokens, false, 0, cps, null, null);
 
-    hc.skip_prefix_cache = true;
     var skipped_cache = try KVCache.init(testing.allocator, 3);
     defer skipped_cache.deinit();
     var skipped_ssm = pcEmptySsm();
     defer pcFreeQsaHybrid(&skipped_ssm);
     var skip_off: usize = 7;
-    const skipped = try hc.lookupAndRestore(&skipped_cache, &skip_off, &skipped_ssm, s, &tokens, false, 0, null, null);
+    const skipped = try hc.lookupAndRestoreWithMedia(&skipped_cache, &skip_off, &skipped_ssm, s, &tokens, false, 0, null, null, null, null, true);
 
     var cold = HotPrefixCache.initWithMem(testing.allocator, 4, 0);
     defer cold.deinit();
@@ -6857,7 +6905,7 @@ test "a 0-token outcome is not a restore: no LRU bump, no protection, and the en
     var ssm = pcEmptySsm();
     defer pcFreeHybrid(&ssm);
     var moe_off: usize = 0;
-    const hit = try hc.lookupAndRestoreWithMedia(&slot_cache, &moe_off, &ssm, s, &tokens, false, 0, null, null, null, 0xF5);
+    const hit = try hc.lookupAndRestoreWithMedia(&slot_cache, &moe_off, &ssm, s, &tokens, false, 0, null, null, null, 0xF5, false);
 
     // The outcome: nothing delivered.
     try t.expectEqual(@as(usize, 0), hit.matched);

--- a/src/restore_dump.zig
+++ b/src/restore_dump.zig
@@ -19,13 +19,19 @@ pub const RestoreDumpMeta = struct {
 
 pub var dump_restore_override: ?[]const u8 = null;
 var dump_seq: std.atomic.Value(u64) = .init(0);
+var dump_dir_cached: ?[]const u8 = null;
+var dump_dir_read: bool = false;
 
 pub fn dumpRestoreDir() ?[]const u8 {
     if (dump_restore_override) |d| {
         if (d.len == 0 or d[0] == '0') return null;
         return d;
     }
-    return dumpRestoreDirFromEnv(std.c.getenv("MLX_SERVE_DUMP_RESTORE"));
+    if (!dump_dir_read) {
+        dump_dir_cached = dumpRestoreDirFromEnv(std.c.getenv("MLX_SERVE_DUMP_RESTORE"));
+        dump_dir_read = true;
+    }
+    return dump_dir_cached;
 }
 
 pub fn dumpRestoreDirFromEnv(raw: ?[*:0]const u8) ?[]const u8 {

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -4363,7 +4363,7 @@ fn inferenceLoop(ctx: ThreadCtx) void {
                             break :prefill;
                         }
                         if (err == error.QsaHistoryGap and !qsa_gap_retried) {
-                            if (sch.hot_prefix_cache) |hc| _ = hc.dropLastRestored();
+                            if (slot.model.prefix_cache) |*hc| _ = prefix_cache_mod.HotPrefixCache.dropQsaGapEntry(hc);
                             if (slot.ssm_entries) |ents| prefix_cache_mod.HotPrefixCache.resetSsmEntries(ents);
                             if (slot.model.transformer) |xf| {
                                 slot.cache.truncate(0, xf.s) catch {};
@@ -5889,7 +5889,6 @@ fn runPrefill(sch: *Scheduler, slot: *Slot) !void {
     // because the conn thread holds a refcount on slot.model.
     const xfm_ptr: *Transformer = slot.model.transformer.?;
     if (slot.model.prefix_cache) |*hc| {
-        if (slot.skip_prefix_cache) hc.skip_prefix_cache = true;
         {
             // Only build a restore target when this request will actually
             // draft — a non-dflash turn leaves the payload in the entry for
@@ -5911,7 +5910,7 @@ fn runPrefill(sch: *Scheduler, slot: *Slot) !void {
             const mtp_head: ?*Transformer = if (mtp_target) |*mc| mc.head() else null;
             // Restore by move: the slot names itself, opting into the checkout; `finishSlot`
             // releases it on every path that ends the slot.
-            const lookup = hc.lookupAndRestoreForSlot(
+            const lookup = hc.lookupAndRestoreWithMedia(
                 &slot.cache,
                 &slot.moe_seq_offset,
                 slot.ssm_entries,
@@ -5923,6 +5922,7 @@ fn runPrefill(sch: *Scheduler, slot: *Slot) !void {
                 if (dfl_target) |*dc| .{ .cache = &dc.cache, .base_pos = &dfl_base } else null,
                 if (mtp_kv) |k| .{ .cache = k, .base_pos = &mtp_base, .head = mtp_head } else null,
                 @intFromPtr(slot),
+                slot.skip_prefix_cache,
             ) catch |err| blk: {
                 log.warn("[hot-cache] lookup failed: {s} — proceeding with cold prefill\n", .{@errorName(err)});
                 break :blk prefix_cache_mod.LookupResult{ .matched = 0, .full_match = false };

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -1375,6 +1375,9 @@ pub const Scheduler = struct {
     /// prompt-token counters and prefill-time histograms only advance when the
     /// request finishes. Written per prefill CHUNK, read by the gauge sampler.
     inflight_prefill_tokens: std.atomic.Value(u64),
+    /// Post-cache tail the in-flight prefill will forward, same scale as
+    /// `inflight_prefill_tokens`; 0 when none is running.
+    inflight_prefill_expected: std.atomic.Value(u64),
     /// Number of slots currently inside `runPrefill`. Set on entry, cleared on
     /// every exit — so the panel can say "prefilling" IMMEDIATELY, rather than
     /// waiting for the first 8192-token chunk to land (~40 s on a 27B). Also
@@ -1491,6 +1494,7 @@ pub const Scheduler = struct {
             .metrics = params.metrics,
             .inflight_generated_tokens = std.atomic.Value(u64).init(0),
             .inflight_prefill_tokens = std.atomic.Value(u64).init(0),
+            .inflight_prefill_expected = std.atomic.Value(u64).init(0),
             .requests_prefilling = std.atomic.Value(u64).init(0),
             .in_flight = 0,
             .queue_cap = cap + 32,
@@ -5777,6 +5781,7 @@ fn runPrefill(sch: *Scheduler, slot: *Slot) !void {
     defer if (observe) {
         _ = sch.requests_prefilling.fetchSub(1, .monotonic);
         sch.inflight_prefill_tokens.store(0, .monotonic);
+        sch.inflight_prefill_expected.store(0, .monotonic);
     };
 
     // ds4-backed model: bypass the MLX prefill path entirely. The ds4
@@ -6141,6 +6146,7 @@ fn runPrefill(sch: *Scheduler, slot: *Slot) !void {
             // restore hybrids too.
             .cancelled_checkpoint_sink = &slot.cancelled_prefill,
             .prefill_progress = if (observe) &sch.inflight_prefill_tokens else null,
+            .prefill_expected = if (observe) &sch.inflight_prefill_expected else null,
             .interleave_hook = if (prefillInterleaveEnabled())
                 .{ .ctx = &interleave_ctx, .call = interleaveDecodeTickCb }
             else

--- a/src/server.zig
+++ b/src/server.zig
@@ -10787,6 +10787,7 @@ fn sampleGauges(ctx: GaugeSamplerCtx) void {
     // pinned, decode reading 0, prefill reading "—". This gauge moves per
     // prefill chunk and returns to 0 the moment the prefill ends.
     ctx.metrics.prefill_tokens_live.set(ctx.scheduler.inflight_prefill_tokens.load(.monotonic));
+    ctx.metrics.prefill_tokens_expected.set(ctx.scheduler.inflight_prefill_expected.load(.monotonic));
     ctx.metrics.requests_prefilling.set(ctx.scheduler.requests_prefilling.load(.monotonic));
 }
 

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -8561,7 +8561,7 @@ test "qsa leftover: restore at L-30 then append/rollback re-pools bit-identicall
     var dest_arr = [_]SSMCacheEntry{.{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true }};
     defer ssmFreeQsaState(&dest_arr[0]);
     try restoreSsmCheckpoint(&dest_arr, &cps[0]);
-    try applyQsaHistoryAt(&dest_arr, &cps[1], @intCast(pos), s);
+    try applyQsaHistoryAt(&dest_arr, &cps[1], @intCast(pos), s, false);
 
     // The restore carries the raw rows of the block `pos` reopened, and nothing else.
     const tail: c_int = @mod(pos, ratio);
@@ -9677,7 +9677,7 @@ fn attachQsaHistoryToLatestMode(cps: []SSMCheckpoint, live: []const SSMCacheEntr
         if (!ssmAuxIsQsaHistory(&src)) continue;
         const materialize = switch (mode) {
             .copy => true,
-            .share => qsaHandoffMustMaterialize(&src, keep),
+            .share => qsaHandoffMustMaterialize(&src, keep) or src.qsa_pooled_buf.ctx == null,
         };
         if (src.qsa_pooled.ctx != null) {
             if (dst.qsa_pooled.ctx != null) _ = mlx.mlx_array_free(dst.qsa_pooled);
@@ -9756,7 +9756,10 @@ pub fn entriesHaveQsaHistory(entries: []const SSMCacheEntry) bool {
 /// onto `entries` already restored to `pos`. Slices aux to `pos` rows and
 /// pooled to `pos/ratio` blocks. No-op on PLE/GDN layers (they already
 /// hold the per-position window from `restoreSsmCheckpoint`).
-pub fn applyQsaHistoryAt(entries: []SSMCacheEntry, src_cp: *const SSMCheckpoint, pos: usize, s: mlx.mlx_stream) !void {
+/// `materialize` false = the destination holds a slice of `src_cp`'s bank (safe when the
+/// checkpoint outlives the slot's first append); true = an owned copy, required when the
+/// source is a transient such as the SSD tier's overlay.
+pub fn applyQsaHistoryAt(entries: []SSMCacheEntry, src_cp: *const SSMCheckpoint, pos: usize, s: mlx.mlx_stream, materialize: bool) !void {
     if (entries.len != src_cp.layers.len) return error.SsmCheckpointLayerMismatch;
     const keep: c_int = @intCast(pos);
     for (entries, src_cp.layers) |*dst, src| {
@@ -9777,9 +9780,13 @@ pub fn applyQsaHistoryAt(entries: []SSMCacheEntry, src_cp: *const SSMCheckpoint,
             const ps = mlx.getShape(src.qsa_pooled);
             const need_blocks = @divTrunc(keep, ratio);
             if (ps.len < 2 or ps[1] < need_blocks) return error.QsaHistoryGap;
-            dst.qsa_pooled = mlx.mlx_array_new();
-            try mlx.check(mlx.mlx_array_set(&dst.qsa_pooled, src.qsa_pooled));
-            try truncatePooled(&dst.qsa_pooled, keep, ratio, s, true);
+            if (materialize) {
+                dst.qsa_pooled = try materializedOwnedCopy(s, src.qsa_pooled);
+            } else {
+                dst.qsa_pooled = mlx.mlx_array_new();
+                try mlx.check(mlx.mlx_array_set(&dst.qsa_pooled, src.qsa_pooled));
+            }
+            try truncatePooled(&dst.qsa_pooled, keep, ratio, s, materialize);
         }
         const from_src = try qsaLeftoverAt(src.aux_state, src_hist, keep, ratio, s);
         if (from_src.ctx != null) {
@@ -33417,7 +33424,7 @@ test "QSA checkpoint aux+pooled bytes are O(rows + checkpoints)" {
     }};
     defer ssmFreeQsaState(&dest[0]);
     try restoreSsmCheckpoint(&dest, &cps[2]);
-    try applyQsaHistoryAt(&dest, &cps[positions.len - 1], 46, s);
+    try applyQsaHistoryAt(&dest, &cps[positions.len - 1], 46, s, false);
     // The leftover is the checkpoint's own raw rows 44 and 45, not the newest ring's overlap.
     try testing.expectEqual(@as(c_int, 2), mlx.getShape(dest[0].aux_state)[1]);
     {
@@ -33617,7 +33624,7 @@ test "attachQsaHistoryToLatest is one copy; applyQsaHistoryAt slices to pos" {
     }};
     defer ssmFreeQsaState(&dest_arr[0]);
     try restoreSsmCheckpoint(&dest_arr, &cps[0]);
-    try applyQsaHistoryAt(&dest_arr, &cps[1], 16, s);
+    try applyQsaHistoryAt(&dest_arr, &cps[1], 16, s, false);
     try testing.expect(dest_arr[0].aux_state.ctx == null);
     try testing.expectEqual(@as(c_int, 4), dest_arr[0].qsa_pooled_blocks);
 
@@ -33721,8 +33728,8 @@ test "handoffQsaHistoryToLatest materializes when the buffer's slack past the sn
 }
 
 test "applyQsaHistoryAt: a sliced restore is a VIEW of the entry's history; the trim's slice is a real copy" {
-    // Restore: the first append re-seeds a private buffer, so a materialized slice was a second
-    // transient copy. Trim: it drops the source next, so its slice must own its bytes.
+    // Restore: the slot appends into qsa_pooled_buf via seedCapBuf, so a view of the entry is not written through.
+    // Trim: the inherit slice must own its rows; a view would pin the donor's full bank.
     if (mlx.noGpuBackend()) return error.SkipZigTest;
     const s = mlx.gpuStream();
     const n: c_int = 32;
@@ -33746,14 +33753,36 @@ test "applyQsaHistoryAt: a sliced restore is a VIEW of the entry's history; the 
     var dest = [_]SSMCacheEntry{.{ .conv_state = .{ .ctx = null }, .ssm_state = .{ .ctx = null }, .initialized = true }};
     defer ssmFreeQsaState(&dest[0]);
     try restoreSsmCheckpoint(&dest, &cps[0]);
-    try applyQsaHistoryAt(&dest, &cps[0], 16, s);
+    try applyQsaHistoryAt(&dest, &cps[0], 16, s, false);
     try testing.expectEqual(@as(c_int, 4), dest[0].qsa_pooled_blocks);
+    try mlx.check(mlx.mlx_array_eval(dest[0].qsa_pooled));
+    try mlx.check(mlx.mlx_array_eval(cps[0].layers[0].qsa_pooled));
+    const dest_ptr = mlx.mlx_array_data_float32(dest[0].qsa_pooled) orelse return error.TestUnexpectedResult;
+    const src_ptr = mlx.mlx_array_data_float32(cps[0].layers[0].qsa_pooled) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(src_ptr, dest_ptr);
+
+    var t: Transformer = undefined;
+    t.s = s;
+    t.allocator = testing.allocator;
+    var extra = mlx.mlx_array_new();
+    defer _ = mlx.mlx_array_free(extra);
+    try mlx.check(mlx.mlx_ones(&extra, &[_]c_int{ 1, 1, 8 }, 3, .float32, s));
+    try t.qsaAppendPooled(&dest[0], extra, dest[0].qsa_pooled_blocks);
+    try mlx.check(mlx.mlx_array_eval(dest[0].qsa_pooled));
+    try mlx.check(mlx.mlx_array_eval(cps[0].layers[0].qsa_pooled));
+    const after_ptr = mlx.mlx_array_data_float32(dest[0].qsa_pooled) orelse return error.TestUnexpectedResult;
+    const src_after = mlx.mlx_array_data_float32(cps[0].layers[0].qsa_pooled) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(src_ptr, src_after);
+    try testing.expect(after_ptr != src_ptr);
 
     var kept = [_]SSMCheckpoint{try captureSsmCheckpoint(testing.allocator, &live, 16, s)};
     defer kept[0].deinit(testing.allocator);
     try sliceQsaHistoryOntoCheckpoint(&kept[0], &cps[0], 16, s);
     try testing.expect(kept[0].layers[0].aux_state.ctx == null);
     try testing.expect(kept[0].layers[0].qsa_pooled.ctx != null);
+    try mlx.check(mlx.mlx_array_eval(kept[0].layers[0].qsa_pooled));
+    const trim_ptr = mlx.mlx_array_data_float32(kept[0].layers[0].qsa_pooled) orelse return error.TestUnexpectedResult;
+    try testing.expect(trim_ptr != src_ptr);
 }
 
 test "affineParamsFromGeometry: exact per-weight solve for off-config sidecar quants" {
@@ -48400,7 +48429,7 @@ test "ssm checkpoint carries the qwen4_exp aux state (key history, pooled keys, 
         ssmFreeQsaState(e);
     };
     try restoreSsmCheckpoint(&dst, cp);
-    try applyQsaHistoryAt(&dst, cp, 37, s);
+    try applyQsaHistoryAt(&dst, cp, 37, s, false);
     try std.testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(dst[0].aux_state, cp.layers[0].aux_state, s));
     try std.testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(dst[0].qsa_pooled, src_e[0].qsa_pooled, s));
     try std.testing.expectEqual(@as(f32, 0.0), try attn256MaxDiff(dst[1].aux_state, src_e[1].aux_state, s));

--- a/tests/test_prefix_inherit_qsa.sh
+++ b/tests/test_prefix_inherit_qsa.sh
@@ -11,6 +11,10 @@
 # the 1-token tail / full-reuse shape actually occurs; the script fails if it
 # never did.
 #
+# Warm and cold run sequentially on ONE port: warm phase, capture greedy
+# texts, stop, wait for the port and for free+inactive+speculative pages,
+# then boot `--prefix-cache-entries 0` and replay. Never two servers at once.
+#
 # Usage: ./tests/test_prefix_inherit_qsa.sh [/path/to/qwen4_exp] [port]
 #
 # Coordinator runs this. Do not start a model server from the agent.
@@ -24,6 +28,8 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
+MEM_RECOVER_GAP_MB=10240
+MEM_RECOVER_TIMEOUT_S=90
 
 if [ ! -d "$MODEL" ]; then
     echo -e "${YELLOW}SKIP${NC} test_prefix_inherit_qsa: $MODEL not found."
@@ -35,30 +41,93 @@ if [ ! -x "$BINARY" ]; then
     exit 1
 fi
 
+SERVER_PID=""
+LOGFILE=""
+COLD_LOG=""
+
+free_mb() {
+  vm_stat | awk '
+    /page size of/         { for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+$/) ps = $i }
+    /^Pages free:/         { gsub(/\./, "", $3); free = $3 }
+    /^Pages inactive:/     { gsub(/\./, "", $3); inact = $3 }
+    /^Pages speculative:/  { gsub(/\./, "", $3); spec = $3 }
+    END { if (ps == "") ps = 16384; printf "%d", (free + inact + spec) * ps / 1048576 }'
+}
+
+wait_port_closed() {
+    local i
+    for i in $(seq 1 60); do
+        lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1 || return 0
+        sleep 1
+    done
+    return 1
+}
+
+stop_server() {
+    [ -n "${SERVER_PID:-}" ] || return 0
+    local was="$SERVER_PID"
+    kill "$was" 2>/dev/null || true
+    for _ in $(seq 1 30); do kill -0 "$was" 2>/dev/null || break; sleep 1; done
+    kill -9 "$was" 2>/dev/null || true
+    wait "$was" 2>/dev/null || true
+    SERVER_PID=""
+    wait_port_closed || true
+}
+
+wait_for_release() {
+    local pid="$1"
+    local baseline="$2"
+    local floor=$((baseline - MEM_RECOVER_GAP_MB))
+    local waited=0
+    local now
+    while [ "$waited" -lt "$MEM_RECOVER_TIMEOUT_S" ]; do
+        now=$(free_mb)
+        if ! kill -0 "$pid" 2>/dev/null && [ "$now" -ge "$floor" ]; then
+            lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1 || {
+                echo "  pack released after ${waited}s (free+inactive+speculative ${now} MB >= floor ${floor} MB)"
+                return 0
+            }
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+    echo "  WARN: memory did not recover within ${MEM_RECOVER_TIMEOUT_S}s (free+inactive+speculative $(free_mb) MB, floor ${floor} MB) - proceeding"
+    wait_port_closed || echo "  WARN: port $PORT still listening"
+    return 0
+}
+
+cleanup() {
+    stop_server
+    rm -f "$LOGFILE" "$COLD_LOG"
+}
+trap cleanup EXIT INT TERM
+
 pkill -f "mlx-serve.*--port $PORT" 2>/dev/null || true
-sleep 1
+wait_port_closed || true
+
+BASELINE_FREE_MB=$(free_mb)
+echo "  baseline free+inactive+speculative before any boot: ${BASELINE_FREE_MB} MB"
+
+start_server() {
+    local log="$1"
+    shift
+    echo "  starting server $*..."
+    "$BINARY" --model "$MODEL" --serve --port "$PORT" --host 127.0.0.1 \
+        "$@" --log-level info ${MLX_SERVE_TEST_EXTRA_ARGS:-} > "$log" 2>&1 &
+    SERVER_PID=$!
+    local up=0
+    local i
+    for i in $(seq 1 180); do
+        curl -s -f "$BASE/health" > /dev/null 2>&1 && { up=1; break; }
+        sleep 1
+    done
+    if [ "$up" != "1" ]; then
+        echo -e "${RED}FAIL${NC} server did not become healthy"; tail -40 "$log"; exit 1
+    fi
+}
 
 LOGFILE=$(mktemp)
-echo "  starting server (--prefix-cache-mem 2048MB)..."
-"$BINARY" --model "$MODEL" --serve --port "$PORT" --host 127.0.0.1 \
-    --prefix-cache-entries 8 --prefix-cache-mem 2048MB --prefix-cache-disk off \
-    --log-level info ${MLX_SERVE_TEST_EXTRA_ARGS:-} > "$LOGFILE" 2>&1 &
-SERVER_PID=$!
-cleanup() {
-    kill $SERVER_PID 2>/dev/null || true
-    wait $SERVER_PID 2>/dev/null || true
-    rm -f "$LOGFILE"
-}
-trap cleanup EXIT
-
-up=0
-for i in $(seq 1 180); do
-    curl -s -f "$BASE/health" > /dev/null 2>&1 && { up=1; break; }
-    sleep 1
-done
-if [ "$up" != "1" ]; then
-    echo -e "${RED}FAIL${NC} server did not become healthy"; tail -40 "$LOGFILE"; exit 1
-fi
+start_server "$LOGFILE" --prefix-cache-entries 8 --prefix-cache-mem 2048MB --prefix-cache-disk off
 
 SYSTEM=$(python3 -c "print('You are a careful assistant for the Orion project. Rule %d: answer briefly. ' * 900 % tuple(range(900)))")
 
@@ -155,31 +224,20 @@ else
     echo "  self-heal events: 0"
 fi
 
-COLD_PORT=$((PORT + 1))
-COLD_BASE="http://127.0.0.1:$COLD_PORT"
+WARM_PID="$SERVER_PID"
+stop_server
+wait_for_release "$WARM_PID" "$BASELINE_FREE_MB"
+
 COLD_LOG=$(mktemp)
-pkill -f "mlx-serve.*--port $COLD_PORT" 2>/dev/null || true
-sleep 1
-echo "  starting cold-control server (--prefix-cache-entries 0)..."
-"$BINARY" --model "$MODEL" --serve --port "$COLD_PORT" --host 127.0.0.1 \
-    --prefix-cache-entries 0 --prefix-cache-disk off \
-    --log-level info ${MLX_SERVE_TEST_EXTRA_ARGS:-} > "$COLD_LOG" 2>&1 &
-COLD_PID=$!
-cold_up=0
-for i in $(seq 1 180); do
-    curl -s -f "$COLD_BASE/health" > /dev/null 2>&1 && { cold_up=1; break; }
-    sleep 1
-done
-if [ "$cold_up" != "1" ]; then
-    echo -e "${RED}FAIL${NC} cold-control server did not become healthy"; tail -40 "$COLD_LOG"; fail=1
-else
-    COLD1=$(post_body "$BODY" "$COLD_BASE") || { echo -e "${RED}FAIL${NC} cold request 1 failed"; fail=1; COLD1='{"code":0,"text":""}'; }
-    python3 -c "
+start_server "$COLD_LOG" --prefix-cache-entries 0 --prefix-cache-disk off
+
+COLD1=$(post_body "$BODY" "$BASE") || { echo -e "${RED}FAIL${NC} cold request 1 failed"; fail=1; COLD1='{"code":0,"text":""}'; }
+python3 -c "
 import json,sys,urllib.request
 warm=json.loads(sys.argv[1])['text']
 cold=json.loads(sys.argv[2])['text']
 base=sys.argv[3]
-if cold and not warm:
+if not warm:
     print('empty warm vs non-empty cold')
     raise SystemExit(1)
 def toks(text):
@@ -194,14 +252,10 @@ if wt != ct:
     print(' warm', wt[:8], 'len', len(toks(warm)))
     print(' cold', ct[:8], 'len', len(toks(cold)))
     raise SystemExit(1)
-" "$WARM2" "$COLD1" "$COLD_BASE" || { echo -e "${RED}FAIL${NC} warm greedy text != cold"; fail=1; }
-    if [ "$fail" -eq 0 ]; then
-        echo -e "${GREEN}PASS${NC} warm greedy text matches cold (first 32 tokens)"
-    fi
+" "$WARM2" "$COLD1" "$BASE" || { echo -e "${RED}FAIL${NC} warm greedy text != cold"; fail=1; }
+if [ "$fail" -eq 0 ]; then
+    echo -e "${GREEN}PASS${NC} warm greedy text matches cold (first 32 tokens)"
 fi
-kill $COLD_PID 2>/dev/null || true
-wait $COLD_PID 2>/dev/null || true
-rm -f "$COLD_LOG"
 
 if [ "$fail" -eq 0 ]; then
     echo -e "${GREEN}PASS${NC} test_prefix_inherit_qsa"


### PR DESCRIPTION
## Summary

Two commits: the prefill gauge for the monitor plugin, and the post-merge follow-up of #394 (five review findings plus the live script).


The opencode2 monitor plugin draws a prefill progress bar, and until now it had to guess the denominator. The chunk loop already publishes how far the in-flight prefill has got (`prefill_tokens_live`); how far there is to go had no surface, so the panel inferred it from the last step. This PR gives it the real target and updates the plugin to use it.

- **`prefill_tokens_expected`**: a new gauge beside `prefill_tokens_live`, on the same scale (the post-cache tail this prefill will forward), published once per prefill and cleared on every prefill exit next to the progress atomic. Wired through the Prometheus text and `/metrics.json`. 0 when idle and on the bypass engines, which the plugin reads as "no bar".
- **Plugin** (`lib/opencode2-mlx-serve`, three bumps): the bar targets the server gauge and falls back to the rate shape when it reads 0 (older builds); the footer settles into three fixed shapes; steady Throughput lines that never disappear at 0; the Server cluster (gpu, running, tokens, requests, messages, tool calls), Model & sampling, Server log as a feed state; the Memory gauge on its own bar row with the reading bright and the ceiling dim.

Server side is 34 lines across `generate.zig`, `metrics.zig`, `scheduler.zig`, `server.zig`, with the metrics test extended for the new gauge in both emitters and the at-rest zero.

## #394 follow-up (second commit)

- The QSA self-heal drops the entry the SLOT's model cache restored, not whichever model loaded last: with two models resident the retry used to evict an innocent entry and re-fail forever.
- A warm restore rebinds the entry's pooled QSA bank as a view instead of copying it (~768 MB per restore at 1M tokens); the SSD-tier overlay and the inherit slice still own their rows, and the commit handoff never shares a never-appended view into a new entry.
- `inherit_limit` is `min(donor.shared, prompt_cap)`; the token-divergence walk recomputed what `bestCheckpointDonor` already stored.
- `skip_prefix_cache` is an argument of the lookup instead of a field on the shared cache, so an early-returning arch cannot leave the next request cold.
- `MLX_SERVE_DUMP_RESTORE` is read once per process; the restore-dump locals collapse into one struct; production dump sites 5 → 2.
- `tests/test_prefix_inherit_qsa.sh` runs its warm and cold phases sequentially on one port instead of booting a second 70 GB server beside the first. Live on the M5 Max: the one-token shape occurs, no `QsaHistoryGap`, warm greedy text equals cold.

Suite on the branch: 2309 pass, 153 skip, 0 fail; executable built ReleaseFast; one Opus audit round, every P1 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
