### PR TITLE
fix(kv): a failed dense KV write leaves no freed view handle behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - **Flash Next sparse-attention prefill runs on the M5 neural accelerators.** The block-gathered attention now uses a NAX cooperative-tensor kernel on M5-class GPUs with macOS 26.3+, contributed by Nikolai V., with a two-term bf16 softmax that matches the stock kernel's precision; long-prompt prefill is about 12% faster at 160k tokens. `MLX_SERVE_QSA_NAX=0` restores the previous gather.
 - **Flash Next prefill scores its sparse-attention blocks in one kernel.** The indexer's score sheet is now produced by a single NAX kernel that reads the bf16 key bank directly, bit-identical to the old four-op chain, and the 1.5 KB-per-token f32 score bank it kept resident (1.6 GB at 1M tokens, rebuilt on every cache restore) is gone. The block-scoring chain runs about 2x faster per prefill chunk, a saving that grows with context length. `MLX_SERVE_QSA_SCORE_FUSED=0` restores the old chain.
 
+### Fixes
+
+- An MLX error while writing the KV cache now fails only the request that hit it, instead of crashing the server when that cache is next reset or freed.
+
 ## v26.9.2 — Per-model settings, chat providers, faster Flash Next
 
 ### Highlights

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,6 +421,7 @@ With `tools`, tokens buffer for detection (all tag families + raw JSON); thinkin
 - **A kernel's dtype and its threadgroup BLOCK SIZE are ONE decision** (`gdnBlockTFor`; dtypes off the ARRAY; Metal has no implicit float→bfloat).
 - **Every KV buffer is sized from the OPERAND it stores; a scheme with a shape constraint refuses at LOAD**: K/V widths differ on MLA; TurboQuant needs pow2 → `initWithConfigAndHeadDim` checks `kvCacheKeyHeadDim()`.
 - **A fallible re-init BEHIND a `deinit` leaves a freed object on the error path** — build first, then swap (`KVCache.reinit`). Scan-pinned: no `.cache = try` in transformer/scheduler/main.
+- **A handle freed before a fallible op is reset AT the free** (`updateDense` views, as `updateAffine` does): a write that failed after the free left freed views in the entry for the next `resetCache` to free again (SIGSEGV in `freeKVEntry`). Guard: the `KVCache dense update` fault sweep.
 - **An MLA cache is billed per ATTENTION head** (`kvBytesPerToken`): the latent decompresses to all heads; only an asymmetric config tells the spellings apart.
 - **A gate's LOWER BOUND may REPLACE the formula, not clamp it** (KDA: `g = exp(bound·σ(…))`); two arms means the arm is SELECTED (`kdaUsesBoundedGate`): absent bound = softplus arm, never bound 0. Read the reference KERNEL's arms.
 - **Per-head vs per-channel gating is an INDEXING contract**: one recurrence generated for both (`gdnKernelSource(vectorized, capture_seq)`); other-shape kernels DECLINE; test = per-channel gate held UNIFORM must match the scalar kernel EXACTLY.

--- a/docs/gotchas/engine-mlx.md
+++ b/docs/gotchas/engine-mlx.md
@@ -4904,3 +4904,17 @@ and the measured-peak rows for qwen3.5 27B/4B were re-derived by subtracting the
 lazily copied side-channel state is not in the residual's graph; the cadence eval must name it, or the copy
 still pins its parent. Same PR: the QSA raw-key ring (32 rows since #381) was still billed per token
 (`qsaHistoryBytesPerToken` 3 KB/token, 1.6 GB of phantom at 512k); it is billed once per slot now.
+
+## A failed dense KV write left freed view handles in the entry (2026-09-10)
+
+`KVCache.updateDense` frees the previous `key_view`/`value_view` first, so the buffer can be
+donated, and assigned the handles fresh only after the grow and the writes. When one of those
+failed (an MLX error, catchable since #353), the entry kept both freed handles and the next
+`resetCache` or `deinit` of that cache freed them again: SIGSEGV in `freeKVEntry`. Seen live when
+Qwen3-Embedding sub-batches shared the cache and a write failed on the batch dimension
+(`broadcast_shapes`). `updateAffine` already reset its handles at the free, and
+`updateTurboQuant` goes through it. Fix: reset the handles at the free; `writeAtOffset` releases
+its result on the error path. A grow that fails after K but before V can leave their capacities
+apart; the error aborts that forward and the next request's reset restores a coherent pair.
+Guard (stale views): the `KVCache dense update` fault sweep over every checked op of an
+in-capacity and a growing update.

--- a/src/transformer.zig
+++ b/src/transformer.zig
@@ -7258,9 +7258,13 @@ pub const KVCache = struct {
     fn updateDense(self: *KVCache, layer: u32, new_k: mlx.mlx_array, new_v: mlx.mlx_array, s: mlx.mlx_stream, max_seq: u32) !DenseKVView {
         const entry = &self.entries[layer];
 
-        // 1. Free stale views — drops refcount on buffer → enables buffer donation
+        // 1. Free stale views — drops refcount on buffer → enables buffer donation.
+        //    Reset the handles at once: a failing op below must not leave freed
+        //    handles for `freeKVEntry` to free again.
         _ = mlx.mlx_array_free(entry.key_view);
         _ = mlx.mlx_array_free(entry.value_view);
+        entry.key_view = mlx.mlx_array_new();
+        entry.value_view = mlx.mlx_array_new();
 
         // 2. Get shape info from new_k: [B, heads, new_len, head_dim]. The V
         //    head dim is read off new_v, NOT new_k: an MLA arch scores over
@@ -7311,8 +7315,6 @@ pub const KVCache = struct {
         else
             0;
 
-        entry.key_view = mlx.mlx_array_new();
-        entry.value_view = mlx.mlx_array_new();
         // buildSliceView takes the whole-buffer shortcut itself (mlx-lm's
         // optimization: no slice when the view covers the buffer) and reads
         // each buffer's own last dim, so K and V may differ in width.
@@ -7461,6 +7463,7 @@ pub const KVCache = struct {
         const su_stop = [_]c_int{ buf_shape[0], buf_shape[1], off_end, buf_shape[3] };
         const su_strides = [_]c_int{ 1, 1, 1, 1 };
         var updated = mlx.mlx_array_new();
+        errdefer _ = mlx.mlx_array_free(updated);
         try mlx.check(mlx.mlx_slice_update(&updated, buf.*, new_chunk, &su_start, 4, &su_stop, 4, &su_strides, 4, s));
         _ = mlx.mlx_array_free(buf.*);
         buf.* = updated;
@@ -48833,6 +48836,49 @@ test "growQuantBuf else-arm: a faulted zeros leaves the old buffer owned (no dou
         }
     }
     try testing.expectEqual(n_ops, fired);
+}
+
+test "KVCache dense update: a faulted op leaves no freed view handle in the entry" {
+    // The bar: after any failing op, `deinit` frees each handle the entry holds exactly once.
+    if (!mlxDeviceUsable()) return error.SkipZigTest;
+    const s = mlx.gpuStream();
+    const first = testKV(4, s);
+    defer _ = mlx.mlx_array_free(first);
+
+    // 4 more tokens fit the first update's buffer; 300 more take the grow path.
+    var ops = [_]u64{ 0, 0 };
+    for ([_]usize{ 4, 300 }, &ops) |len, *n_ops| {
+        const kv = testKV(len, s);
+        defer _ = mlx.mlx_array_free(kv);
+        {
+            var cache = try KVCache.init(testing.allocator, 1);
+            defer cache.deinit();
+            var dv = try cache.update(0, first, first, s, 0);
+            dv.deinit();
+            const c0 = mlx.op_count.load(.monotonic);
+            var dv2 = try cache.update(0, kv, kv, s, 0);
+            dv2.deinit();
+            n_ops.* = mlx.op_count.load(.monotonic) - c0;
+        }
+
+        var k: u64 = 1;
+        while (k <= n_ops.*) : (k += 1) {
+            var cache = try KVCache.init(testing.allocator, 1);
+            defer cache.deinit();
+            var dv = try cache.update(0, first, first, s, 0);
+            dv.deinit();
+            mlx.fault.arm(k);
+            const r = cache.update(0, kv, kv, s, 0);
+            const did = mlx.fault.didFire();
+            mlx.fault.disarm();
+            try testing.expectError(error.MlxError, r);
+            try testing.expect(did);
+            // The views are built last, K then V: a fault before a view's own build leaves it empty.
+            if (k + 1 < n_ops.*) try testing.expect(cache.entries[0].key_view.ctx == null);
+            if (k < n_ops.*) try testing.expect(cache.entries[0].value_view.ctx == null);
+        }
+    }
+    try testing.expect(ops[0] >= 4 and ops[1] > ops[0]);
 }
 
 test "mlx check fault injection: the ownership shape releases its array on every faulted op" {


### PR DESCRIPTION
**What changed / why**

Refs #403. `KVCache.updateDense` freed `key_view`/`value_view` before the grow and the writes and assigned fresh handles only after them, so an MLX error in between (catchable since #353) left freed handles in the entry, and the next reset or free of that cache freed them again: SIGSEGV in `freeKVEntry`. #403 hit it through Qwen3-Embedding sub-batches (#404 removes that trigger), but any failing dense KV write reaches it.
- The handles are reset at the free, as `updateAffine` already does (`updateTurboQuant` goes through `updateAffine`); `writeAtOffset` releases its result on the error path.
- A fault sweep beside the `growQuantBuf` one, over every checked op of an in-capacity and a growing update; a rule + gotcha; a CHANGELOG line (it conflicts with #404's `### Fixes` hunk; I'll rebase whichever lands second).

**How I verified it** (M4 Pro 48 GB, macOS 26.6.2)
- `zig build test`: 9/9 steps, 2316 pass, 166 skip, 0 fail. With the `updateDense` hunk reverted the sweep aborts the test runner: a stale view fails its assertion and the cleanup double-frees it.
- The issue's script against this branch alone, where the sub-batch write still fails: the second request still gets its 500, and the server now answers the third instead of crashing.

- [x] Searched open and closed issues, open PRs and recent commits; linked the existing thread if there is one
- [x] Built and ran this tree on a real Apple Silicon Mac in this session
- [x] No comments that restate code, carry history, or cite audit/review items
- [x] No source-scan tests; every test checks behaviour
- [x] One fix or feature; description under ~15 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uayEz8B1LK1dexi5FDxxe
